### PR TITLE
Fix unit tests by calling TestWidgetsFlutterBinding.ensureInitialized()

### DIFF
--- a/packages/cloud_firestore/test/cloud_firestore_test.dart
+++ b/packages/cloud_firestore/test/cloud_firestore_test.dart
@@ -11,6 +11,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
   group('$Firestore', () {
     int mockHandleId = 0;
     FirebaseApp app;

--- a/packages/cloud_firestore/test/cloud_firestore_test.dart
+++ b/packages/cloud_firestore/test/cloud_firestore_test.dart
@@ -12,6 +12,7 @@ import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
+
   group('$Firestore', () {
     int mockHandleId = 0;
     FirebaseApp app;

--- a/packages/cloud_functions/test/cloud_functions_test.dart
+++ b/packages/cloud_functions/test/cloud_functions_test.dart
@@ -9,6 +9,7 @@ import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
+
   group('$CloudFunctions', () {
     final List<MethodCall> log = <MethodCall>[];
 

--- a/packages/cloud_functions/test/cloud_functions_test.dart
+++ b/packages/cloud_functions/test/cloud_functions_test.dart
@@ -8,6 +8,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
   group('$CloudFunctions', () {
     final List<MethodCall> log = <MethodCall>[];
 

--- a/packages/firebase_admob/test/firebase_admob_test.dart
+++ b/packages/firebase_admob/test/firebase_admob_test.dart
@@ -9,6 +9,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
   group('FirebaseAdMob', () {
     const MethodChannel channel =
         MethodChannel('plugins.flutter.io/firebase_admob');

--- a/packages/firebase_admob/test/firebase_admob_test.dart
+++ b/packages/firebase_admob/test/firebase_admob_test.dart
@@ -10,6 +10,7 @@ import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
+
   group('FirebaseAdMob', () {
     const MethodChannel channel =
         MethodChannel('plugins.flutter.io/firebase_admob');

--- a/packages/firebase_analytics/example/pubspec.yaml
+++ b/packages/firebase_analytics/example/pubspec.yaml
@@ -6,7 +6,8 @@ dependencies:
     sdk: flutter
   firebase_analytics:
     path: ../
-  firebase_core: ^0.4.0
+  _firebase_api: 43.0.0
+  firebase_core: any
 
 dev_dependencies:
   flutter_test:

--- a/packages/firebase_analytics/example/pubspec.yaml
+++ b/packages/firebase_analytics/example/pubspec.yaml
@@ -6,8 +6,7 @@ dependencies:
     sdk: flutter
   firebase_analytics:
     path: ../
-  _firebase_api: 43.0.0
-  firebase_core: any
+  firebase_core: ^0.4.0
 
 dev_dependencies:
   flutter_test:

--- a/packages/firebase_analytics/test/firebase_analytics_test.dart
+++ b/packages/firebase_analytics/test/firebase_analytics_test.dart
@@ -9,6 +9,7 @@ import 'package:firebase_analytics/firebase_analytics.dart';
 import 'package:flutter/services.dart';
 
 void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
   final FirebaseAnalytics analytics = FirebaseAnalytics();
   const MethodChannel channel =
       MethodChannel('plugins.flutter.io/firebase_analytics');

--- a/packages/firebase_analytics/test/firebase_analytics_test.dart
+++ b/packages/firebase_analytics/test/firebase_analytics_test.dart
@@ -10,6 +10,7 @@ import 'package:flutter/services.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
+
   final FirebaseAnalytics analytics = FirebaseAnalytics();
   const MethodChannel channel =
       MethodChannel('plugins.flutter.io/firebase_analytics');

--- a/packages/firebase_analytics/test/observer_test.dart
+++ b/packages/firebase_analytics/test/observer_test.dart
@@ -14,6 +14,7 @@ import 'package:firebase_analytics/firebase_analytics.dart';
 import 'package:firebase_analytics/observer.dart';
 
 void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
   group('FirebaseAnalyticsObserver', () {
     FirebaseAnalytics analytics;
     FirebaseAnalyticsObserver observer;

--- a/packages/firebase_analytics/test/observer_test.dart
+++ b/packages/firebase_analytics/test/observer_test.dart
@@ -15,6 +15,7 @@ import 'package:firebase_analytics/observer.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
+
   group('FirebaseAnalyticsObserver', () {
     FirebaseAnalytics analytics;
     FirebaseAnalyticsObserver observer;

--- a/packages/firebase_auth/test/firebase_auth_test.dart
+++ b/packages/firebase_auth/test/firebase_auth_test.dart
@@ -68,6 +68,7 @@ const Map<String, dynamic> kMockAdditionalUserInfo = <String, dynamic>{
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
+
   group('$FirebaseAuth', () {
     final String appName = 'testApp';
     final FirebaseApp app = FirebaseApp(name: appName);

--- a/packages/firebase_auth/test/firebase_auth_test.dart
+++ b/packages/firebase_auth/test/firebase_auth_test.dart
@@ -67,6 +67,7 @@ const Map<String, dynamic> kMockAdditionalUserInfo = <String, dynamic>{
 };
 
 void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
   group('$FirebaseAuth', () {
     final String appName = 'testApp';
     final FirebaseApp app = FirebaseApp(name: appName);

--- a/packages/firebase_core/test/firebase_core_test.dart
+++ b/packages/firebase_core/test/firebase_core_test.dart
@@ -8,6 +8,7 @@ import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
+
   group('$FirebaseApp', () {
     final List<MethodCall> log = <MethodCall>[];
     const FirebaseApp testApp = FirebaseApp(

--- a/packages/firebase_core/test/firebase_core_test.dart
+++ b/packages/firebase_core/test/firebase_core_test.dart
@@ -7,6 +7,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
   group('$FirebaseApp', () {
     final List<MethodCall> log = <MethodCall>[];
     const FirebaseApp testApp = FirebaseApp(

--- a/packages/firebase_crashlytics/test/firebase_crashlytics_test.dart
+++ b/packages/firebase_crashlytics/test/firebase_crashlytics_test.dart
@@ -11,6 +11,7 @@ import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
+
   group('$Crashlytics', () {
     final List<MethodCall> log = <MethodCall>[];
 

--- a/packages/firebase_crashlytics/test/firebase_crashlytics_test.dart
+++ b/packages/firebase_crashlytics/test/firebase_crashlytics_test.dart
@@ -10,6 +10,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
   group('$Crashlytics', () {
     final List<MethodCall> log = <MethodCall>[];
 

--- a/packages/firebase_database/test/firebase_database_test.dart
+++ b/packages/firebase_database/test/firebase_database_test.dart
@@ -10,6 +10,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
   group('$FirebaseDatabase', () {
     const MethodChannel channel = MethodChannel(
       'plugins.flutter.io/firebase_database',

--- a/packages/firebase_database/test/firebase_database_test.dart
+++ b/packages/firebase_database/test/firebase_database_test.dart
@@ -11,6 +11,7 @@ import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
+
   group('$FirebaseDatabase', () {
     const MethodChannel channel = MethodChannel(
       'plugins.flutter.io/firebase_database',

--- a/packages/firebase_database/test/firebase_list_test.dart
+++ b/packages/firebase_database/test/firebase_list_test.dart
@@ -10,6 +10,7 @@ import 'package:mockito/mockito.dart';
 import 'package:test/test.dart';
 
 void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
   group('FirebaseList', () {
     StreamController<Event> onChildAddedStreamController;
     StreamController<Event> onChildRemovedStreamController;

--- a/packages/firebase_database/test/firebase_list_test.dart
+++ b/packages/firebase_database/test/firebase_list_test.dart
@@ -6,11 +6,13 @@ import 'dart:async';
 
 import 'package:firebase_database/firebase_database.dart';
 import 'package:firebase_database/ui/firebase_list.dart';
+import 'package:flutter_test/flutter_test.dart' show TestWidgetsFlutterBinding;
 import 'package:mockito/mockito.dart';
 import 'package:test/test.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
+
   group('FirebaseList', () {
     StreamController<Event> onChildAddedStreamController;
     StreamController<Event> onChildRemovedStreamController;

--- a/packages/firebase_dynamic_links/test/firebase_dynamic_links_test.dart
+++ b/packages/firebase_dynamic_links/test/firebase_dynamic_links_test.dart
@@ -8,6 +8,7 @@ import 'package:firebase_dynamic_links/firebase_dynamic_links.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
   group('$FirebaseDynamicLinks', () {
     final List<MethodCall> log = <MethodCall>[];
 

--- a/packages/firebase_dynamic_links/test/firebase_dynamic_links_test.dart
+++ b/packages/firebase_dynamic_links/test/firebase_dynamic_links_test.dart
@@ -9,6 +9,7 @@ import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
+
   group('$FirebaseDynamicLinks', () {
     final List<MethodCall> log = <MethodCall>[];
 

--- a/packages/firebase_messaging/test/firebase_messaging_test.dart
+++ b/packages/firebase_messaging/test/firebase_messaging_test.dart
@@ -6,12 +6,14 @@ import 'dart:async';
 
 import 'package:flutter/services.dart';
 import 'package:firebase_messaging/firebase_messaging.dart';
+import 'package:flutter_test/flutter_test.dart' show TestWidgetsFlutterBinding;
 import 'package:mockito/mockito.dart';
 import 'package:platform/platform.dart';
 import 'package:test/test.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
+
   MockMethodChannel mockChannel;
   FirebaseMessaging firebaseMessaging;
 

--- a/packages/firebase_messaging/test/firebase_messaging_test.dart
+++ b/packages/firebase_messaging/test/firebase_messaging_test.dart
@@ -11,6 +11,7 @@ import 'package:platform/platform.dart';
 import 'package:test/test.dart';
 
 void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
   MockMethodChannel mockChannel;
   FirebaseMessaging firebaseMessaging;
 

--- a/packages/firebase_ml_vision/test/firebase_ml_vision_test.dart
+++ b/packages/firebase_ml_vision/test/firebase_ml_vision_test.dart
@@ -11,6 +11,7 @@ import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
+
   group('$FirebaseVision', () {
     final List<MethodCall> log = <MethodCall>[];
     dynamic returnValue;

--- a/packages/firebase_ml_vision/test/firebase_ml_vision_test.dart
+++ b/packages/firebase_ml_vision/test/firebase_ml_vision_test.dart
@@ -10,6 +10,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
   group('$FirebaseVision', () {
     final List<MethodCall> log = <MethodCall>[];
     dynamic returnValue;

--- a/packages/firebase_ml_vision/test/image_labeler_test.dart
+++ b/packages/firebase_ml_vision/test/image_labeler_test.dart
@@ -7,6 +7,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
   group('$FirebaseVision', () {
     final List<MethodCall> log = <MethodCall>[];
     dynamic returnValue;

--- a/packages/firebase_ml_vision/test/image_labeler_test.dart
+++ b/packages/firebase_ml_vision/test/image_labeler_test.dart
@@ -8,6 +8,7 @@ import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
+
   group('$FirebaseVision', () {
     final List<MethodCall> log = <MethodCall>[];
     dynamic returnValue;

--- a/packages/firebase_performance/test/firebase_performance_test.dart
+++ b/packages/firebase_performance/test/firebase_performance_test.dart
@@ -9,6 +9,7 @@ import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
+
   group('$FirebasePerformance', () {
     final List<MethodCall> performanceLog = <MethodCall>[];
 

--- a/packages/firebase_performance/test/firebase_performance_test.dart
+++ b/packages/firebase_performance/test/firebase_performance_test.dart
@@ -8,6 +8,7 @@ import 'package:firebase_performance/firebase_performance.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
   group('$FirebasePerformance', () {
     final List<MethodCall> performanceLog = <MethodCall>[];
 

--- a/packages/firebase_remote_config/test/firebase_remote_config_test.dart
+++ b/packages/firebase_remote_config/test/firebase_remote_config_test.dart
@@ -7,6 +7,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
   final int lastFetchTime = 1520618753782;
   Map<String, dynamic> getDefaultInstance() {
     return <String, dynamic>{

--- a/packages/firebase_remote_config/test/firebase_remote_config_test.dart
+++ b/packages/firebase_remote_config/test/firebase_remote_config_test.dart
@@ -8,6 +8,7 @@ import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
+
   final int lastFetchTime = 1520618753782;
   Map<String, dynamic> getDefaultInstance() {
     return <String, dynamic>{

--- a/packages/firebase_storage/test/firebase_storage_test.dart
+++ b/packages/firebase_storage/test/firebase_storage_test.dart
@@ -11,6 +11,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
   group('FirebaseStorage', () {
     final FirebaseApp app = const FirebaseApp(
       name: 'testApp',

--- a/packages/firebase_storage/test/firebase_storage_test.dart
+++ b/packages/firebase_storage/test/firebase_storage_test.dart
@@ -12,6 +12,7 @@ import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
+
   group('FirebaseStorage', () {
     final FirebaseApp app = const FirebaseApp(
       name: 'testApp',


### PR DESCRIPTION
Fixes tests that were broken by flutter/flutter#38464

See also flutter/flutter#39077