### PR TITLE
[firebase_messaging] check permissions

### DIFF
--- a/packages/firebase_messaging/CHANGELOG.md
+++ b/packages/firebase_messaging/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 5.1.5
+* Add checkIosNotificationSettings method to check whether the user has previously accepted or declined the push notifications on iOS devices.
+
 ## 5.1.4
 
 * Update documentation to reflect new repository location.

--- a/packages/firebase_messaging/ios/Classes/FirebaseMessagingPlugin.m
+++ b/packages/firebase_messaging/ios/Classes/FirebaseMessagingPlugin.m
@@ -122,6 +122,15 @@ static FlutterError *getFlutterError(NSError *error) {
     NSNumber *value = call.arguments;
     [FIRMessaging messaging].autoInitEnabled = value.boolValue;
     result(nil);
+  } else if ([@"iosCheckPermissions" isEqualToString:method]) {
+    UIUserNotificationSettings *currentSettings =
+        [[UIApplication sharedApplication] currentUserNotificationSettings];
+    NSDictionary *settingsDictionary = @{
+      @"sound" : [NSNumber numberWithBool:currentSettings.types & UIUserNotificationTypeSound],
+      @"badge" : [NSNumber numberWithBool:currentSettings.types & UIUserNotificationTypeBadge],
+      @"alert" : [NSNumber numberWithBool:currentSettings.types & UIUserNotificationTypeAlert],
+    };
+    result(settingsDictionary);
   } else {
     result(FlutterMethodNotImplemented);
   }

--- a/packages/firebase_messaging/lib/firebase_messaging.dart
+++ b/packages/firebase_messaging/lib/firebase_messaging.dart
@@ -134,6 +134,11 @@ class FirebaseMessaging {
         throw UnsupportedError("Unrecognized JSON message");
     }
   }
+
+  Future<IosNotificationSettings> checkIosNotificationSettings() async {
+    return IosNotificationSettings._fromMap(
+        await _channel.invokeMapMethod<String, bool>('iosCheckPermissions'));
+  }
 }
 
 class IosNotificationSettings {
@@ -159,4 +164,14 @@ class IosNotificationSettings {
 
   @override
   String toString() => 'PushNotificationSettings ${toMap()}';
+
+  @override
+  int get hashCode => sound.hashCode ^ alert.hashCode ^ badge.hashCode;
+
+  @override
+  bool operator ==(dynamic other) =>
+      other is IosNotificationSettings &&
+      other.sound == sound &&
+      other.alert == alert &&
+      other.badge == badge;
 }

--- a/packages/firebase_messaging/pubspec.yaml
+++ b/packages/firebase_messaging/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for Firebase Cloud Messaging, a cross-platform
   messaging solution that lets you reliably deliver messages on Android and iOS.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/firebase_messaging
-version: 5.1.4
+version: 5.1.5
 
 flutter:
   plugin:
@@ -27,5 +27,5 @@ dev_dependencies:
     sdk: flutter
 
 environment:
-  sdk: ">=2.0.0-dev.28.0 <3.0.0"
-  flutter: ">=1.5.0 <2.0.0"
+  sdk: '>=2.0.0-dev.28.0 <3.0.0'
+  flutter: '>=1.5.0 <2.0.0'

--- a/packages/firebase_messaging/test/firebase_messaging_test.dart
+++ b/packages/firebase_messaging/test/firebase_messaging_test.dart
@@ -166,6 +166,19 @@ void main() {
 
     verify(mockChannel.invokeMethod<void>('setAutoInitEnabled', false));
   });
+
+  test('checkIosNotificationSettings', () async {
+    when(mockChannel.invokeMapMethod<String, bool>('iosCheckPermissions'))
+        .thenAnswer((_) async =>
+            const IosNotificationSettings(sound: true, alert: true, badge: true)
+                .toMap());
+
+    expect(await firebaseMessaging.checkIosNotificationSettings(),
+        const IosNotificationSettings(sound: true, alert: true, badge: true));
+    verify(mockChannel.invokeMapMethod<String, bool>(captureAny))
+        .captured
+        .single;
+  });
 }
 
 class MockMethodChannel extends Mock implements MethodChannel {}


### PR DESCRIPTION
## Description

This change introduces a method call for iOS to check whether the user has previously accepted or declined the push notification setting. This is useful to check it later in the app and then remind the user to enable the push notifications manually in the control center, because the initial request permissions dialog is only displayed once. Or if the user changed the permissions in the Settings, and switches back to the app, the `onIosSettingsRegistered` event is also not fired. 

## Related Issues

I stuck to the old API, if https://github.com/flutter/plugins/pull/1009 is merged in, this should also be updated to use the new [UNUserNotificationCenter](https://developer.apple.com/documentation/usernotifications/unusernotificationcenter?language=objc)

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/flutter/plugins/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/