### PR TITLE
[firebase_auth] Consistent platform behavior for fetchSignInMethodsForEmail

### DIFF
--- a/packages/firebase_auth/CHANGELOG.md
+++ b/packages/firebase_auth/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.14.0+5
+
+* On iOS, `fetchSignInMethodsForEmail` now returns an empty list when the email
+  cannot be found, matching the Android behavior.
+
 ## 0.14.0+4
 
 * Fixed "Register a user" example code snippet in README.md.

--- a/packages/firebase_auth/example/test/firebase_auth.dart
+++ b/packages/firebase_auth/example/test/firebase_auth.dart
@@ -83,6 +83,9 @@ void main() {
         password: testPassword,
       );
       expect(result.user.uid, equals(user.uid));
+      List<String> methods = await auth.fetchSignInMethodsForEmail(email: testEmail);
+      expect(methods.length, 1);
+      expect(methods[0], 'password');
       await user.delete();
     });
 
@@ -96,6 +99,13 @@ void main() {
       expect(await auth.isSignInWithEmailLink(emailLink1), true);
       expect(await auth.isSignInWithEmailLink(emailLink2), false);
       expect(await auth.isSignInWithEmailLink(emailLink3), false);
+    });
+
+    test('fetchSignInMethodsForEmail nonexistent user', () async {
+      String testEmail = 'testuser${Uuid().v4()}@example.com';
+      List<String> methods = await auth.fetchSignInMethodsForEmail(email: testEmail);
+      expect(methods, isNotNull);
+      expect(methods.length, 0);
     });
   });
 }

--- a/packages/firebase_auth/example/test/firebase_auth.dart
+++ b/packages/firebase_auth/example/test/firebase_auth.dart
@@ -83,7 +83,8 @@ void main() {
         password: testPassword,
       );
       expect(result.user.uid, equals(user.uid));
-      List<String> methods = await auth.fetchSignInMethodsForEmail(email: testEmail);
+      final List<String> methods =
+          await auth.fetchSignInMethodsForEmail(email: testEmail);
       expect(methods.length, 1);
       expect(methods[0], 'password');
       await user.delete();
@@ -102,8 +103,9 @@ void main() {
     });
 
     test('fetchSignInMethodsForEmail nonexistent user', () async {
-      String testEmail = 'testuser${Uuid().v4()}@example.com';
-      List<String> methods = await auth.fetchSignInMethodsForEmail(email: testEmail);
+      final String testEmail = 'testuser${Uuid().v4()}@example.com';
+      final List<String> methods =
+          await auth.fetchSignInMethodsForEmail(email: testEmail);
       expect(methods, isNotNull);
       expect(methods.length, 0);
     });

--- a/packages/firebase_auth/ios/Classes/FirebaseAuthPlugin.m
+++ b/packages/firebase_auth/ios/Classes/FirebaseAuthPlugin.m
@@ -131,7 +131,11 @@ int nextHandle = 0;
     [[self getAuth:call.arguments]
         fetchProvidersForEmail:email
                     completion:^(NSArray<NSString *> *providers, NSError *error) {
-                      [self sendResult:result forObject:providers error:error];
+                      // For unrecognized emails, the Auth iOS SDK should return an
+                      // empty `NSArray` here, but instead returns `nil`, so we coalesce
+                      // to an empty array.
+                      // https://github.com/firebase/firebase-ios-sdk/issues/3655
+                      [self sendResult:result forObject:providers ?: @[] error:error];
                     }];
   } else if ([@"sendEmailVerification" isEqualToString:call.method]) {
     [[self getAuth:call.arguments].currentUser

--- a/packages/firebase_auth/ios/Classes/FirebaseAuthPlugin.m
+++ b/packages/firebase_auth/ios/Classes/FirebaseAuthPlugin.m
@@ -133,7 +133,7 @@ int nextHandle = 0;
                     completion:^(NSArray<NSString *> *providers, NSError *error) {
                       // For unrecognized emails, the Auth iOS SDK should return an
                       // empty `NSArray` here, but instead returns `nil`, so we coalesce
-                      // to an empty array.
+                      // with an empty `NSArray`.
                       // https://github.com/firebase/firebase-ios-sdk/issues/3655
                       [self sendResult:result forObject:providers ?: @[] error:error];
                     }];

--- a/packages/firebase_auth/lib/src/firebase_auth.dart
+++ b/packages/firebase_auth/lib/src/firebase_auth.dart
@@ -118,9 +118,9 @@ class FirebaseAuth {
   }) async {
     assert(email != null);
     return await channel.invokeListMethod<String>(
-          'fetchSignInMethodsForEmail',
-          <String, String>{'email': email, 'app': app.name},
-        );
+      'fetchSignInMethodsForEmail',
+      <String, String>{'email': email, 'app': app.name},
+    );
   }
 
   /// Triggers the Firebase Authentication backend to send a password-reset

--- a/packages/firebase_auth/lib/src/firebase_auth.dart
+++ b/packages/firebase_auth/lib/src/firebase_auth.dart
@@ -109,17 +109,18 @@ class FirebaseAuth {
   /// This method is useful when you support multiple authentication mechanisms
   /// if you want to implement an email-first authentication flow.
   ///
+  /// An empty `List` is returned if the user could not be found.
+  ///
   /// Errors:
   ///   • `ERROR_INVALID_CREDENTIAL` - If the [email] address is malformed.
-  ///   • `ERROR_USER_NOT_FOUND` - If there is no user corresponding to the given [email] address.
   Future<List<String>> fetchSignInMethodsForEmail({
     @required String email,
   }) async {
     assert(email != null);
     return await channel.invokeListMethod<String>(
-      'fetchSignInMethodsForEmail',
-      <String, String>{'email': email, 'app': app.name},
-    );
+          'fetchSignInMethodsForEmail',
+          <String, String>{'email': email, 'app': app.name},
+        );
   }
 
   /// Triggers the Firebase Authentication backend to send a password-reset

--- a/packages/firebase_auth/pubspec.yaml
+++ b/packages/firebase_auth/pubspec.yaml
@@ -4,7 +4,7 @@ description: Flutter plugin for Firebase Auth, enabling Android and iOS
   like Google, Facebook and Twitter.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/firebase_auth
-version: 0.14.0+4
+version: 0.14.0+5
 
 flutter:
   plugin:


### PR DESCRIPTION
## Description

Migrates flutter/plugins#2002 by @timtraversy

I ended up rewriting the PR a bit:

* updated documentation
* added integration test
* updated CHANGELOG
* put the coalescing on the native side

## Related Issues

https://github.com/firebase/firebase-ios-sdk/issues/3655
