### PR TITLE
[firebase_remote_config] Fix Future already completed RemoteConfig.instance

### DIFF
--- a/packages/firebase_remote_config/CHANGELOG.md
+++ b/packages/firebase_remote_config/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.2.0+7
+
+* Fix `Bad state: Future already completed` error when initially
+  calling `RemoteConfig.instance` multiple times in parallel.
+
 ## 0.2.0+6
 
 * Update documentation to reflect new repository location.

--- a/packages/firebase_remote_config/example/test_driver/firebase_remote_config.dart
+++ b/packages/firebase_remote_config/example/test_driver/firebase_remote_config.dart
@@ -39,16 +39,5 @@ void main() {
         ValueSource.valueStatic,
       );
     });
-
-    test('doubleInstance', () async {
-      final List<Future<RemoteConfig>> futures = <Future<RemoteConfig>>[
-        RemoteConfig.instance,
-        RemoteConfig.instance,
-      ];
-      Future.wait(futures).then((List<RemoteConfig> remoteConfigs) {
-        // Check that both returned Remote Config instances are the same.
-        expect(remoteConfigs[0], remoteConfigs[1]);
-      });
-    });
   });
 }

--- a/packages/firebase_remote_config/example/test_driver/firebase_remote_config.dart
+++ b/packages/firebase_remote_config/example/test_driver/firebase_remote_config.dart
@@ -39,5 +39,16 @@ void main() {
         ValueSource.valueStatic,
       );
     });
+
+    test('doubleInstance', () async {
+      final List<Future<RemoteConfig>> futures = <Future<RemoteConfig>>[
+        RemoteConfig.instance,
+        RemoteConfig.instance,
+      ];
+      Future.wait(futures).then((List<RemoteConfig> remoteConfigs) {
+        // Check that both returned Remote Config instances are the same.
+        expect(remoteConfigs[0], remoteConfigs[1]);
+      });
+    });
   });
 }

--- a/packages/firebase_remote_config/lib/src/remote_config.dart
+++ b/packages/firebase_remote_config/lib/src/remote_config.dart
@@ -33,12 +33,12 @@ class RemoteConfig extends ChangeNotifier {
   /// Gets the instance of RemoteConfig for the default Firebase app.
   static Future<RemoteConfig> get instance async {
     if (!_instanceCompleter.isCompleted) {
-      _getRemoteConfigInstance();
+      _instanceCompleter.complete(await _getRemoteConfigInstance());
     }
     return _instanceCompleter.future;
   }
 
-  static void _getRemoteConfigInstance() async {
+  static Future<RemoteConfig> _getRemoteConfigInstance() async {
     final Map<String, dynamic> properties =
         await channel.invokeMapMethod<String, dynamic>('RemoteConfig#instance');
 
@@ -53,7 +53,7 @@ class RemoteConfig extends ChangeNotifier {
     instance._remoteConfigSettings = remoteConfigSettings;
     instance._parameters =
         _parseRemoteConfigParameters(parameters: properties['parameters']);
-    _instanceCompleter.complete(instance);
+    return instance;
   }
 
   static Map<String, RemoteConfigValue> _parseRemoteConfigParameters(

--- a/packages/firebase_remote_config/pubspec.yaml
+++ b/packages/firebase_remote_config/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for Firebase Remote Config. Update your application 
   re-releasing.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/firebase_remote_config
-version: 0.2.0+6
+version: 0.2.0+7
 
 dependencies:
   flutter:


### PR DESCRIPTION
Migrates flutter/plugins#1966 by @IchordeDionysos

I ended up rewriting it a bit.

Note: It seems the plugin was working fine and the behavior is covered by a test, but there was a spurious error message in the logs. This PR is removing the error message in the logs, and I don't think I can easily cover that in a test.

Fixes flutter/flutter#38060