### PR TITLE
[cloud_firestore] Fix possible NullPointerException

### DIFF
--- a/packages/cloud_firestore/CHANGELOG.md
+++ b/packages/cloud_firestore/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.12.9+2
+
+* Removed Activity reference to avoid possible NullPointerException.
+
 ## 0.12.9+1
 
 * Update documentation to reflect new repository location.

--- a/packages/cloud_firestore/example/lib/main.dart
+++ b/packages/cloud_firestore/example/lib/main.dart
@@ -63,9 +63,11 @@ class MyHomePage extends StatelessWidget {
   CollectionReference get messages => firestore.collection('messages');
 
   Future<void> _addMessage() async {
-    await messages.add(<String, dynamic>{
-      'message': 'Hello world!',
-      'created_at': FieldValue.serverTimestamp(),
+    firestore.runTransaction((Transaction tx) async {
+      await tx.set(messages.document(), <String, dynamic>{
+        'message': 'Hello world!',
+        'created_at': FieldValue.serverTimestamp(),
+      });
     });
   }
 

--- a/packages/cloud_firestore/pubspec.yaml
+++ b/packages/cloud_firestore/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for Cloud Firestore, a cloud-hosted, noSQL database 
   live synchronization and offline support on Android and iOS.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/cloud_firestore
-version: 0.12.9+1
+version: 0.12.9+2
 
 flutter:
   plugin:


### PR DESCRIPTION
## Description
Removed Activity Reference from plugin to avoid possible NullPointerException.
AsyncTasks are not needed to run Transactions, however [transactions are not guaranteed run in UI Thread](https://firebase.google.com/docs/firestore/manage-data/transactions#passing_information_out_of_transactions) so the Handler is still needed to send data to Dart.

## Related Issues

https://github.com/flutter/flutter/issues/38692

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [X] All existing and new tests are passing.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [X] I read and followed the [Flutter Style Guide].
- [X] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [X] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [X] I updated CHANGELOG.md to add a description of the change.
- [X] I signed the [CLA].
- [X] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [X] No, this is *not* a breaking change.