### PR TITLE
[cloud_firestore] Improve reliability of includeMetadataChanges integration test

### DIFF
--- a/packages/cloud_firestore/CHANGELOG.md
+++ b/packages/cloud_firestore/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.12.9+2
+
+* Fix flaky integration test for `includeMetadataChanges`.
+
 ## 0.12.9+1
 
 * Update documentation to reflect new repository location.

--- a/packages/cloud_firestore/example/test_driver/cloud_firestore.dart
+++ b/packages/cloud_firestore/example/test_driver/cloud_firestore.dart
@@ -123,17 +123,15 @@ void main() {
       expect(snapshot.metadata.isFromCache, true);
       expect(snapshot.data['hello'], 'world');
 
-      final List<DocumentSnapshot> snapshots =
-          await snapshotsWithMetadataChanges.toList();
-      snapshot = snapshotsWithMetadataChanges.take(1).first;
-      expect(snapshots.metadata.hasPendingWrites, true);
-      expect(snapshots.metadata.isFromCache, true);
-      expect(snapshots.data['hello'], 'world');
+      snapshot = await snapshotsWithMetadataChanges.take(1).first;
+      expect(snapshot.metadata.hasPendingWrites, true);
+      expect(snapshot.metadata.isFromCache, true);
+      expect(snapshot.data['hello'], 'world');
 
-      while (snapshot.hasPendingWrites || snapshot.isFromCache) {
-        snapshot = snapshotsWithMetadataChanges.take(1).first;
+      while (snapshot.metadata.hasPendingWrites || snapshot.metadata.isFromCache) {
+        snapshot = await snapshotsWithMetadataChanges.take(1).first;
       }
-      expect(snapshots.data['hello'], 'world');
+      expect(snapshot.data['hello'], 'world');
 
       await ref.delete();
     });

--- a/packages/cloud_firestore/example/test_driver/cloud_firestore.dart
+++ b/packages/cloud_firestore/example/test_driver/cloud_firestore.dart
@@ -128,7 +128,8 @@ void main() {
       expect(snapshot.metadata.isFromCache, true);
       expect(snapshot.data['hello'], 'world');
 
-      while (snapshot.metadata.hasPendingWrites || snapshot.metadata.isFromCache) {
+      while (
+          snapshot.metadata.hasPendingWrites || snapshot.metadata.isFromCache) {
         snapshot = await snapshotsWithMetadataChanges.take(1).first;
       }
       expect(snapshot.data['hello'], 'world');

--- a/packages/cloud_firestore/example/test_driver/cloud_firestore.dart
+++ b/packages/cloud_firestore/example/test_driver/cloud_firestore.dart
@@ -110,28 +110,30 @@ void main() {
       final DocumentReference ref = firestore.collection('messages').document();
       final Stream<DocumentSnapshot> snapshotWithoutMetadataChanges =
           ref.snapshots(includeMetadataChanges: false).take(1);
+      // It should take either two or three snapshots to make a change when
+      // metadata is included, depending on whether `hasPendingWrites` and
+      // `isFromCache` update at the same time.
       final Stream<DocumentSnapshot> snapshotsWithMetadataChanges =
           ref.snapshots(includeMetadataChanges: true).take(3);
 
       ref.setData(<String, dynamic>{'hello': 'world'});
 
-      final DocumentSnapshot snapshot =
-          await snapshotWithoutMetadataChanges.first;
+      DocumentSnapshot snapshot = await snapshotWithoutMetadataChanges.first;
       expect(snapshot.metadata.hasPendingWrites, true);
       expect(snapshot.metadata.isFromCache, true);
       expect(snapshot.data['hello'], 'world');
 
       final List<DocumentSnapshot> snapshots =
           await snapshotsWithMetadataChanges.toList();
-      expect(snapshots[0].metadata.hasPendingWrites, true);
-      expect(snapshots[0].metadata.isFromCache, true);
-      expect(snapshots[0].data['hello'], 'world');
-      expect(snapshots[1].metadata.hasPendingWrites, true);
-      expect(snapshots[1].metadata.isFromCache, false);
-      expect(snapshots[1].data['hello'], 'world');
-      expect(snapshots[2].metadata.hasPendingWrites, false);
-      expect(snapshots[2].metadata.isFromCache, false);
-      expect(snapshots[2].data['hello'], 'world');
+      snapshot = snapshotsWithMetadataChanges.take(1).first;
+      expect(snapshots.metadata.hasPendingWrites, true);
+      expect(snapshots.metadata.isFromCache, true);
+      expect(snapshots.data['hello'], 'world');
+
+      while (snapshot.hasPendingWrites || snapshot.isFromCache) {
+        snapshot = snapshotsWithMetadataChanges.take(1).first;
+      }
+      expect(snapshots.data['hello'], 'world');
 
       await ref.delete();
     });

--- a/packages/cloud_firestore/pubspec.yaml
+++ b/packages/cloud_firestore/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for Cloud Firestore, a cloud-hosted, noSQL database 
   live synchronization and offline support on Android and iOS.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/cloud_firestore
-version: 0.12.9+1
+version: 0.12.9+2
 
 flutter:
   plugin:


### PR DESCRIPTION
I have a theory about why this test is timing out on CI, although I can't reproduce it locally -- if `hasPendingWrites` and `isFromCache` update at the same time, the test could fail.