### PR TITLE
[all] Switch Android from api dependencies to implementation dependencies

### DIFF
--- a/packages/cloud_firestore/android/build.gradle
+++ b/packages/cloud_firestore/android/build.gradle
@@ -34,7 +34,7 @@ android {
         disable 'InvalidPackage'
     }
     dependencies {
-        api 'com.google.firebase:firebase-firestore:19.0.0'
+        implementation 'com.google.firebase:firebase-firestore:19.0.0'
         implementation 'com.google.firebase:firebase-common:16.1.0'
         implementation 'androidx.annotation:annotation:1.0.0'
     }

--- a/packages/cloud_functions/android/build.gradle
+++ b/packages/cloud_functions/android/build.gradle
@@ -32,7 +32,7 @@ android {
         disable 'InvalidPackage'
     }
     dependencies {
-        api 'com.google.firebase:firebase-functions:17.0.0'
+        implementation 'com.google.firebase:firebase-functions:17.0.0'
         implementation 'com.google.firebase:firebase-common:16.1.0'
         implementation 'androidx.annotation:annotation:1.0.0'
     }

--- a/packages/firebase_admob/android/build.gradle
+++ b/packages/firebase_admob/android/build.gradle
@@ -32,6 +32,6 @@ android {
         disable 'InvalidPackage'
     }
     dependencies {
-        api 'com.google.firebase:firebase-ads:18.1.1'
+        implementation 'com.google.firebase:firebase-ads:18.1.1'
     }
 }

--- a/packages/firebase_analytics/android/build.gradle
+++ b/packages/firebase_analytics/android/build.gradle
@@ -32,7 +32,7 @@ android {
         disable 'InvalidPackage'
     }
     dependencies {
-        api 'com.google.firebase:firebase-analytics:16.5.0'
+        implementation 'com.google.firebase:firebase-analytics:16.5.0'
         implementation 'com.google.firebase:firebase-common:16.1.0'
     }
 }

--- a/packages/firebase_auth/android/build.gradle
+++ b/packages/firebase_auth/android/build.gradle
@@ -35,7 +35,7 @@ android {
     dependencies {
         implementation 'androidx.annotation:annotation:1.0.0'
         implementation 'com.google.firebase:firebase-common:16.1.0'
-        api 'com.google.firebase:firebase-auth:17.0.0'
+        implementation 'com.google.firebase:firebase-auth:17.0.0'
         api 'com.google.code.gson:gson:2.8.5'
     }
 }

--- a/packages/firebase_database/android/build.gradle
+++ b/packages/firebase_database/android/build.gradle
@@ -32,7 +32,7 @@ android {
         disable 'InvalidPackage'
     }
     dependencies {
-        api 'com.google.firebase:firebase-database:17.0.0'
+        implementation 'com.google.firebase:firebase-database:17.0.0'
         implementation 'com.google.firebase:firebase-common:16.1.0'
     }
 }

--- a/packages/firebase_dynamic_links/android/build.gradle
+++ b/packages/firebase_dynamic_links/android/build.gradle
@@ -32,7 +32,7 @@ android {
         disable 'InvalidPackage'
     }
     dependencies {
-        api 'com.google.firebase:firebase-dynamic-links:16.1.8'
+        implementation 'com.google.firebase:firebase-dynamic-links:16.1.8'
         implementation 'com.google.firebase:firebase-common:16.1.0'
         implementation 'androidx.annotation:annotation:1.0.0'
     }

--- a/packages/firebase_in_app_messaging/android/build.gradle
+++ b/packages/firebase_in_app_messaging/android/build.gradle
@@ -32,6 +32,6 @@ android {
         disable 'InvalidPackage'
     }
     dependencies {
-        api 'com.google.firebase:firebase-inappmessaging-display:18.0.2'
+        implementation 'com.google.firebase:firebase-inappmessaging-display:18.0.2'
     }
 }

--- a/packages/firebase_messaging/android/build.gradle
+++ b/packages/firebase_messaging/android/build.gradle
@@ -32,7 +32,7 @@ android {
         disable 'InvalidPackage'
     }
     dependencies {
-        api 'com.google.firebase:firebase-messaging:20.0.0'
+        implementation 'com.google.firebase:firebase-messaging:20.0.0'
         implementation 'com.google.firebase:firebase-common:16.1.0'
         implementation 'androidx.annotation:annotation:1.0.0'
         implementation 'androidx.localbroadcastmanager:localbroadcastmanager:1.0.0'

--- a/packages/firebase_ml_vision/android/build.gradle
+++ b/packages/firebase_ml_vision/android/build.gradle
@@ -32,7 +32,7 @@ android {
         disable 'InvalidPackage'
     }
     dependencies {
-        api 'com.google.firebase:firebase-ml-vision:20.0.0'
+        implementation 'com.google.firebase:firebase-ml-vision:20.0.0'
         implementation 'com.google.firebase:firebase-common:16.1.0'
         implementation 'androidx.annotation:annotation:1.0.0'
         implementation 'androidx.exifinterface:exifinterface:1.0.0'

--- a/packages/firebase_ml_vision/example/android/app/build.gradle
+++ b/packages/firebase_ml_vision/example/android/app/build.gradle
@@ -47,8 +47,8 @@ android {
     }
 
     dependencies {
-        api 'com.google.firebase:firebase-ml-vision-image-label-model:17.0.2'
-        api 'com.google.firebase:firebase-ml-vision-face-model:17.0.2'
+        implementation 'com.google.firebase:firebase-ml-vision-image-label-model:17.0.2'
+        implementation 'com.google.firebase:firebase-ml-vision-face-model:17.0.2'
         androidTestImplementation 'androidx.test:runner:1.2.0'
         androidTestImplementation 'androidx.test:rules:1.2.0'
         androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'

--- a/packages/firebase_performance/android/build.gradle
+++ b/packages/firebase_performance/android/build.gradle
@@ -32,7 +32,7 @@ android {
         disable 'InvalidPackage'
     }
     dependencies {
-        api 'com.google.firebase:firebase-perf:17.0.0'
+        implementation 'com.google.firebase:firebase-perf:17.0.0'
         implementation 'com.google.firebase:firebase-common:16.1.0'
     }
 }

--- a/packages/firebase_remote_config/android/build.gradle
+++ b/packages/firebase_remote_config/android/build.gradle
@@ -32,7 +32,7 @@ android {
         disable 'InvalidPackage'
     }
     dependencies {
-        api 'com.google.firebase:firebase-config:16.4.1'
+        implementation 'com.google.firebase:firebase-config:16.4.1'
         implementation 'com.google.firebase:firebase-common:16.1.0'
         implementation 'androidx.annotation:annotation:1.0.0'
     }

--- a/packages/firebase_storage/android/build.gradle
+++ b/packages/firebase_storage/android/build.gradle
@@ -40,7 +40,7 @@ android {
         disable 'InvalidPackage'
     }
     dependencies {
-        api 'com.google.firebase:firebase-storage:17.0.0'
+        implementation 'com.google.firebase:firebase-storage:17.0.0'
         implementation 'com.google.firebase:firebase-common:16.1.0'
         implementation 'androidx.annotation:annotation:1.0.0'
     }


### PR DESCRIPTION
Flutterfire plugins don't expose a public API to other Java libraries (with the exception of the plugin registration process). I am wondering if it would be reasonable to allow a developer to mix and match plugins that depend on different versions of Firebase Android SDK.

Using implementation dependencies instead of api dependencies gets our dependencies off the classpath of the developer's app and reduces the chance of Gradle build errors due to version resolution conflicts. Being able to mix and match Flutterfire plugins on Android might reduce the need for "symbolic" Dart packages.

Here's an article on the differences of api vs implementation in libraries:
https://docs.gradle.org/current/userguide/java_library_plugin.html#sec:java_library_separation

I think this might be a more ideal approach for the problem that is addressed by https://github.com/FirebaseExtended/flutterfire/pull/12 where adding an explicit Firebase dependency to the developer's app-level build.gradle can lead to unexpected build breaks elsewhere.

Possible con: It might increase the size of builds slightly if developers are depending on multiple implementations of Firebase Android SDKs. However, I'm not seeing this in practice.

#### Related Issues

flutter/flutter#37837