### PR TITLE
[firebase_admob] exclude translatesAutoresizingMaskIntoConstraints = NO under ios 11

### DIFF
--- a/packages/firebase_admob/ios/Classes/FLTMobileAd.m
+++ b/packages/firebase_admob/ios/Classes/FLTMobileAd.m
@@ -144,12 +144,12 @@ GADAdSize _adSize;
 
   if (_status != LOADED) return;
 
-  _banner.translatesAutoresizingMaskIntoConstraints = NO;
   UIView *screen = [FLTMobileAd rootViewController].view;
   [screen addSubview:_banner];
 
 #if defined(__IPHONE_11_0) && (__IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_11_0)
   if (@available(ios 11.0, *)) {
+    _banner.translatesAutoresizingMaskIntoConstraints = NO;
     UILayoutGuide *guide = screen.safeAreaLayoutGuide;
     [NSLayoutConstraint activateConstraints:@[
       [_banner.centerXAnchor constraintEqualToAnchor:guide.centerXAnchor


### PR DESCRIPTION
Migrates flutter/plugins#1631

Author description: "AdView be placed with frame location under ios 11. But translatesAutoresizingMaskIntoConstraints has NO flag."

Fixes flutter/flutter#27457