### PR TITLE
[cloud_firestore] Catch exceptions for transactions on Android

### DIFF
--- a/packages/cloud_firestore/CHANGELOG.md
+++ b/packages/cloud_firestore/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.12.9+3
+
+* Updated error handling on Android for transactions to prevent crashes.
+
 ## 0.12.9+2
 
 * Fix flaky integration test for `includeMetadataChanges`.

--- a/packages/cloud_firestore/android/src/main/java/io/flutter/plugins/firebase/cloudfirestore/CloudFirestorePlugin.java
+++ b/packages/cloud_firestore/android/src/main/java/io/flutter/plugins/firebase/cloudfirestore/CloudFirestorePlugin.java
@@ -532,20 +532,20 @@ public class CloudFirestorePlugin implements MethodCallHandler {
               try {
                 transaction.set(getDocumentReference(arguments), data);
                 activity.runOnUiThread(
-                        new Runnable() {
-                          @Override
-                          public void run() {
-                            result.success(null);
-                          }
-                        });
+                    new Runnable() {
+                      @Override
+                      public void run() {
+                        result.success(null);
+                      }
+                    });
               } catch (final Exception e) {
                 activity.runOnUiThread(
-                        new Runnable() {
-                          @Override
-                          public void run() {
-                            result.error("Error performing Transaction#set", e.getMessage(), null);
-                          }
-                        });
+                    new Runnable() {
+                      @Override
+                      public void run() {
+                        result.error("Error performing Transaction#set", e.getMessage(), null);
+                      }
+                    });
               }
               return null;
             }
@@ -562,20 +562,20 @@ public class CloudFirestorePlugin implements MethodCallHandler {
               try {
                 transaction.delete(getDocumentReference(arguments));
                 activity.runOnUiThread(
-                        new Runnable() {
-                          @Override
-                          public void run() {
-                            result.success(null);
-                          }
-                        });
+                    new Runnable() {
+                      @Override
+                      public void run() {
+                        result.success(null);
+                      }
+                    });
               } catch (final Exception e) {
                 activity.runOnUiThread(
-                        new Runnable() {
-                          @Override
-                          public void run() {
-                            result.error("Error performing Transaction#delete", e.getMessage(), null);
-                          }
-                        });
+                    new Runnable() {
+                      @Override
+                      public void run() {
+                        result.error("Error performing Transaction#delete", e.getMessage(), null);
+                      }
+                    });
               }
               return null;
             }

--- a/packages/cloud_firestore/android/src/main/java/io/flutter/plugins/firebase/cloudfirestore/CloudFirestorePlugin.java
+++ b/packages/cloud_firestore/android/src/main/java/io/flutter/plugins/firebase/cloudfirestore/CloudFirestorePlugin.java
@@ -474,7 +474,7 @@ public class CloudFirestorePlugin implements MethodCallHandler {
                         result.success(snapshotMap);
                       }
                     });
-              } catch (final FirebaseFirestoreException e) {
+              } catch (final Exception e) {
                 activity.runOnUiThread(
                     new Runnable() {
                       @Override
@@ -506,7 +506,7 @@ public class CloudFirestorePlugin implements MethodCallHandler {
                         result.success(null);
                       }
                     });
-              } catch (final IllegalStateException e) {
+              } catch (final Exception e) {
                 activity.runOnUiThread(
                     new Runnable() {
                       @Override
@@ -529,14 +529,24 @@ public class CloudFirestorePlugin implements MethodCallHandler {
             @Override
             protected Void doInBackground(Void... voids) {
               Map<String, Object> data = (Map<String, Object>) arguments.get("data");
-              transaction.set(getDocumentReference(arguments), data);
-              activity.runOnUiThread(
-                  new Runnable() {
-                    @Override
-                    public void run() {
-                      result.success(null);
-                    }
-                  });
+              try {
+                transaction.set(getDocumentReference(arguments), data);
+                activity.runOnUiThread(
+                        new Runnable() {
+                          @Override
+                          public void run() {
+                            result.success(null);
+                          }
+                        });
+              } catch (final Exception e) {
+                activity.runOnUiThread(
+                        new Runnable() {
+                          @Override
+                          public void run() {
+                            result.error("Error performing Transaction#set", e.getMessage(), null);
+                          }
+                        });
+              }
               return null;
             }
           }.execute();
@@ -549,14 +559,24 @@ public class CloudFirestorePlugin implements MethodCallHandler {
           new AsyncTask<Void, Void, Void>() {
             @Override
             protected Void doInBackground(Void... voids) {
-              transaction.delete(getDocumentReference(arguments));
-              activity.runOnUiThread(
-                  new Runnable() {
-                    @Override
-                    public void run() {
-                      result.success(null);
-                    }
-                  });
+              try {
+                transaction.delete(getDocumentReference(arguments));
+                activity.runOnUiThread(
+                        new Runnable() {
+                          @Override
+                          public void run() {
+                            result.success(null);
+                          }
+                        });
+              } catch (final Exception e) {
+                activity.runOnUiThread(
+                        new Runnable() {
+                          @Override
+                          public void run() {
+                            result.error("Error performing Transaction#delete", e.getMessage(), null);
+                          }
+                        });
+              }
               return null;
             }
           }.execute();

--- a/packages/cloud_firestore/pubspec.yaml
+++ b/packages/cloud_firestore/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for Cloud Firestore, a cloud-hosted, noSQL database 
   live synchronization and offline support on Android and iOS.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/cloud_firestore
-version: 0.12.9+2
+version: 0.12.9+3
 
 flutter:
   plugin:


### PR DESCRIPTION
This should resolve #70.

I assume that the `RuntimeException`s I am seeing there happen in the `doInBackground` `AsyncTask` of `Transaction#set`, which is why I added a `try-catch` block there.

`Transaction#update` and `Transaction#get` already had `try-catch` blocks, however, they only caught `IllegalStateException`'s and since I got `RuntimeException`s and there is no need to be specific about the type of exception when only `e.getMessage` is called anyway, I generalized the `catch` block for those as well.

Additionally, I applied the same logic to `Transaction#delete`, just to be consistent.