### PR TITLE
[cloud_firestore] Fixes crash on Android when run a transaction

### DIFF
--- a/packages/cloud_firestore/CHANGELOG.md
+++ b/packages/cloud_firestore/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.12.10
+
+* Fixes crash on Android when run a transaction and without internet connection.
+
+
 ## 0.12.9+3
 
 * Updated error handling on Android for transactions to prevent crashes.

--- a/packages/cloud_firestore/CHANGELOG.md
+++ b/packages/cloud_firestore/CHANGELOG.md
@@ -1,7 +1,6 @@
-## 0.12.10
+## 0.12.9+4
 
-* Fixes crash on Android when run a transaction and without internet connection.
-
+* Fixes a crash on Android when running a transaction without an internet connection.
 
 ## 0.12.9+3
 

--- a/packages/cloud_firestore/android/src/main/java/io/flutter/plugins/firebase/cloudfirestore/CloudFirestorePlugin.java
+++ b/packages/cloud_firestore/android/src/main/java/io/flutter/plugins/firebase/cloudfirestore/CloudFirestorePlugin.java
@@ -446,7 +446,9 @@ public class CloudFirestorePlugin implements MethodCallHandler {
                         result.success(transactionResult);
                       } else {
                         result.error(
-                            "Error performing transaction", transactionResult.exception.getMessage(), null);
+                            "Error performing transaction",
+                            transactionResult.exception.getMessage(),
+                            null);
                       }
                     }
                   });

--- a/packages/cloud_firestore/android/src/main/java/io/flutter/plugins/firebase/cloudfirestore/CloudFirestorePlugin.java
+++ b/packages/cloud_firestore/android/src/main/java/io/flutter/plugins/firebase/cloudfirestore/CloudFirestorePlugin.java
@@ -443,7 +443,7 @@ public class CloudFirestorePlugin implements MethodCallHandler {
 
                       TransactionResult transactionResult = task.getResult();
                       if (transactionResult.exception == null) {
-                        result.success(transactionResult);
+                        result.success(transactionResult.result);
                       } else {
                         result.error(
                             "Error performing transaction",

--- a/packages/cloud_firestore/pubspec.yaml
+++ b/packages/cloud_firestore/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for Cloud Firestore, a cloud-hosted, noSQL database 
   live synchronization and offline support on Android and iOS.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/cloud_firestore
-version: 0.12.10
+version: 0.12.9+4
 
 flutter:
   plugin:

--- a/packages/cloud_firestore/pubspec.yaml
+++ b/packages/cloud_firestore/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for Cloud Firestore, a cloud-hosted, noSQL database 
   live synchronization and offline support on Android and iOS.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/cloud_firestore
-version: 0.12.9+3
+version: 0.12.10
 
 flutter:
   plugin:


### PR DESCRIPTION
## Description

* Fixes crash on Android when run a transaction and without internet connection.
* This occurred because:

`Tasks.await(transactionTCSTask, timeout, TimeUnit.MILLISECONDS)`
throws a `Exception`
→ `result.error("Error performing transaction", e.getMessage(), null)` will be called
→ transaction result is `null`
→ in `addOnCompleteListener`#`onComplete`:
```java
    if (task.isSuccessful()) { // result is null
      result.success(task.getResult());
    }
```
will also be called
→ **result#success has been called after result#error**
→ This cause `java.lang.IllegalStateException: Reply already submitted`

## Related Issues

fix #79 

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] If the pull request affects only one plugin, the PR title starts with the name of the plugin in brackets (e.g. [cloud_firestore])
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
