### PR TITLE
[cloud_firestore] Fix runTransaction Android crash

### DIFF
--- a/packages/cloud_firestore/CHANGELOG.md
+++ b/packages/cloud_firestore/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.12.9+4
+
+* Fixed `runTransaction` crash on Android.
+
 ## 0.12.9+3
 
 * Updated error handling on Android for transactions to prevent crashes.

--- a/packages/cloud_firestore/android/src/main/java/io/flutter/plugins/firebase/cloudfirestore/CloudFirestorePlugin.java
+++ b/packages/cloud_firestore/android/src/main/java/io/flutter/plugins/firebase/cloudfirestore/CloudFirestorePlugin.java
@@ -426,7 +426,6 @@ public class CloudFirestorePlugin implements MethodCallHandler {
                         // Once transaction completes return the result to the Dart side.
                         return transactionResult;
                       } catch (Exception e) {
-                        Log.e(TAG, e.getMessage(), e);
                         result.error("Error performing transaction", e.getMessage(), null);
                       }
                       return null;

--- a/packages/cloud_firestore/pubspec.yaml
+++ b/packages/cloud_firestore/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for Cloud Firestore, a cloud-hosted, noSQL database 
   live synchronization and offline support on Android and iOS.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/cloud_firestore
-version: 0.12.9+3
+version: 0.12.9+4
 
 flutter:
   plugin:


### PR DESCRIPTION
Trying to resolve #102.

---

I only removed logging for now because the way I understand Android `Task`s, it should be impossible for both of the `result.error` calls to occur because I do not see a possible cause for an `Exception` that would cause the `onComplete` task to be unsuccessful after the `try-catch`. 

Also, is it okay to call `result.success` after `result.error`?  
The flow I imagine is the following: `Exception` in `try-catch` `->` `result.error` in `runTransaction` `->` `return null` in `runTransaction` `->` `result.success` in `onComplete`. Or does `return null` not trigger `onComplete`?

Maybe I interpreted the stack trace incorrectly?  
@kroikie @collinjackson Can you please take a look, I would love to prevent this crash, but I might misunderstand `Reply already submitted at io.flutter.embedding.engine.dart.DartMessenger$Reply.reply + 35(DartMessenger.java:35)`.