### PR TITLE
[firebase_crashlytics] Always log crash details in debug mode

### DIFF
--- a/packages/firebase_crashlytics/CHANGELOG.md
+++ b/packages/firebase_crashlytics/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.1.1
+
+* Log FlutterErrorDetails using Flutter's standard `FlutterError.dumpErrorToConsole`.
+* In debug mode, always log errors.
+
 ## 0.1.0+5
 
 * Fix example app `support-compat` crash by setting `compileSdkVersion` to 28.

--- a/packages/firebase_crashlytics/lib/src/firebase_crashlytics.dart
+++ b/packages/firebase_crashlytics/lib/src/firebase_crashlytics.dart
@@ -28,7 +28,9 @@ class Crashlytics {
   /// to Firebase Crashlytics.
   Future<void> recordFlutterError(FlutterErrorDetails details) async {
     print('Flutter error caught by Crashlytics plugin:');
-    FlutterError.dumpErrorToConsole(details);
+    // Since multiple errors can be caught during a single session, we set
+    // forceReport=true.
+    FlutterError.dumpErrorToConsole(details, forceReport: true);
 
     _recordError(details.exceptionAsString(), details.stack,
         context: details.context,

--- a/packages/firebase_crashlytics/lib/src/firebase_crashlytics.dart
+++ b/packages/firebase_crashlytics/lib/src/firebase_crashlytics.dart
@@ -28,12 +28,14 @@ class Crashlytics {
   /// to Firebase Crashlytics.
   Future<void> recordFlutterError(FlutterErrorDetails details) async {
     print('Flutter error caught by Crashlytics plugin:');
+    FlutterError.dumpErrorToConsole(details);
 
     _recordError(details.exceptionAsString(), details.stack,
         context: details.context,
         information: details.informationCollector == null
             ? null
-            : details.informationCollector());
+            : details.informationCollector(),
+        printDetails: false);
   }
 
   /// Submits a report of a non-fatal error.
@@ -200,18 +202,25 @@ class Crashlytics {
   // occurred and give useful background information in [FlutterErrorDetails.informationCollector].
   // Crashlytics will log this information in addition to the stack trace.
   // If [information] is `null` or empty, it will be ignored.
-  Future<void> _recordError(dynamic exception, StackTrace stack,
-      {dynamic context, Iterable<DiagnosticsNode> information}) async {
+  Future<void> _recordError(
+    dynamic exception,
+    StackTrace stack, {
+    dynamic context,
+    Iterable<DiagnosticsNode> information,
+    bool printDetails,
+  }) async {
     bool inDebugMode = false;
     if (!enableInDevMode) {
       assert(inDebugMode = true);
     }
 
+    printDetails ??= inDebugMode;
+
     final String _information = (information == null || information.isEmpty)
         ? ''
         : (StringBuffer()..writeAll(information, '\n')).toString();
 
-    if (inDebugMode && !enableInDevMode) {
+    if (printDetails) {
       // If available, give context to the exception.
       if (context != null)
         print('The following exception was thrown $context:');
@@ -225,7 +234,8 @@ class Crashlytics {
       // Not using Trace.format here to stick to the default stack trace format
       // that Flutter developers are used to seeing.
       if (stack != null) print('\n$stack');
-    } else {
+    }
+    if (!inDebugMode || enableInDevMode) {
       // The stack trace can be null. To avoid the following exception:
       // Invalid argument(s): Cannot create a Trace from null.
       // To avoid that exception, we can check for null and provide an empty stack trace.

--- a/packages/firebase_crashlytics/pubspec.yaml
+++ b/packages/firebase_crashlytics/pubspec.yaml
@@ -2,7 +2,7 @@ name: firebase_crashlytics
 description:
   Flutter plugin for Firebase Crashlytics. It reports uncaught errors to the
   Firebase console.
-version: 0.1.0+5
+version: 0.1.1
 author: Flutter Team <flutter-dev@google.com>
 homepage: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/firebase_crashlytics
 


### PR DESCRIPTION
## Description

Always log crash details in debug mode, even if `enableInDevMode=true`.
And for Flutter error, log even when not inDebugMode -- with FlutterError.dumpErrorToConsole, keeping existing Flutter behavior.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] If the pull request affects only one plugin, the PR title starts with the name of the plugin in brackets (e.g. [cloud_firestore])
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.
