### PR TITLE
[firebase_crashlytics] Use current stacktrace when null

### DIFF
--- a/packages/firebase_crashlytics/CHANGELOG.md
+++ b/packages/firebase_crashlytics/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.4+1
+
+* Put current stack trace into report if no other stack trace is supplied.
+
 ## 0.1.4
 
 * Update lower bound of dart dependency to 2.0.0.

--- a/packages/firebase_crashlytics/lib/src/firebase_crashlytics.dart
+++ b/packages/firebase_crashlytics/lib/src/firebase_crashlytics.dart
@@ -241,7 +241,7 @@ class Crashlytics {
       // The stack trace can be null. To avoid the following exception:
       // Invalid argument(s): Cannot create a Trace from null.
       // We can check for null and provide an empty stack trace.
-      stack ??= StackTrace.fromString('');
+      stack ??= StackTrace.current ?? StackTrace.fromString('');
 
       // Report error.
       final List<String> stackTraceLines =

--- a/packages/firebase_crashlytics/pubspec.yaml
+++ b/packages/firebase_crashlytics/pubspec.yaml
@@ -2,7 +2,7 @@ name: firebase_crashlytics
 description:
   Flutter plugin for Firebase Crashlytics. It reports uncaught errors to the
   Firebase console.
-version: 0.1.4
+version: 0.1.4+1
 homepage: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/firebase_crashlytics
 
 environment:

--- a/packages/firebase_crashlytics/test/firebase_crashlytics_test.dart
+++ b/packages/firebase_crashlytics/test/firebase_crashlytics_test.dart
@@ -82,11 +82,15 @@ void main() {
     test('recordError', () async {
       crashlytics.enableInDevMode = true;
       crashlytics.log('foo');
-      await crashlytics.recordError('foo exception', StackTrace.current,
-          context: "context");
+      await crashlytics.recordError('foo exception', null, context: "context");
       expect(log[0].method, 'Crashlytics#onError');
       expect(log[0].arguments['exception'], 'foo exception');
       expect(log[0].arguments['context'], "context");
+      // Confirm that the stack trace contains current stack.
+      expect(
+        log[0].arguments['stackTraceElements'],
+        contains(containsPair('file', 'firebase_crashlytics_test.dart')),
+      );
       expect(log[0].arguments['logs'], isNotEmpty);
       expect(log[0].arguments['logs'], contains('foo'));
       expect(log[0].arguments['keys'][0]['key'], 'testBool');


### PR DESCRIPTION
## Description

Put current stack trace into report if no other stack trace is supplied. This may give a clue if `reportError` was called manually.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] #105 is merged
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] If the pull request affects only one plugin, the PR title starts with the name of the plugin in brackets (e.g. [cloud_firestore])
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.
