### PR TITLE
[firebase_crashlytics] Fix pre-existing dartanalyzer finding

### DIFF
--- a/packages/firebase_crashlytics/CHANGELOG.md
+++ b/packages/firebase_crashlytics/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.0+4
+
+* Fix linter finding in examples.
+
 ## 0.1.0+3
 
 * Update documentation to reflect new repository location.

--- a/packages/firebase_crashlytics/example/lib/main.dart
+++ b/packages/firebase_crashlytics/example/lib/main.dart
@@ -4,9 +4,8 @@
 
 import 'dart:async';
 
-import 'package:flutter/material.dart';
-
 import 'package:firebase_crashlytics/firebase_crashlytics.dart';
+import 'package:flutter/material.dart';
 
 void main() {
   // Set `enableInDevMode` to true to see reports while in debug mode
@@ -74,7 +73,7 @@ class _MyAppState extends State<MyApp> {
                     // Example of an exception that does not get caught
                     // by `FlutterError.onError` but is caught by the `onError` handler of
                     // `runZoned`.
-                    Future<void>.delayed(Duration(seconds: 2), () {
+                    Future<void>.delayed(const Duration(seconds: 2), () {
                       final List<int> list = <int>[];
                       print(list[100]);
                     });

--- a/packages/firebase_crashlytics/pubspec.yaml
+++ b/packages/firebase_crashlytics/pubspec.yaml
@@ -2,7 +2,7 @@ name: firebase_crashlytics
 description:
   Flutter plugin for Firebase Crashlytics. It reports uncaught errors to the
   Firebase console.
-version: 0.1.0+3
+version: 0.1.0+4
 author: Flutter Team <flutter-dev@google.com>
 homepage: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/firebase_crashlytics
 


### PR DESCRIPTION
## Description

Fix pre-existing dartanalyzer finding:

  info - Prefer const with constant constructors at example/lib/main.dart:77:42 - (prefer_const_constructors)

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] If the pull request affects only one plugin, the PR title starts with the name of the plugin in brackets (e.g. [cloud_firestore])
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
