### PR TITLE
[firebase_analytics] Fix setAnalyticsCollectionEnabled

### DIFF
--- a/packages/firebase_analytics/CHANGELOG.md
+++ b/packages/firebase_analytics/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 5.0.2
+
+* Fixed `setAnalyticsCollectionEnabled` on iOS.
+
 ## 5.0.1
 
 * Update documentation to reflect new repository location.

--- a/packages/firebase_analytics/ios/Classes/FirebaseAnalyticsPlugin.m
+++ b/packages/firebase_analytics/ios/Classes/FirebaseAnalyticsPlugin.m
@@ -62,7 +62,7 @@
     [FIRAnalytics setUserPropertyString:value forName:name];
     result(nil);
   } else if ([@"setAnalyticsCollectionEnabled" isEqualToString:call.method]) {
-    NSNumber *enabled = [NSNumber numberWithBool:call.arguments];
+    NSNumber *enabled = call.arguments;
     [FIRAnalytics setAnalyticsCollectionEnabled:[enabled boolValue]];
     result(nil);
   } else if ([@"resetAnalyticsData" isEqualToString:call.method]) {

--- a/packages/firebase_analytics/pubspec.yaml
+++ b/packages/firebase_analytics/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for Google Analytics for Firebase, an app measuremen
   solution that provides insight on app usage and user engagement on Android and iOS.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/firebase_analytics
-version: 5.0.1
+version: 5.0.2
 
 flutter:
   plugin:


### PR DESCRIPTION
Fixes `setAnalyticsCollectionEnabled` on iOS.

When a boolean is passed across the bridge, it arrives as an `NSNumber *`. That means that when call.arguments has a `NO` `boolValue`, our code will call `[FIRAnalytics setAnalyticsCollectionEnabled:YES];` because the pointer isn't `nil`. This PR fixes the issue.

Unfortunately I can't think of a good way to integration test this.