### PR TITLE
[firebase_auth] Update iOS CocoaPod dependency.

### DIFF
--- a/packages/firebase_auth/CHANGELOG.md
+++ b/packages/firebase_auth/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.14.0+6
+
+* Increase iOS CocoaPod dependency to '~> 6.8' to address `UIWebView` deprecation.
+
 ## 0.14.0+5
 
 * On iOS, `fetchSignInMethodsForEmail` now returns an empty list when the email

--- a/packages/firebase_auth/ios/firebase_auth.podspec
+++ b/packages/firebase_auth/ios/firebase_auth.podspec
@@ -21,7 +21,7 @@ Firebase Auth plugin for Flutter.
   s.public_header_files = 'Classes/**/*.h'
   s.ios.deployment_target = '8.0'
   s.dependency 'Flutter'
-  s.dependency 'Firebase/Auth', '~> 6.0'
+  s.dependency 'Firebase/Auth', '~> 6.8'
   s.dependency 'Firebase/Core'
   s.static_framework = true
 

--- a/packages/firebase_auth/pubspec.yaml
+++ b/packages/firebase_auth/pubspec.yaml
@@ -4,7 +4,7 @@ description: Flutter plugin for Firebase Auth, enabling Android and iOS
   like Google, Facebook and Twitter.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/firebase_auth
-version: 0.14.0+5
+version: 0.14.0+6
 
 flutter:
   plugin:


### PR DESCRIPTION
Avoids deprecation warnings relating to `UIWebView`.

Running `pod repo update` may be required.

Related issue: flutter/flutter#39470