### PR TITLE
[firebase_dynamic_links] Update CocoaPods dependency

### DIFF
--- a/packages/firebase_dynamic_links/CHANGELOG.md
+++ b/packages/firebase_dynamic_links/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.5.0+4
+
+* Increase iOS CocoaPod dependency to '~> 6.8' to address `UIWebView` deprecation.
+
 ## 0.5.0+3
 
 * Don't crash if registrar.activity() is not there.

--- a/packages/firebase_dynamic_links/ios/firebase_dynamic_links.podspec
+++ b/packages/firebase_dynamic_links/ios/firebase_dynamic_links.podspec
@@ -21,7 +21,7 @@ Flutter plugin for Google Dynamic Links for Firebase, an app solution for creati
   s.source_files = 'Classes/**/*'
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Flutter'
-  s.dependency 'Firebase/DynamicLinks'
+  s.dependency 'Firebase/DynamicLinks', '~> 6.8'
   s.ios.deployment_target = '8.0'
   s.static_framework = true
 

--- a/packages/firebase_dynamic_links/pubspec.yaml
+++ b/packages/firebase_dynamic_links/pubspec.yaml
@@ -1,7 +1,7 @@
 name: firebase_dynamic_links
 description: Flutter plugin for Google Dynamic Links for Firebase, an app solution for creating
   and handling links across multiple platforms.
-version: 0.5.0+3
+version: 0.5.0+4
 
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/firebase_dynamic_links


### PR DESCRIPTION
Avoids deprecation warnings relating to `UIWebView`.

Running `pod repo update` may be required.

Related issue: flutter/flutter#39470