### PR TITLE
[firebase_admob] Parameters for rewarded video SSV Callbacks

### DIFF
--- a/packages/firebase_admob/CHANGELOG.md
+++ b/packages/firebase_admob/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.9.1+1
+
+* Enable custom parameters for rewarded video server-side verification callbacks.
+
 ## 0.9.1
 
 * Support v2 embedding. This will remain compatible with the original embedding and won't require

--- a/packages/firebase_admob/android/src/main/java/io/flutter/plugins/firebaseadmob/FirebaseAdMobPlugin.java
+++ b/packages/firebase_admob/android/src/main/java/io/flutter/plugins/firebaseadmob/FirebaseAdMobPlugin.java
@@ -217,6 +217,20 @@ public class FirebaseAdMobPlugin implements FlutterPlugin, ActivityAware, Method
     }
   }
 
+  private void callSetRewardedVideoAdUserId(MethodCall call, Result result) {
+    String userId = call.argument("userId");
+
+    rewardedWrapper.setUserId(userId);
+    result.success(Boolean.TRUE);
+  }
+
+  private void callSetRewardedVideoAdCustomData(MethodCall call, Result result) {
+    String customData = call.argument("customData");
+
+    rewardedWrapper.setCustomData(customData);
+    result.success(Boolean.TRUE);
+  }
+
   private void callDisposeAd(Integer id, Result result) {
     MobileAd ad = MobileAd.getAdForId(id);
     if (ad == null) {
@@ -293,6 +307,12 @@ public class FirebaseAdMobPlugin implements FlutterPlugin, ActivityAware, Method
         break;
       case "showRewardedVideoAd":
         callShowRewardedVideoAd(result);
+        break;
+      case "setRewardedVideoAdUserId":
+        callSetRewardedVideoAdUserId(call, result);
+        break;
+      case "setRewardedVideoAdCustomData":
+        callSetRewardedVideoAdCustomData(call, result);
         break;
       case "disposeAd":
         callDisposeAd(id, result);

--- a/packages/firebase_admob/android/src/main/java/io/flutter/plugins/firebaseadmob/RewardedVideoAdWrapper.java
+++ b/packages/firebase_admob/android/src/main/java/io/flutter/plugins/firebaseadmob/RewardedVideoAdWrapper.java
@@ -85,6 +85,14 @@ public class RewardedVideoAdWrapper implements RewardedVideoAdListener {
     return status;
   }
 
+  public void setUserId(String userId) {
+    rewardedInstance.setUserId(userId);
+  }
+
+  public void setCustomData(String customData) {
+    rewardedInstance.setCustomData(customData);
+  }
+
   public void load(String adUnitId, Map<String, Object> targetingInfo) {
     status = Status.LOADING;
     AdRequestBuilderFactory factory = new AdRequestBuilderFactory(targetingInfo);

--- a/packages/firebase_admob/ios/Classes/FLTFirebaseAdMobPlugin.m
+++ b/packages/firebase_admob/ios/Classes/FLTFirebaseAdMobPlugin.m
@@ -220,6 +220,20 @@
   }
 }
 
+- (void)callSetRewardedVideoAdUserId:(FlutterMethodCall *)call result:(FlutterResult)result {
+  NSString *userId = (NSString *)call.arguments[@"userId"];
+
+  [self.rewardedWrapper setUserIdentifier:userId];
+  result([NSNumber numberWithBool:YES]);
+}
+
+- (void)callSetRewardedVideoAdCustomData:(FlutterMethodCall *)call result:(FlutterResult)result {
+  NSString *customData = (NSString *)call.arguments[@"customData"];
+
+  [self.rewardedWrapper setCustomRewardString:customData];
+  result([NSNumber numberWithBool:YES]);
+}
+
 - (void)callShowRewardedVideoAd:(FlutterMethodCall *)call result:(FlutterResult)result {
   if (self.rewardedWrapper.status != FLTRewardedVideoAdStatusLoaded) {
     result([FlutterError errorWithCode:@"ad_not_loaded"
@@ -254,6 +268,16 @@
 
   if ([call.method isEqualToString:@"loadRewardedVideoAd"]) {
     [self callLoadRewardedVideoAd:call result:result];
+    return;
+  }
+
+  if ([call.method isEqualToString:@"setRewardedVideoAdUserId"]) {
+    [self callSetRewardedVideoAdUserId:call result:result];
+    return;
+  }
+
+  if ([call.method isEqualToString:@"setRewardedVideoAdCustomData"]) {
+    [self callSetRewardedVideoAdCustomData:call result:result];
     return;
   }
 

--- a/packages/firebase_admob/ios/Classes/FLTRewardedVideoAdWrapper.h
+++ b/packages/firebase_admob/ios/Classes/FLTRewardedVideoAdWrapper.h
@@ -17,4 +17,6 @@ typedef enum : NSUInteger {
 - (FLTRewardedVideoAdStatus)status;
 - (void)loadWithAdUnitId:(NSString *)adUnitId targetingInfo:(NSDictionary *)targetingInfo;
 - (void)show;
+- (void)setUserIdentifier:(NSString *)userIdentifier;
+- (void)setCustomRewardString:(NSString *)customRewardString;
 @end

--- a/packages/firebase_admob/ios/Classes/FLTRewardedVideoAdWrapper.m
+++ b/packages/firebase_admob/ios/Classes/FLTRewardedVideoAdWrapper.m
@@ -62,6 +62,14 @@ FLTRewardedVideoAdStatus _rewardedStatus;
       presentFromRootViewController:[FLTRewardedVideoAdWrapper rootViewController]];
 }
 
+- (void)setUserIdentifier:(NSString *)userIdentifier {
+  [[GADRewardBasedVideoAd sharedInstance] setUserIdentifier:userIdentifier];
+}
+
+- (void)setCustomRewardString:(NSString *)customRewardString {
+  [[GADRewardBasedVideoAd sharedInstance] setCustomRewardString:customRewardString];
+}
+
 - (NSString *)description {
   NSString *statusString =
       (NSString *)rewardedStatusToString[[NSNumber numberWithInt:_rewardedStatus]];

--- a/packages/firebase_admob/lib/firebase_admob.dart
+++ b/packages/firebase_admob/lib/firebase_admob.dart
@@ -400,6 +400,31 @@ class RewardedVideoAd {
   /// Callback invoked for events in the rewarded video ad lifecycle.
   RewardedVideoAdListener listener;
 
+  String _userId;
+  String _customData;
+
+  /// The user id used in server-to-server reward callbacks
+  String get userId => _userId;
+
+  /// The custom data included in server-to-server reward callbacks
+  String get customData => _customData;
+
+  /// Sets the user id to be used in server-to-server reward callbacks.
+  set userId(String userId) {
+    _invokeBooleanMethod("setRewardedVideoAdUserId", <String, dynamic>{
+      'userId': userId,
+    });
+    _userId = userId;
+  }
+
+  /// Sets custom data to be included in server-to-server reward callbacks.
+  set customData(String customData) {
+    _invokeBooleanMethod("setRewardedVideoAdCustomData", <String, dynamic>{
+      'customData': customData,
+    });
+    _customData = customData;
+  }
+
   /// Shows a rewarded video ad if one has been loaded.
   Future<bool> show() {
     return _invokeBooleanMethod("showRewardedVideoAd");

--- a/packages/firebase_admob/pubspec.yaml
+++ b/packages/firebase_admob/pubspec.yaml
@@ -2,7 +2,7 @@ name: firebase_admob
 description: Flutter plugin for Firebase AdMob, supporting
   banner, interstitial (full-screen), and rewarded video ads
 homepage: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/firebase_admob
-version: 0.9.1
+version: 0.9.1+1
 
 flutter:
   plugin:

--- a/packages/firebase_admob/test/firebase_admob_test.dart
+++ b/packages/firebase_admob/test/firebase_admob_test.dart
@@ -28,6 +28,8 @@ void main() {
           case 'loadRewardedVideoAd':
           case 'showAd':
           case 'showRewardedVideoAd':
+          case 'setRewardedVideoAdUserId':
+          case 'setRewardedVideoAdCustomData':
           case 'disposeAd':
             return Future<bool>.value(true);
           default:
@@ -128,6 +130,9 @@ void main() {
               targetingInfo: const MobileAdTargetingInfo()),
           true);
 
+      RewardedVideoAd.instance.userId = "user-id";
+      RewardedVideoAd.instance.customData = "custom-data";
+
       expect(await RewardedVideoAd.instance.show(), true);
 
       expect(log, <Matcher>[
@@ -135,6 +140,13 @@ void main() {
           'adUnitId': RewardedVideoAd.testAdUnitId,
           'targetingInfo': <String, String>{'requestAgent': 'flutter-alpha'},
         }),
+        isMethodCall('setRewardedVideoAdUserId', arguments: <String, dynamic>{
+          'userId': "user-id",
+        }),
+        isMethodCall('setRewardedVideoAdCustomData',
+            arguments: <String, dynamic>{
+              'customData': "custom-data",
+            }),
         isMethodCall('showRewardedVideoAd', arguments: null),
       ]);
     });


### PR DESCRIPTION
## Description

Enable the use of custom parameters for [rewarded video Server-side verification callbacks](https://developers.google.com/admob/android/rewarded-video-ssv)

I added setter methods for the custom parameters `user_id` and `custom_data`. Two new methods have been added to the by RewardedVideoAd class. I tried to keep them similar to the methods used in the android implementation

[`setUserId(String userId)`)](https://developers.google.com/android/reference/com/google/android/gms/ads/reward/RewardedVideoAd#setUserId(java.lang.String))
[`setCustomData(String userId)`](https://developers.google.com/android/reference/com/google/android/gms/ads/reward/RewardedVideoAd#setCustomData(java.lang.String))

## Related Issues
FirebaseExtended/flutterfire#164
flutter/flutter#33033

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] If the pull request affects only one plugin, the PR title starts with the name of the plugin in brackets (e.g. [cloud_firestore])
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
