### PR TITLE
[firebase_auth] Fix NoSuchMethodError exception

### DIFF
--- a/packages/firebase_auth/android/src/main/java/io/flutter/plugins/firebaseauth/FirebaseAuthPlugin.java
+++ b/packages/firebase_auth/android/src/main/java/io/flutter/plugins/firebaseauth/FirebaseAuthPlugin.java
@@ -491,8 +491,8 @@ public class FirebaseAuthPlugin implements MethodCallHandler {
     AuthCredential credential = getCredential((Map<String, Object>) call.arguments());
 
     currentUser
-        .reauthenticate(credential)
-        .addOnCompleteListener(new TaskVoidCompleteListener(result));
+       .reauthenticateAndRetrieveData(credential)
+       .addOnCompleteListener(new SignInCompleteListener(result));
   }
 
   private void handleUnlinkFromProvider(MethodCall call, Result result, FirebaseAuth firebaseAuth) {


### PR DESCRIPTION
Fix NoSuchMethodError exception when calling FirebaseUser.reauthenticateWithCredential

## Description

The stacktrace of the issue was this:
```
#0      Object.noSuchMethod (dart:core-patch/object_patch.dart:51:5)
#1      new AuthResult._ (package:firebase_auth/src/auth_result.dart:12:36)
#2      FirebaseUser.reauthenticateWithCredential (package:firebase_auth/src/firebase_user.dart:213:23)
<asynchronous suspension>
#3      ...............
```

This is the relevant part in `auth_result.dart`:
```dart
class AuthResult {
  AuthResult._(this._data, FirebaseApp app)
      : user = FirebaseUser._(_data['user'].cast<String, dynamic>(), app);

  final Map<String, dynamic> _data;
```

So, the `data` parameter passed to the `FirebaseUser` constructor was `null`.

From the `reauthenticateWithCredential` method:
```dart
Future<AuthResult> reauthenticateWithCredential(
      AuthCredential credential) async {
    assert(credential != null);
    final Map<String, dynamic> data =
        await FirebaseAuth.channel.invokeMapMethod<String, dynamic>(
      'reauthenticateWithCredential',
      <String, dynamic>{
        'app': _app.name,
        'provider': credential._provider,
        'data': credential._data,
      },
    );
    return AuthResult._(data, _app);
  }
```
the `data` parameter passed to `AuhtResult` came from the `reauthenticateWithCredential` invoked channel method.

By looking inside the `handleReauthenticateWithCredential` method in the `FirebaseAuthPlugin.java` I notice the line:
```java
currentUser
        .reauthenticate(credential)
        .addOnCompleteListener(new TaskVoidCompleteListener(result));
```

The `reauthenticate` has a return type of `Task<void>`, for this reason, the `data` in the `reauthenticateWithCredential` was filled with null.
The `FirebaseUser`'s `reauthenticateAndRetrieveData` method has `Task<AuthResult>` as return type. Also the `SignInCompleteListener` returns a map containing the Firebase user data inside the "user" key (exactly what the `AuthResult` needs in its constructor).
By applying these two modifications the code works properly.

## Related Issues

https://github.com/FirebaseExtended/flutterfire/issues/76

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] If the pull request affects only one plugin, the PR title starts with the name of the plugin in brackets (e.g. [cloud_firestore])
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] The title of the PR starts with the name of the plugin surrounded by square brackets, e.g. [shared_preferences]
- [ ] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [ ] I updated CHANGELOG.md to add a description of the change.
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
