### PR TITLE
[firebase_auth] Add some info about method swizzling problem in iOS

### DIFF
--- a/packages/firebase_auth/CHANGELOG.md
+++ b/packages/firebase_auth/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.14.0+7
+
+* Update README to show how to fix the method swizzling problem on iOS when call `verifyPhoneNumber`
+
 ## 0.14.0+6
 
 * Update example app with correct const constructors.

--- a/packages/firebase_auth/README.md
+++ b/packages/firebase_auth/README.md
@@ -121,10 +121,16 @@ After a successful authentication, you will receive a `FirebaseUser` object. You
 
   - When testing you can add test phone numbers and verification codes to the Firebase console.
 
-1. [Enable App verification](https://firebase.google.com/docs/auth/ios/phone-auth#enable-app-verification)  
+2. [Enable App verification](https://firebase.google.com/docs/auth/ios/phone-auth#enable-app-verification)  
 
 **Note:** App verification may use APNs, if using a simulator (where APNs does not work) or APNs is not setup on the
 device you are using you must set the `URL Schemes` to the `REVERSE_CLIENT_ID` from the GoogleServices-Info.plist file.
+
+**Known issue:** If you are trying to call `verifyPhoneNumber` and are receiving an `verifyPhoneNumberError` with the message 
+
+> If app delegate swizzling is disabled, remote notifications received by UIApplicationDelegate need to be forwarded to FIRAuth's canHandleNotificaton: method.
+
+you should take a look at [this appendix on Firebase docs](https://firebase.google.com/docs/auth/ios/phone-auth#appendix:-using-phone-sign-in-without-swizzling). It'll require some changes in your iOS project.
 
 #### Android setup
 

--- a/packages/firebase_auth/pubspec.yaml
+++ b/packages/firebase_auth/pubspec.yaml
@@ -4,7 +4,7 @@ description: Flutter plugin for Firebase Auth, enabling Android and iOS
   like Google, Facebook and Twitter.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/firebase_auth
-version: 0.14.0+6
+version: 0.14.0+7
 
 flutter:
   plugin:


### PR DESCRIPTION
## Description

Add some info about how to solve the [method swizzling problem](https://github.com/flutter/flutter/issues/35267) that still happening.

I'm sending this change in the documentation due to the time I spent trying to solve this problem. 
I think this could help more people that still having this situation.

This issue started when I upgraded my flutter to `v1.7.8+hotfix.2` from `v1.5.4-hotfix.2`. 

## Related Issues

[#35267](https://github.com/flutter/flutter/issues/35267)

## Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] If the pull request affects only one plugin, the PR title starts with the name of the plugin in brackets (e.g. [cloud_firestore])
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [X] All existing and new tests are passing.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [X] I read and followed the [Flutter Style Guide].
- [X] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [X] I updated CHANGELOG.md to add a description of the change.
- [X] I signed the [CLA].
- [X] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [X] No, this is *not* a breaking change.
