### PR TITLE
[firebase_auth] Fixes completely broken `reauthenticateWithCredential` method.

### DIFF
--- a/packages/firebase_auth/CHANGELOG.md
+++ b/packages/firebase_auth/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.14.0+7
+
+* Fixes broken `reauthenticateWithCredential` method on both Android and iOS.
+
 ## 0.14.0+6
 
 * Update example app with correct const constructors.

--- a/packages/firebase_auth/android/src/main/java/io/flutter/plugins/firebaseauth/FirebaseAuthPlugin.java
+++ b/packages/firebase_auth/android/src/main/java/io/flutter/plugins/firebaseauth/FirebaseAuthPlugin.java
@@ -491,8 +491,8 @@ public class FirebaseAuthPlugin implements MethodCallHandler {
     AuthCredential credential = getCredential((Map<String, Object>) call.arguments());
 
     currentUser
-        .reauthenticate(credential)
-        .addOnCompleteListener(new TaskVoidCompleteListener(result));
+        .reauthenticateAndRetrieveData(credential)
+        .addOnCompleteListener(new SignInCompleteListener(result));
   }
 
   private void handleUnlinkFromProvider(MethodCall call, Result result, FirebaseAuth firebaseAuth) {

--- a/packages/firebase_auth/ios/Classes/FirebaseAuthPlugin.m
+++ b/packages/firebase_auth/ios/Classes/FirebaseAuthPlugin.m
@@ -238,9 +238,9 @@ int nextHandle = 0;
   } else if ([@"reauthenticateWithCredential" isEqualToString:call.method]) {
     [[self getAuth:call.arguments].currentUser
         reauthenticateAndRetrieveDataWithCredential:[self getCredential:call.arguments]
-                                         completion:^(FIRAuthDataResult *r,
+                                         completion:^(FIRAuthDataResult *authResult,
                                                       NSError *_Nullable error) {
-                                           [self sendResult:result forObject:nil error:error];
+                                           [self sendResult:result forAuthDataResult:authResult error:error];
                                          }];
   } else if ([@"linkWithCredential" isEqualToString:call.method]) {
     [[self getAuth:call.arguments].currentUser

--- a/packages/firebase_auth/pubspec.yaml
+++ b/packages/firebase_auth/pubspec.yaml
@@ -4,7 +4,7 @@ description: Flutter plugin for Firebase Auth, enabling Android and iOS
   like Google, Facebook and Twitter.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/firebase_auth
-version: 0.14.0+6
+version: 0.14.0+7
 
 flutter:
   plugin:


### PR DESCRIPTION
## Description

Last November there was a move away from the methods for each auth provider and to instead use the new credential methods. #928 c78ced72dfbe38153ea02bae4255e35fa1fbc2c4 At this point the `reauthenticateWithCredential` dart method invoked the platform channel and did not expect any response data.

Along came #1911 cc7353b3825de1ab5f82b3bccc89a512c9d8074f in July where all the auth methods were set to return a AuthResult object. However, nobody updated the platform specific code for `reauthenticateWithCredential` to return back the fields for `AuthResult`. This has left the `reauthenticateWithCredential` method in dart broken since then.

This PR fixes the platform specific code to account for this change.

## Related Issues
* Caused by #1911 cc7353b3825de1ab5f82b3bccc89a512c9d8074f
* Fixes #76 

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] If the pull request affects only one plugin, the PR title starts with the name of the plugin in brackets (e.g. [cloud_firestore])
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
