### PR TITLE
[cloud_firestore] Documentation Fix for SnapshotMetadata.

### DIFF
--- a/packages/cloud_firestore/lib/src/snapshot_metadata.dart
+++ b/packages/cloud_firestore/lib/src/snapshot_metadata.dart
@@ -11,8 +11,8 @@ class SnapshotMetadata {
   /// Whether the snapshot contains the result of local writes that have not yet
   /// been committed to the backend.
   ///
-  /// If your listener has opted into metadata updates (via
-  /// [DocumentListenOptions] or [QueryListenOptions]) you will receive another
+  /// If you called [DocumentReference.snapshots] or [Query.snapshots] with
+  /// `includeMetadataChanges` parameter set to `true` you will receive another
   /// snapshot with `hasPendingWrites` equal to `false` once the writes have been
   /// committed to the backend.
   final bool hasPendingWrites;
@@ -20,8 +20,8 @@ class SnapshotMetadata {
   /// Whether the snapshot was created from cached data rather than guaranteed
   /// up-to-date server data.
   ///
-  /// If your listener has opted into metadata updates (via
-  /// [DocumentListenOptions] or [QueryListenOptions]) you will receive another
+  /// If you called [DocumentReference.snapshots] or [Query.snapshots] with
+  /// `includeMetadataChanges` parameter set to `true` you will receive another
   /// snapshot with `isFomCache` equal to `false` once the client has received
   /// up-to-date data from the backend.
   final bool isFromCache;


### PR DESCRIPTION
## Description
Fix SnapshotMetadata comments that referenced Android classes to reference the dart mechanism instead. It is now clear how the developer can use the metadata feature of Firestore.

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] If the pull request affects only one plugin, the PR title starts with the name of the plugin in brackets (e.g. [cloud_firestore])
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.
