### PR TITLE
Enable Firebase Test Lab testing

### DIFF
--- a/.ci/Dockerfile
+++ b/.ci/Dockerfile
@@ -1,6 +1,21 @@
 
 FROM cirrusci/flutter:latest
 
+RUN sudo apt-get update -y
+
+RUN sudo apt-get install -y --no-install-recommends gnupg
+
+# Add repo for gcloud sdk and install it
+RUN echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" | \
+    sudo tee -a /etc/apt/sources.list.d/google-cloud-sdk.list 
+
+RUN curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | \
+    sudo apt-key --keyring /usr/share/keyrings/cloud.google.gpg add -
+
+RUN sudo apt-get update && sudo apt-get install -y google-cloud-sdk && \
+    gcloud config set core/disable_usage_reporting true && \
+    gcloud config set component_manager/disable_update_check true
+
 RUN yes | sdkmanager \
     "platforms;android-27" \
     "build-tools;27.0.3" \

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -28,6 +28,7 @@ task:
           PLUGIN_SHARDING: "--shardIndex 0 --shardCount 2"
           PLUGIN_SHARDING: "--shardIndex 1 --shardCount 2"
         MAPS_API_KEY: ENCRYPTED[596a9f6bca436694625ac50851dc5da6b4d34cba8025f7db5bc9465142e8cd44e15f69e3507787753accebfc4910d550]
+        GCLOUD_FIREBASE_TESTLAB_KEY: ENCRYPTED[fd81ffb7c44af2f8a1ae55e470c69690c1ec7e90aba49d18635fa4f3c72b6807034287e9e697f64e37ab836a66ba9eab]
       create_device_script:
         echo no | avdmanager -v create avd -n test -k "system-images;android-21;default;armeabi-v7a"
       script:
@@ -43,6 +44,12 @@ task:
         - export CIRRUS_COMMIT_MESSAGE=""
         - ./script/incremental_build.sh build-examples --apk
         - ./script/incremental_build.sh java-test  # must come after apk build
+        - if [[ $GCLOUD_FIREBASE_TESTLAB_KEY == ENCRYPTED* ]]; then
+        -   echo "This user does not have permission to run Firebase Test Lab tests."
+        - else
+        -   echo $GCLOUD_FIREBASE_TESTLAB_KEY > ${HOME}/gcloud-service-key.json
+        -   ./script/incremental_build.sh firebase-test-lab
+        - fi
         - export CIRRUS_CHANGE_MESSAGE=`cat /tmp/cirrus_change_message.txt`
         - export CIRRUS_COMMIT_MESSAGE=`cat /tmp/cirrus_commit_message.txt`
 

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -5,6 +5,8 @@ task:
     cpu: 8
     memory: 16G
   upgrade_script:
+    - flutter channel stable
+    - flutter upgrade
     - flutter channel master
     - flutter upgrade
     - git fetch origin master
@@ -12,26 +14,44 @@ task:
   matrix:
     - name: publishable
       script: ./script/check_publish.sh
-    - name: test+format
+    - name: test
+    - name: format
       install_script:
         - wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
         - sudo apt-add-repository "deb http://apt.llvm.org/xenial/ llvm-toolchain-xenial-7 main"
         - sudo apt-get update
         - sudo apt-get install -y --allow-unauthenticated clang-format-7
       format_script: ./script/incremental_build.sh format --travis --clang-format=clang-format-7
-      test_script: ./script/incremental_build.sh test
+    - name: test
+      env:
+        matrix:
+          CHANNEL: "master"
+          CHANNEL: "stable"
+      test_script:
+        # TODO(jackson): Allow web plugins once supported on stable
+        # https://github.com/flutter/flutter/issues/42864
+        - if [[ "$CHANNEL" -eq "stable" ]]; then find . | grep _web$ | xargs rm -rf; fi
+        - flutter channel $CHANNEL
+        - ./script/incremental_build.sh test
     - name: analyze
       script: ./script/incremental_build.sh analyze
-    - name: build-apks+java-test+drive-examples
+    - name: build-apks+java-test+firebase-test-lab
       env:
         matrix:
           PLUGIN_SHARDING: "--shardIndex 0 --shardCount 2"
           PLUGIN_SHARDING: "--shardIndex 1 --shardCount 2"
+        matrix:
+          CHANNEL: "master"
+          CHANNEL: "stable"
         MAPS_API_KEY: ENCRYPTED[596a9f6bca436694625ac50851dc5da6b4d34cba8025f7db5bc9465142e8cd44e15f69e3507787753accebfc4910d550]
         GCLOUD_FIREBASE_TESTLAB_KEY: ENCRYPTED[fd81ffb7c44af2f8a1ae55e470c69690c1ec7e90aba49d18635fa4f3c72b6807034287e9e697f64e37ab836a66ba9eab]
       create_device_script:
         echo no | avdmanager -v create avd -n test -k "system-images;android-21;default;armeabi-v7a"
       script:
+        # TODO(jackson): Allow web plugins once supported on stable
+        # https://github.com/flutter/flutter/issues/42864
+        - if [[ "$CHANNEL" -eq "stable" ]]; then find . | grep _web$ | xargs rm -rf; fi
+        - flutter channel $CHANNEL
         # Unsetting CIRRUS_CHANGE_MESSAGE and CIRRUS_COMMIT_MESSAGE as they
         # might include non-ASCII characters which makes Gradle crash.
         # See: https://github.com/flutter/flutter/issues/24935
@@ -60,6 +80,8 @@ task:
   setup_script:
     - pod repo update
   upgrade_script:
+    - flutter channel stable
+    - flutter upgrade
     - flutter channel master
     - flutter upgrade
     - git fetch origin master
@@ -77,7 +99,14 @@ task:
           PLUGIN_SHARDING: "--shardIndex 1 --shardCount 4"
           PLUGIN_SHARDING: "--shardIndex 2 --shardCount 4"
           PLUGIN_SHARDING: "--shardIndex 3 --shardCount 4"
+        matrix:
+          CHANNEL: "master"
+          CHANNEL: "stable"
         SIMCTL_CHILD_MAPS_API_KEY: ENCRYPTED[596a9f6bca436694625ac50851dc5da6b4d34cba8025f7db5bc9465142e8cd44e15f69e3507787753accebfc4910d550]
       build_script:
+        # TODO(jackson): Allow web plugins once supported on stable
+        # https://github.com/flutter/flutter/issues/42864
+        - if [[ "$CHANNEL" -eq "stable" ]]; then find . | grep _web$ | xargs rm -rf; fi
+        - flutter channel $CHANNEL
         - ./script/incremental_build.sh build-examples --ipa
         - ./script/incremental_build.sh drive-examples

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -42,7 +42,6 @@ task:
         MAPS_API_KEY: ENCRYPTED[596a9f6bca436694625ac50851dc5da6b4d34cba8025f7db5bc9465142e8cd44e15f69e3507787753accebfc4910d550]
         GCLOUD_FIREBASE_TESTLAB_KEY: ENCRYPTED[fd81ffb7c44af2f8a1ae55e470c69690c1ec7e90aba49d18635fa4f3c72b6807034287e9e697f64e37ab836a66ba9eab]
       script:
-        - if [[ "$CHANNEL" -eq "stable" ]]; then find . | grep _web$ | xargs rm -rf; fi
         - flutter channel $CHANNEL
         # Unsetting CIRRUS_CHANGE_MESSAGE and CIRRUS_COMMIT_MESSAGE as they
         # might include non-ASCII characters which makes Gradle crash.

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -27,9 +27,6 @@ task:
           CHANNEL: "master"
           CHANNEL: "stable"
       test_script:
-        # TODO(jackson): Allow web plugins once supported on stable
-        # https://github.com/flutter/flutter/issues/42864
-        - if [[ "$CHANNEL" -eq "stable" ]]; then find . | grep _web$ | xargs rm -rf; fi
         - flutter channel $CHANNEL
         - ./script/incremental_build.sh test
     - name: analyze
@@ -45,8 +42,6 @@ task:
         MAPS_API_KEY: ENCRYPTED[596a9f6bca436694625ac50851dc5da6b4d34cba8025f7db5bc9465142e8cd44e15f69e3507787753accebfc4910d550]
         GCLOUD_FIREBASE_TESTLAB_KEY: ENCRYPTED[fd81ffb7c44af2f8a1ae55e470c69690c1ec7e90aba49d18635fa4f3c72b6807034287e9e697f64e37ab836a66ba9eab]
       script:
-        # TODO(jackson): Allow web plugins once supported on stable
-        # https://github.com/flutter/flutter/issues/42864
         - if [[ "$CHANNEL" -eq "stable" ]]; then find . | grep _web$ | xargs rm -rf; fi
         - flutter channel $CHANNEL
         # Unsetting CIRRUS_CHANGE_MESSAGE and CIRRUS_COMMIT_MESSAGE as they
@@ -100,9 +95,6 @@ task:
           CHANNEL: "stable"
         SIMCTL_CHILD_MAPS_API_KEY: ENCRYPTED[596a9f6bca436694625ac50851dc5da6b4d34cba8025f7db5bc9465142e8cd44e15f69e3507787753accebfc4910d550]
       build_script:
-        # TODO(jackson): Allow web plugins once supported on stable
-        # https://github.com/flutter/flutter/issues/42864
-        - if [[ "$CHANNEL" -eq "stable" ]]; then find . | grep _web$ | xargs rm -rf; fi
         - flutter channel $CHANNEL
         - ./script/incremental_build.sh build-examples --ipa
         - ./script/incremental_build.sh drive-examples

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -14,7 +14,6 @@ task:
   matrix:
     - name: publishable
       script: ./script/check_publish.sh
-    - name: test
     - name: format
       install_script:
         - wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
@@ -45,8 +44,6 @@ task:
           CHANNEL: "stable"
         MAPS_API_KEY: ENCRYPTED[596a9f6bca436694625ac50851dc5da6b4d34cba8025f7db5bc9465142e8cd44e15f69e3507787753accebfc4910d550]
         GCLOUD_FIREBASE_TESTLAB_KEY: ENCRYPTED[fd81ffb7c44af2f8a1ae55e470c69690c1ec7e90aba49d18635fa4f3c72b6807034287e9e697f64e37ab836a66ba9eab]
-      create_device_script:
-        echo no | avdmanager -v create avd -n test -k "system-images;android-21;default;armeabi-v7a"
       script:
         # TODO(jackson): Allow web plugins once supported on stable
         # https://github.com/flutter/flutter/issues/42864
@@ -85,8 +82,7 @@ task:
     - flutter channel master
     - flutter upgrade
     - git fetch origin master
-  activate_script:
-    - pub global activate flutter_plugin_tools
+  activate_script: pub global activate flutter_plugin_tools
   create_simulator_script:
     - xcrun simctl list
     - xcrun simctl create Flutter-iPhone com.apple.CoreSimulator.SimDeviceType.iPhone-X com.apple.CoreSimulator.SimRuntime.iOS-12-2 | xargs xcrun simctl boot


### PR DESCRIPTION
Updates the FirebaseExtended repo CI to have the same testing on Firebase Test Lab that is used for flutter/plugins.

Eventually I'd like to refactor to eliminate duplicated code, but I'm not sure how to do that.

The only differences between flutter/plugins and FirebaseExtended/flutterfire are the encrypted Firebase Test Lab key, and the all plugins tests.