### PR TITLE
Remove unused encrypted variables

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -39,7 +39,6 @@ task:
         matrix:
           CHANNEL: "master"
           CHANNEL: "stable"
-        MAPS_API_KEY: ENCRYPTED[596a9f6bca436694625ac50851dc5da6b4d34cba8025f7db5bc9465142e8cd44e15f69e3507787753accebfc4910d550]
         GCLOUD_FIREBASE_TESTLAB_KEY: ENCRYPTED[fd81ffb7c44af2f8a1ae55e470c69690c1ec7e90aba49d18635fa4f3c72b6807034287e9e697f64e37ab836a66ba9eab]
       script:
         - flutter channel $CHANNEL
@@ -92,7 +91,6 @@ task:
         matrix:
           CHANNEL: "master"
           CHANNEL: "stable"
-        SIMCTL_CHILD_MAPS_API_KEY: ENCRYPTED[596a9f6bca436694625ac50851dc5da6b4d34cba8025f7db5bc9465142e8cd44e15f69e3507787753accebfc4910d550]
       build_script:
         - flutter channel $CHANNEL
         - ./script/incremental_build.sh build-examples --ipa


### PR DESCRIPTION
See https://cirrus-ci.com/task/5375987256131584

<img width="830" alt="Screen Shot 2019-10-22 at 17 13 47" src="https://user-images.githubusercontent.com/394889/67345274-56ac3c00-f4ef-11e9-88cb-828a2adde156.png">

This unused environment variable is copy pasta from the flutter/plugins version of .cirrus.yml. seems to be causing other encrypted data to fail to decrypt, so the Firebase Test Lab tests aren't running.
