### PR TITLE
[firebase_auth] getIdToken use actual refresh value instead of checking if object exists

### DIFF
--- a/packages/firebase_auth/CHANGELOG.md
+++ b/packages/firebase_auth/CHANGELOG.md
@@ -4,7 +4,11 @@
 
 ## 0.14.0+7
 
+<<<<<<< HEAD
 * Remove AndroidX warning.
+=======
+* Do not ignore "refresh" value for "getIdToken" on iOS
+>>>>>>> getIdToken use actual refresh value instead of checking if object exists
 
 ## 0.14.0+6
 

--- a/packages/firebase_auth/CHANGELOG.md
+++ b/packages/firebase_auth/CHANGELOG.md
@@ -10,7 +10,6 @@
 
 * Remove AndroidX warning.
 
-
 ## 0.14.0+6
 
 * Update example app with correct const constructors.

--- a/packages/firebase_auth/CHANGELOG.md
+++ b/packages/firebase_auth/CHANGELOG.md
@@ -1,14 +1,15 @@
 ## 0.14.0+8
 
+<<<<<<< HEAD
 * Updated README instructions for contributing for consistency with other Flutterfire plugins.
+=======
+* getIdToken use actual refresh value instead of checking if object exists
+>>>>>>> Rebase fixes
 
 ## 0.14.0+7
 
-<<<<<<< HEAD
 * Remove AndroidX warning.
-=======
-* Do not ignore "refresh" value for "getIdToken" on iOS
->>>>>>> getIdToken use actual refresh value instead of checking if object exists
+
 
 ## 0.14.0+6
 

--- a/packages/firebase_auth/CHANGELOG.md
+++ b/packages/firebase_auth/CHANGELOG.md
@@ -1,10 +1,10 @@
+## 0.14.0+9
+
+* getIdToken use actual refresh value instead of checking if object exists
+
 ## 0.14.0+8
 
-<<<<<<< HEAD
 * Updated README instructions for contributing for consistency with other Flutterfire plugins.
-=======
-* getIdToken use actual refresh value instead of checking if object exists
->>>>>>> Rebase fixes
 
 ## 0.14.0+7
 

--- a/packages/firebase_auth/CHANGELOG.md
+++ b/packages/firebase_auth/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 0.14.0+9
 
-* getIdToken use actual refresh value instead of checking if object exists
+* Fix the behavior of `getIdToken` to use the `refresh` parameter instead of always refreshing.
 
 ## 0.14.0+8
 

--- a/packages/firebase_auth/example/test/firebase_auth.dart
+++ b/packages/firebase_auth/example/test/firebase_auth.dart
@@ -55,7 +55,8 @@ void main() {
       expect(tokenResult.claims['firebase']['sign_in_provider'], 'anonymous');
       expect(tokenResult.claims['user_id'], user.uid);
       // Verify that token will be the same after another getIdToken call with refresh = false option
-      final IdTokenResult newTokenResultWithoutRefresh = await user.getIdToken(refresh: false);
+      final IdTokenResult newTokenResultWithoutRefresh =
+          await user.getIdToken(refresh: false);
       expect(originalToken, newTokenResultWithoutRefresh.token);
       await auth.signOut();
       final FirebaseUser user2 = (await auth.signInAnonymously()).user;

--- a/packages/firebase_auth/example/test/firebase_auth.dart
+++ b/packages/firebase_auth/example/test/firebase_auth.dart
@@ -40,6 +40,7 @@ void main() {
       expect(user.metadata.creationTime.isAfter(DateTime(2018, 1, 1)), isTrue);
       expect(user.metadata.creationTime.isBefore(DateTime.now()), isTrue);
       final IdTokenResult tokenResult = await user.getIdToken();
+      final String originalToken = tokenResult.token;
       expect(tokenResult.token, isNotNull);
       expect(tokenResult.expirationTime.isAfter(DateTime.now()), isTrue);
       expect(tokenResult.authTime, isNotNull);
@@ -53,6 +54,9 @@ void main() {
       expect(tokenResult.claims['provider_id'], 'anonymous');
       expect(tokenResult.claims['firebase']['sign_in_provider'], 'anonymous');
       expect(tokenResult.claims['user_id'], user.uid);
+      // Verify that token will be the same after another getIdToken call with refresh = false option
+      final IdTokenResult newTokenResultWithoutRefresh = await user.getIdToken(refresh: false);
+      expect(originalToken, newTokenResultWithoutRefresh.token);
       await auth.signOut();
       final FirebaseUser user2 = (await auth.signInAnonymously()).user;
       expect(user2.uid, isNot(equals(user.uid)));

--- a/packages/firebase_auth/ios/Classes/FirebaseAuthPlugin.m
+++ b/packages/firebase_auth/ios/Classes/FirebaseAuthPlugin.m
@@ -205,7 +205,7 @@ int nextHandle = 0;
     }
   } else if ([@"getIdToken" isEqualToString:call.method]) {
     NSDictionary *args = call.arguments;
-    BOOL refresh = [args objectForKey:@"refresh"];
+    BOOL refresh = [[args objectForKey:@"refresh"] boolValue];
     [[self getAuth:call.arguments].currentUser
         getIDTokenResultForcingRefresh:refresh
                             completion:^(FIRAuthTokenResult *_Nullable tokenResult,

--- a/packages/firebase_auth/pubspec.yaml
+++ b/packages/firebase_auth/pubspec.yaml
@@ -4,7 +4,7 @@ description: Flutter plugin for Firebase Auth, enabling Android and iOS
   like Google, Facebook and Twitter.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/firebase_auth
-version: 0.14.0+8
+version: 0.14.0+9
 
 flutter:
   plugin:


### PR DESCRIPTION
## Description

Currently, we have different behavior in Android and iOS implementation for token refreshing. On Android we are expecting to get a `boolean` value, so everything works as expected:
`getIdToken(refresh: false)` - will not update token and `getIdToken(refresh: true)` will refresh it.
On iOS we are checking if `refresh` object exists in the dictionary, so `getIdToken(refresh: false)` will force token refreshing.

## Related Issues

https://github.com/FirebaseExtended/flutterfire/issues/847

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] If the pull request affects only one plugin, the PR title starts with the name of the plugin in brackets (e.g. [cloud_firestore])
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
