### PR TITLE
[firebase_crashlytics] Use Trace object instead of parsing strings

### DIFF
--- a/packages/firebase_crashlytics/CHANGELOG.md
+++ b/packages/firebase_crashlytics/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.3
+
+* Use `Trace` object instead of parsing strings.
+
 ## 0.1.2
 
 * Updated to use the v2 plugin API.

--- a/packages/firebase_crashlytics/pubspec.yaml
+++ b/packages/firebase_crashlytics/pubspec.yaml
@@ -2,7 +2,7 @@ name: firebase_crashlytics
 description:
   Flutter plugin for Firebase Crashlytics. It reports uncaught errors to the
   Firebase console.
-version: 0.1.2
+version: 0.1.3
 author: Flutter Team <flutter-dev@google.com>
 homepage: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/firebase_crashlytics
 

--- a/packages/firebase_crashlytics/test/firebase_crashlytics_test.dart
+++ b/packages/firebase_crashlytics/test/firebase_crashlytics_test.dart
@@ -8,6 +8,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:stack_trace/stack_trace.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -151,11 +152,10 @@ void main() {
     });
 
     test('getStackTraceElements with character index', () async {
-      final List<String> lines = <String>[
-        'package:flutter/src/widgets/framework.dart 3825:27  StatefulElement.build'
-      ];
+      final Trace trace = Trace.parse(
+          'package:flutter/src/widgets/framework.dart 3825:27  StatefulElement.build');
       final List<Map<String, String>> elements =
-          crashlytics.getStackTraceElements(lines);
+          crashlytics.getStackTraceElements(trace);
       expect(elements.length, 1);
       expect(elements.first, <String, String>{
         'class': 'StatefulElement',
@@ -166,11 +166,10 @@ void main() {
     });
 
     test('getStackTraceElements without character index', () async {
-      final List<String> lines = <String>[
-        'package:flutter/src/widgets/framework.dart 3825  StatefulElement.build'
-      ];
+      final Trace trace = Trace.parse(
+          'package:flutter/src/widgets/framework.dart 3825  StatefulElement.build');
       final List<Map<String, String>> elements =
-          crashlytics.getStackTraceElements(lines);
+          crashlytics.getStackTraceElements(trace);
       expect(elements.length, 1);
       expect(elements.first, <String, String>{
         'class': 'StatefulElement',
@@ -181,11 +180,10 @@ void main() {
     });
 
     test('getStackTraceElements without class', () async {
-      final List<String> lines = <String>[
-        'package:firebase_crashlytics/test/main.dart 12  main'
-      ];
+      final Trace trace =
+          Trace.parse('package:firebase_crashlytics/test/main.dart 12  main');
       final List<Map<String, String>> elements =
-          crashlytics.getStackTraceElements(lines);
+          crashlytics.getStackTraceElements(trace);
       expect(elements.length, 1);
       expect(elements.first, <String, String>{
         'method': 'main',


### PR DESCRIPTION
## Description

Currently, we get a Trace object but then convert it to a String and parse. In this PR we stop parsing a string and instead use Trace object as it is.

The method in question is `@visibleForTesting`, so this should not be a breaking change.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] If the pull request affects only one plugin, the PR title starts with the name of the plugin in brackets (e.g. [cloud_firestore])
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [ ] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [ ] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
