### PR TITLE
[All] Add keep annotation to Firebase registrar

### DIFF
--- a/packages/cloud_firestore/cloud_firestore/android/src/main/java/io/flutter/plugins/firebase/cloudfirestore/FlutterFirebaseAppRegistrar.java
+++ b/packages/cloud_firestore/cloud_firestore/android/src/main/java/io/flutter/plugins/firebase/cloudfirestore/FlutterFirebaseAppRegistrar.java
@@ -4,12 +4,15 @@
 
 package io.flutter.plugins.firebase.cloudfirestore;
 
+import androidx.annotation.Keep;
+
 import com.google.firebase.components.Component;
 import com.google.firebase.components.ComponentRegistrar;
 import com.google.firebase.platforminfo.LibraryVersionComponent;
 import java.util.Collections;
 import java.util.List;
 
+@Keep
 public class FlutterFirebaseAppRegistrar implements ComponentRegistrar {
   @Override
   public List<Component<?>> getComponents() {

--- a/packages/cloud_firestore/cloud_firestore/android/src/main/java/io/flutter/plugins/firebase/cloudfirestore/FlutterFirebaseAppRegistrar.java
+++ b/packages/cloud_firestore/cloud_firestore/android/src/main/java/io/flutter/plugins/firebase/cloudfirestore/FlutterFirebaseAppRegistrar.java
@@ -5,7 +5,6 @@
 package io.flutter.plugins.firebase.cloudfirestore;
 
 import androidx.annotation.Keep;
-
 import com.google.firebase.components.Component;
 import com.google.firebase.components.ComponentRegistrar;
 import com.google.firebase.platforminfo.LibraryVersionComponent;

--- a/packages/cloud_functions/android/src/main/java/io/flutter/plugins/firebase/cloudfunctions/FlutterFirebaseAppRegistrar.java
+++ b/packages/cloud_functions/android/src/main/java/io/flutter/plugins/firebase/cloudfunctions/FlutterFirebaseAppRegistrar.java
@@ -5,7 +5,6 @@
 package io.flutter.plugins.firebase.cloudfunctions;
 
 import androidx.annotation.Keep;
-
 import com.google.firebase.components.Component;
 import com.google.firebase.components.ComponentRegistrar;
 import com.google.firebase.platforminfo.LibraryVersionComponent;

--- a/packages/cloud_functions/android/src/main/java/io/flutter/plugins/firebase/cloudfunctions/FlutterFirebaseAppRegistrar.java
+++ b/packages/cloud_functions/android/src/main/java/io/flutter/plugins/firebase/cloudfunctions/FlutterFirebaseAppRegistrar.java
@@ -4,12 +4,15 @@
 
 package io.flutter.plugins.firebase.cloudfunctions;
 
+import androidx.annotation.Keep;
+
 import com.google.firebase.components.Component;
 import com.google.firebase.components.ComponentRegistrar;
 import com.google.firebase.platforminfo.LibraryVersionComponent;
 import java.util.Collections;
 import java.util.List;
 
+@Keep
 public class FlutterFirebaseAppRegistrar implements ComponentRegistrar {
   @Override
   public List<Component<?>> getComponents() {

--- a/packages/firebase_analytics/firebase_analytics/android/build.gradle
+++ b/packages/firebase_analytics/firebase_analytics/android/build.gradle
@@ -34,6 +34,7 @@ android {
     dependencies {
         api 'com.google.firebase:firebase-analytics:16.5.0'
         implementation 'com.google.firebase:firebase-common:16.1.0'
+        implementation 'androidx.annotation:annotation:1.1.0'
     }
 }
 

--- a/packages/firebase_analytics/firebase_analytics/android/src/main/java/io/flutter/plugins/firebaseanalytics/FlutterFirebaseAppRegistrar.java
+++ b/packages/firebase_analytics/firebase_analytics/android/src/main/java/io/flutter/plugins/firebaseanalytics/FlutterFirebaseAppRegistrar.java
@@ -5,7 +5,6 @@
 package io.flutter.plugins.firebaseanalytics;
 
 import androidx.annotation.Keep;
-
 import com.google.firebase.components.Component;
 import com.google.firebase.components.ComponentRegistrar;
 import com.google.firebase.platforminfo.LibraryVersionComponent;

--- a/packages/firebase_analytics/firebase_analytics/android/src/main/java/io/flutter/plugins/firebaseanalytics/FlutterFirebaseAppRegistrar.java
+++ b/packages/firebase_analytics/firebase_analytics/android/src/main/java/io/flutter/plugins/firebaseanalytics/FlutterFirebaseAppRegistrar.java
@@ -4,12 +4,15 @@
 
 package io.flutter.plugins.firebaseanalytics;
 
+import androidx.annotation.Keep;
+
 import com.google.firebase.components.Component;
 import com.google.firebase.components.ComponentRegistrar;
 import com.google.firebase.platforminfo.LibraryVersionComponent;
 import java.util.Collections;
 import java.util.List;
 
+@Keep
 public class FlutterFirebaseAppRegistrar implements ComponentRegistrar {
   @Override
   public List<Component<?>> getComponents() {

--- a/packages/firebase_auth/firebase_auth/android/src/main/java/io/flutter/plugins/firebaseauth/FlutterFirebaseAppRegistrar.java
+++ b/packages/firebase_auth/firebase_auth/android/src/main/java/io/flutter/plugins/firebaseauth/FlutterFirebaseAppRegistrar.java
@@ -5,7 +5,6 @@
 package io.flutter.plugins.firebaseauth;
 
 import androidx.annotation.Keep;
-
 import com.google.firebase.components.Component;
 import com.google.firebase.components.ComponentRegistrar;
 import com.google.firebase.platforminfo.LibraryVersionComponent;

--- a/packages/firebase_auth/firebase_auth/android/src/main/java/io/flutter/plugins/firebaseauth/FlutterFirebaseAppRegistrar.java
+++ b/packages/firebase_auth/firebase_auth/android/src/main/java/io/flutter/plugins/firebaseauth/FlutterFirebaseAppRegistrar.java
@@ -4,12 +4,15 @@
 
 package io.flutter.plugins.firebaseauth;
 
+import androidx.annotation.Keep;
+
 import com.google.firebase.components.Component;
 import com.google.firebase.components.ComponentRegistrar;
 import com.google.firebase.platforminfo.LibraryVersionComponent;
 import java.util.Collections;
 import java.util.List;
 
+@Keep
 public class FlutterFirebaseAppRegistrar implements ComponentRegistrar {
   @Override
   public List<Component<?>> getComponents() {

--- a/packages/firebase_core/firebase_core/android/build.gradle
+++ b/packages/firebase_core/firebase_core/android/build.gradle
@@ -33,6 +33,7 @@ android {
     }
     dependencies {
         implementation 'com.google.firebase:firebase-common:16.1.0'
+        implementation 'androidx.annotation:annotation:1.1.0'
     }
 }
 

--- a/packages/firebase_core/firebase_core/android/src/main/java/io/flutter/plugins/firebase/core/FlutterFirebaseAppRegistrar.java
+++ b/packages/firebase_core/firebase_core/android/src/main/java/io/flutter/plugins/firebase/core/FlutterFirebaseAppRegistrar.java
@@ -5,7 +5,6 @@
 package io.flutter.plugins.firebase.core;
 
 import androidx.annotation.Keep;
-
 import com.google.firebase.components.Component;
 import com.google.firebase.components.ComponentRegistrar;
 import com.google.firebase.platforminfo.LibraryVersionComponent;

--- a/packages/firebase_core/firebase_core/android/src/main/java/io/flutter/plugins/firebase/core/FlutterFirebaseAppRegistrar.java
+++ b/packages/firebase_core/firebase_core/android/src/main/java/io/flutter/plugins/firebase/core/FlutterFirebaseAppRegistrar.java
@@ -4,12 +4,15 @@
 
 package io.flutter.plugins.firebase.core;
 
+import androidx.annotation.Keep;
+
 import com.google.firebase.components.Component;
 import com.google.firebase.components.ComponentRegistrar;
 import com.google.firebase.platforminfo.LibraryVersionComponent;
 import java.util.Collections;
 import java.util.List;
 
+@Keep
 public class FlutterFirebaseAppRegistrar implements ComponentRegistrar {
   @Override
   public List<Component<?>> getComponents() {

--- a/packages/firebase_crashlytics/android/build.gradle
+++ b/packages/firebase_crashlytics/android/build.gradle
@@ -39,6 +39,7 @@ android {
 dependencies {
     implementation 'com.crashlytics.sdk.android:crashlytics:2.9.9'
     implementation 'com.google.firebase:firebase-common:16.1.0'
+    implementation 'androidx.annotation:annotation:1.1.0'
 }
 
 apply from: file("./user-agent.gradle")

--- a/packages/firebase_crashlytics/android/src/main/java/io/flutter/plugins/firebase/crashlytics/firebasecrashlytics/FlutterFirebaseAppRegistrar.java
+++ b/packages/firebase_crashlytics/android/src/main/java/io/flutter/plugins/firebase/crashlytics/firebasecrashlytics/FlutterFirebaseAppRegistrar.java
@@ -5,7 +5,6 @@
 package io.flutter.plugins.firebase.crashlytics.firebasecrashlytics;
 
 import androidx.annotation.Keep;
-
 import com.google.firebase.components.Component;
 import com.google.firebase.components.ComponentRegistrar;
 import com.google.firebase.platforminfo.LibraryVersionComponent;

--- a/packages/firebase_crashlytics/android/src/main/java/io/flutter/plugins/firebase/crashlytics/firebasecrashlytics/FlutterFirebaseAppRegistrar.java
+++ b/packages/firebase_crashlytics/android/src/main/java/io/flutter/plugins/firebase/crashlytics/firebasecrashlytics/FlutterFirebaseAppRegistrar.java
@@ -4,12 +4,15 @@
 
 package io.flutter.plugins.firebase.crashlytics.firebasecrashlytics;
 
+import androidx.annotation.Keep;
+
 import com.google.firebase.components.Component;
 import com.google.firebase.components.ComponentRegistrar;
 import com.google.firebase.platforminfo.LibraryVersionComponent;
 import java.util.Collections;
 import java.util.List;
 
+@Keep
 public class FlutterFirebaseAppRegistrar implements ComponentRegistrar {
   @Override
   public List<Component<?>> getComponents() {

--- a/packages/firebase_database/android/build.gradle
+++ b/packages/firebase_database/android/build.gradle
@@ -34,6 +34,7 @@ android {
     dependencies {
         api 'com.google.firebase:firebase-database:17.0.0'
         implementation 'com.google.firebase:firebase-common:16.1.0'
+        implementation 'androidx.annotation:annotation:1.1.0'
     }
 }
 

--- a/packages/firebase_database/android/src/main/java/io/flutter/plugins/firebase/database/FlutterFirebaseAppRegistrar.java
+++ b/packages/firebase_database/android/src/main/java/io/flutter/plugins/firebase/database/FlutterFirebaseAppRegistrar.java
@@ -5,7 +5,6 @@
 package io.flutter.plugins.firebase.database;
 
 import androidx.annotation.Keep;
-
 import com.google.firebase.components.Component;
 import com.google.firebase.components.ComponentRegistrar;
 import com.google.firebase.platforminfo.LibraryVersionComponent;

--- a/packages/firebase_database/android/src/main/java/io/flutter/plugins/firebase/database/FlutterFirebaseAppRegistrar.java
+++ b/packages/firebase_database/android/src/main/java/io/flutter/plugins/firebase/database/FlutterFirebaseAppRegistrar.java
@@ -4,12 +4,15 @@
 
 package io.flutter.plugins.firebase.database;
 
+import androidx.annotation.Keep;
+
 import com.google.firebase.components.Component;
 import com.google.firebase.components.ComponentRegistrar;
 import com.google.firebase.platforminfo.LibraryVersionComponent;
 import java.util.Collections;
 import java.util.List;
 
+@Keep
 public class FlutterFirebaseAppRegistrar implements ComponentRegistrar {
   @Override
   public List<Component<?>> getComponents() {

--- a/packages/firebase_dynamic_links/android/src/main/java/io/flutter/plugins/firebasedynamiclinks/FlutterFirebaseAppRegistrar.java
+++ b/packages/firebase_dynamic_links/android/src/main/java/io/flutter/plugins/firebasedynamiclinks/FlutterFirebaseAppRegistrar.java
@@ -4,12 +4,15 @@
 
 package io.flutter.plugins.firebasedynamiclinks;
 
+import androidx.annotation.Keep;
+
 import com.google.firebase.components.Component;
 import com.google.firebase.components.ComponentRegistrar;
 import com.google.firebase.platforminfo.LibraryVersionComponent;
 import java.util.Collections;
 import java.util.List;
 
+@Keep
 public class FlutterFirebaseAppRegistrar implements ComponentRegistrar {
   @Override
   public List<Component<?>> getComponents() {

--- a/packages/firebase_dynamic_links/android/src/main/java/io/flutter/plugins/firebasedynamiclinks/FlutterFirebaseAppRegistrar.java
+++ b/packages/firebase_dynamic_links/android/src/main/java/io/flutter/plugins/firebasedynamiclinks/FlutterFirebaseAppRegistrar.java
@@ -5,7 +5,6 @@
 package io.flutter.plugins.firebasedynamiclinks;
 
 import androidx.annotation.Keep;
-
 import com.google.firebase.components.Component;
 import com.google.firebase.components.ComponentRegistrar;
 import com.google.firebase.platforminfo.LibraryVersionComponent;

--- a/packages/firebase_messaging/android/src/main/java/io/flutter/plugins/firebasemessaging/FlutterFirebaseAppRegistrar.java
+++ b/packages/firebase_messaging/android/src/main/java/io/flutter/plugins/firebasemessaging/FlutterFirebaseAppRegistrar.java
@@ -5,7 +5,6 @@
 package io.flutter.plugins.firebasemessaging;
 
 import androidx.annotation.Keep;
-
 import com.google.firebase.components.Component;
 import com.google.firebase.components.ComponentRegistrar;
 import com.google.firebase.platforminfo.LibraryVersionComponent;

--- a/packages/firebase_messaging/android/src/main/java/io/flutter/plugins/firebasemessaging/FlutterFirebaseAppRegistrar.java
+++ b/packages/firebase_messaging/android/src/main/java/io/flutter/plugins/firebasemessaging/FlutterFirebaseAppRegistrar.java
@@ -4,12 +4,15 @@
 
 package io.flutter.plugins.firebasemessaging;
 
+import androidx.annotation.Keep;
+
 import com.google.firebase.components.Component;
 import com.google.firebase.components.ComponentRegistrar;
 import com.google.firebase.platforminfo.LibraryVersionComponent;
 import java.util.Collections;
 import java.util.List;
 
+@Keep
 public class FlutterFirebaseAppRegistrar implements ComponentRegistrar {
   @Override
   public List<Component<?>> getComponents() {

--- a/packages/firebase_ml_vision/android/src/main/java/io/flutter/plugins/firebasemlvision/FlutterFirebaseAppRegistrar.java
+++ b/packages/firebase_ml_vision/android/src/main/java/io/flutter/plugins/firebasemlvision/FlutterFirebaseAppRegistrar.java
@@ -5,7 +5,6 @@
 package io.flutter.plugins.firebasemlvision;
 
 import androidx.annotation.Keep;
-
 import com.google.firebase.components.Component;
 import com.google.firebase.components.ComponentRegistrar;
 import com.google.firebase.platforminfo.LibraryVersionComponent;

--- a/packages/firebase_ml_vision/android/src/main/java/io/flutter/plugins/firebasemlvision/FlutterFirebaseAppRegistrar.java
+++ b/packages/firebase_ml_vision/android/src/main/java/io/flutter/plugins/firebasemlvision/FlutterFirebaseAppRegistrar.java
@@ -4,12 +4,15 @@
 
 package io.flutter.plugins.firebasemlvision;
 
+import androidx.annotation.Keep;
+
 import com.google.firebase.components.Component;
 import com.google.firebase.components.ComponentRegistrar;
 import com.google.firebase.platforminfo.LibraryVersionComponent;
 import java.util.Collections;
 import java.util.List;
 
+@Keep
 public class FlutterFirebaseAppRegistrar implements ComponentRegistrar {
   @Override
   public List<Component<?>> getComponents() {

--- a/packages/firebase_performance/android/build.gradle
+++ b/packages/firebase_performance/android/build.gradle
@@ -34,6 +34,7 @@ android {
     dependencies {
         api 'com.google.firebase:firebase-perf:17.0.0'
         implementation 'com.google.firebase:firebase-common:16.1.0'
+        implementation 'androidx.annotation:annotation:1.1.0'
     }
 }
 

--- a/packages/firebase_performance/android/src/main/java/io/flutter/plugins/firebaseperformance/FlutterFirebaseAppRegistrar.java
+++ b/packages/firebase_performance/android/src/main/java/io/flutter/plugins/firebaseperformance/FlutterFirebaseAppRegistrar.java
@@ -4,12 +4,15 @@
 
 package io.flutter.plugins.firebaseperformance;
 
+import androidx.annotation.Keep;
+
 import com.google.firebase.components.Component;
 import com.google.firebase.components.ComponentRegistrar;
 import com.google.firebase.platforminfo.LibraryVersionComponent;
 import java.util.Collections;
 import java.util.List;
 
+@Keep
 public class FlutterFirebaseAppRegistrar implements ComponentRegistrar {
   @Override
   public List<Component<?>> getComponents() {

--- a/packages/firebase_performance/android/src/main/java/io/flutter/plugins/firebaseperformance/FlutterFirebaseAppRegistrar.java
+++ b/packages/firebase_performance/android/src/main/java/io/flutter/plugins/firebaseperformance/FlutterFirebaseAppRegistrar.java
@@ -5,7 +5,6 @@
 package io.flutter.plugins.firebaseperformance;
 
 import androidx.annotation.Keep;
-
 import com.google.firebase.components.Component;
 import com.google.firebase.components.ComponentRegistrar;
 import com.google.firebase.platforminfo.LibraryVersionComponent;

--- a/packages/firebase_remote_config/android/src/main/java/io/flutter/plugins/firebase/firebaseremoteconfig/FlutterFirebaseAppRegistrar.java
+++ b/packages/firebase_remote_config/android/src/main/java/io/flutter/plugins/firebase/firebaseremoteconfig/FlutterFirebaseAppRegistrar.java
@@ -4,12 +4,15 @@
 
 package io.flutter.plugins.firebase.firebaseremoteconfig;
 
+import androidx.annotation.Keep;
+
 import com.google.firebase.components.Component;
 import com.google.firebase.components.ComponentRegistrar;
 import com.google.firebase.platforminfo.LibraryVersionComponent;
 import java.util.Collections;
 import java.util.List;
 
+@Keep
 public class FlutterFirebaseAppRegistrar implements ComponentRegistrar {
   @Override
   public List<Component<?>> getComponents() {

--- a/packages/firebase_remote_config/android/src/main/java/io/flutter/plugins/firebase/firebaseremoteconfig/FlutterFirebaseAppRegistrar.java
+++ b/packages/firebase_remote_config/android/src/main/java/io/flutter/plugins/firebase/firebaseremoteconfig/FlutterFirebaseAppRegistrar.java
@@ -5,7 +5,6 @@
 package io.flutter.plugins.firebase.firebaseremoteconfig;
 
 import androidx.annotation.Keep;
-
 import com.google.firebase.components.Component;
 import com.google.firebase.components.ComponentRegistrar;
 import com.google.firebase.platforminfo.LibraryVersionComponent;

--- a/packages/firebase_storage/android/src/main/java/io/flutter/plugins/firebase/storage/FlutterFirebaseAppRegistrar.java
+++ b/packages/firebase_storage/android/src/main/java/io/flutter/plugins/firebase/storage/FlutterFirebaseAppRegistrar.java
@@ -5,7 +5,6 @@
 package io.flutter.plugins.firebase.storage;
 
 import androidx.annotation.Keep;
-
 import com.google.firebase.components.Component;
 import com.google.firebase.components.ComponentRegistrar;
 import com.google.firebase.platforminfo.LibraryVersionComponent;

--- a/packages/firebase_storage/android/src/main/java/io/flutter/plugins/firebase/storage/FlutterFirebaseAppRegistrar.java
+++ b/packages/firebase_storage/android/src/main/java/io/flutter/plugins/firebase/storage/FlutterFirebaseAppRegistrar.java
@@ -4,12 +4,15 @@
 
 package io.flutter.plugins.firebase.storage;
 
+import androidx.annotation.Keep;
+
 import com.google.firebase.components.Component;
 import com.google.firebase.components.ComponentRegistrar;
 import com.google.firebase.platforminfo.LibraryVersionComponent;
 import java.util.Collections;
 import java.util.List;
 
+@Keep
 public class FlutterFirebaseAppRegistrar implements ComponentRegistrar {
   @Override
   public List<Component<?>> getComponents() {

--- a/script/incremental_build.sh
+++ b/script/incremental_build.sh
@@ -45,7 +45,8 @@ if [[ "${BRANCH_NAME}" == "master" ]]; then
   (cd "$REPO_DIR" && pub global run flutter_plugin_tools "${ACTIONS[@]}" $PLUGIN_SHARDING)
 else
   # Sets CHANGED_PACKAGES
-  check_changed_packages
+  # check_changed_packages
+  CHANGED_PACKAGES="firebase_storage"
 
   if [[ "$CHANGED_PACKAGES" == "" ]]; then
     echo "No changes detected in packages."

--- a/script/incremental_build.sh
+++ b/script/incremental_build.sh
@@ -45,8 +45,7 @@ if [[ "${BRANCH_NAME}" == "master" ]]; then
   (cd "$REPO_DIR" && pub global run flutter_plugin_tools "${ACTIONS[@]}" $PLUGIN_SHARDING)
 else
   # Sets CHANGED_PACKAGES
-  # check_changed_packages
-  CHANGED_PACKAGES="firebase_storage"
+  check_changed_packages
 
   if [[ "$CHANGED_PACKAGES" == "" ]]; then
     echo "No changes detected in packages."


### PR DESCRIPTION
fixes: #1337

When using proguard the registrar classes are removed from FlutterFire plugins. This change adds the keep annotation to the registrar classes.