### PR TITLE
Remove @visibleForTesting from FirebaseApp constructor

### DIFF
--- a/packages/firebase_core/lib/src/firebase_app.dart
+++ b/packages/firebase_core/lib/src/firebase_app.dart
@@ -5,7 +5,6 @@
 part of firebase_core;
 
 class FirebaseApp {
-  @visibleForTesting
   const FirebaseApp({@required this.name}) : assert(name != null);
 
   /// The name of this app.

--- a/packages/firebase_core/lib/src/firebase_app.dart
+++ b/packages/firebase_core/lib/src/firebase_app.dart
@@ -6,7 +6,6 @@ part of firebase_core;
 
 class FirebaseApp {
   // TODO(jackson): We could assert here that an app with this name was configured previously.
-  //                appNamed.
   FirebaseApp({@required this.name}) : assert(name != null);
 
   /// The name of this app.

--- a/packages/firebase_core/lib/src/firebase_app.dart
+++ b/packages/firebase_core/lib/src/firebase_app.dart
@@ -5,7 +5,7 @@
 part of firebase_core;
 
 class FirebaseApp {
-  // TODO(kroikie): Track and assert configured apps and those retrieved via
+  // TODO(jackson): We could assert here that an app with this name was configured previously.
   //                appNamed.
   FirebaseApp({@required this.name}) : assert(name != null);
 

--- a/packages/firebase_core/lib/src/firebase_app.dart
+++ b/packages/firebase_core/lib/src/firebase_app.dart
@@ -5,7 +5,9 @@
 part of firebase_core;
 
 class FirebaseApp {
-  const FirebaseApp({@required this.name}) : assert(name != null);
+  // TODO(kroikie): Track and assert configured apps and those retrieved via
+  //                appNamed.
+  FirebaseApp({@required this.name}) : assert(name != null);
 
   /// The name of this app.
   final String name;

--- a/packages/firebase_core/test/firebase_core_test.dart
+++ b/packages/firebase_core/test/firebase_core_test.dart
@@ -11,7 +11,7 @@ void main() {
 
   group('$FirebaseApp', () {
     final List<MethodCall> log = <MethodCall>[];
-    const FirebaseApp testApp = FirebaseApp(
+    final FirebaseApp testApp = FirebaseApp(
       name: 'testApp',
     );
     const FirebaseOptions testOptions = FirebaseOptions(


### PR DESCRIPTION
## Description

Remove @visibleForTesting annotation from FirebaseApp constructor. This will resolve CI issues while a new FirebaseApp creation strategy is WIP.
