### PR TITLE
[CI] Use available simulator for CI

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -80,7 +80,7 @@ task:
   activate_script: pub global activate flutter_plugin_tools
   create_simulator_script:
     - xcrun simctl list
-    - xcrun simctl create Flutter-iPhone com.apple.CoreSimulator.SimDeviceType.iPhone-X com.apple.CoreSimulator.SimRuntime.iOS-12-2 | xargs xcrun simctl boot
+    - xcrun simctl create Flutter-iPhone com.apple.CoreSimulator.SimDeviceType.iPhone-X com.apple.CoreSimulator.SimRuntime.iOS-13-2 | xargs xcrun simctl boot
   matrix:
     - name: build-ipas+drive-examples
       env:


### PR DESCRIPTION
## Description

Current iOS simulator is not available in CI. This PR updates the selected simulator to one that is available in CI.