### PR TITLE
Remove deprecated firebase-core dependency

### DIFF
--- a/packages/firebase_core/CHANGELOG.md
+++ b/packages/firebase_core/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.4.1+5
+
+* Remove deprecated [firebase-core](https://firebase.google.com/support/release-notes/android) dependency.
+
 ## 0.4.1+4
 
 * Remove visibleForTesting annotation from FirebaseApp constructor. 

--- a/packages/firebase_core/android/build.gradle
+++ b/packages/firebase_core/android/build.gradle
@@ -32,8 +32,7 @@ android {
         disable 'InvalidPackage'
     }
     dependencies {
-        api 'com.google.firebase:firebase-core:16.0.9'
-        implementation 'com.google.firebase:firebase-common:16.1.0'
+        implementation 'com.google.firebase:firebase-common:19.2.0'
     }
 }
 

--- a/packages/firebase_core/android/build.gradle
+++ b/packages/firebase_core/android/build.gradle
@@ -32,7 +32,7 @@ android {
         disable 'InvalidPackage'
     }
     dependencies {
-        implementation 'com.google.firebase:firebase-common:19.2.0'
+        implementation 'com.google.firebase:firebase-common:16.1.0'
     }
 }
 
@@ -54,9 +54,9 @@ afterEvaluate {
         android {
             dependencies {
                 def lifecycle_version = "1.1.1"
-                compileOnly "android.arch.lifecycle:runtime:$lifecycle_version"
-                compileOnly "android.arch.lifecycle:common:$lifecycle_version"
-                compileOnly "android.arch.lifecycle:common-java8:$lifecycle_version"
+                implementation "android.arch.lifecycle:runtime:$lifecycle_version"
+                implementation "android.arch.lifecycle:common:$lifecycle_version"
+                implementation "android.arch.lifecycle:common-java8:$lifecycle_version"
             }
         }
     }

--- a/packages/firebase_core/pubspec.yaml
+++ b/packages/firebase_core/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for Firebase Core, enabling connecting to multiple
   Firebase apps.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/firebase_core
-version: 0.4.1+4
+version: 0.4.1+5
 
 flutter:
   plugin:


### PR DESCRIPTION
## Description

- Remove [deprecated firebase-core](https://firebase.google.com/support/release-notes/android) dependency.
- Update firebase-common dependency.


This PR resolves a CI build failure where android dependencies are not being resolved between core and other plugins.

[Eg](https://cirrus-ci.com/task/5018600573763584?command=main#L205)
```
* What went wrong:
Could not resolve all files for configuration ':firebase_core:releaseCompileClasspath'.
> Could not resolve android.arch.lifecycle:runtime:1.1.1.
```