### PR TITLE
[CI] update xcode to v11

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -68,7 +68,7 @@ task:
 task:
   use_compute_credits: $CIRRUS_USER_COLLABORATOR == 'true'
   osx_instance:
-    image: mojave-xcode-10.2-flutter
+    image: mojave-xcode-11.2.1-flutter
   setup_script:
     - pod repo update
   upgrade_script:


### PR DESCRIPTION
## Description

Update CI version of XCode to allow use of iOS 13, and resolve [CI build failures](https://cirrus-ci.com/task/4616326890389504).
