### PR TITLE
[CI] Fix perf tests

### DIFF
--- a/packages/firebase_performance/example/test_driver/firebase_performance.dart
+++ b/packages/firebase_performance/example/test_driver/firebase_performance.dart
@@ -65,12 +65,12 @@ void main() {
         await testTrace.start();
 
         print('incrementing 14');
-        testTrace.incrementMetric('metric', 14);
+        await testTrace.incrementMetric('metric', 14);
         print('expecting 14');
         expect(testTrace.getMetric('metric'), completion(14));
 
         print('incrementing 45');
-        testTrace.incrementMetric('metric', 45);
+        await testTrace.incrementMetric('metric', 45);
         print('expecting 59');
         expect(testTrace.getMetric('metric'), completion(59));
       });

--- a/packages/firebase_performance/example/test_driver/firebase_performance.dart
+++ b/packages/firebase_performance/example/test_driver/firebase_performance.dart
@@ -61,11 +61,11 @@ void main() {
         testTrace = null;
       });
 
-      test('incrementMetric', () {
-        testTrace.start();
+      test('incrementMetric', () async {
+        await testTrace.start();
 
         testTrace.incrementMetric('metric', 14);
-        expectLater(testTrace.getMetric('metric'), completion(14));
+        expect(testTrace.getMetric('metric'), completion(14));
 
         testTrace.incrementMetric('metric', 45);
         expect(testTrace.getMetric('metric'), completion(59));

--- a/packages/firebase_performance/example/test_driver/firebase_performance.dart
+++ b/packages/firebase_performance/example/test_driver/firebase_performance.dart
@@ -65,10 +65,10 @@ void main() {
         await testTrace.start();
 
         testTrace.incrementMetric('metric', 14);
-        expect(testTrace.getMetric('metric'), completion(14));
+        expectLater(testTrace.getMetric('metric'), completion(14));
 
         testTrace.incrementMetric('metric', 45);
-        expect(testTrace.getMetric('metric'), completion(59));
+        expectLater(testTrace.getMetric('metric'), completion(59));
       });
 
       test('setMetric', () {

--- a/packages/firebase_performance/example/test_driver/firebase_performance.dart
+++ b/packages/firebase_performance/example/test_driver/firebase_performance.dart
@@ -64,11 +64,15 @@ void main() {
       test('incrementMetric', () async {
         await testTrace.start();
 
+        print('incrementing 14');
         testTrace.incrementMetric('metric', 14);
-        expectLater(testTrace.getMetric('metric'), completion(14));
+        print('expecting 14');
+        expect(testTrace.getMetric('metric'), completion(14));
 
+        print('incrementing 45');
         testTrace.incrementMetric('metric', 45);
-        expectLater(testTrace.getMetric('metric'), completion(59));
+        print('expecting 59');
+        expect(testTrace.getMetric('metric'), completion(59));
       });
 
       test('setMetric', () {

--- a/packages/firebase_performance/ios/Classes/FLTTrace.m
+++ b/packages/firebase_performance/ios/Classes/FLTTrace.m
@@ -29,6 +29,7 @@
     NSLog(@"incrementing on the native side");
     [self incrementMetric:call result:result];
   } else if ([@"Trace#getMetric" isEqualToString:call.method]) {
+    NSLog(@"getting metric on the native side");
     [self getMetric:call result:result];
   } else if ([@"PerformanceAttributes#putAttribute" isEqualToString:call.method]) {
     [self putAttribute:call result:result];
@@ -67,6 +68,7 @@
   NSString *name = call.arguments[@"name"];
   NSNumber *value = call.arguments[@"value"];
 
+  NSLog(@"incrementing on native side with name: %@ and value: %@", name, [value stringValue]);
   [_trace incrementMetric:name byInt:value.longValue];
   result(nil);
 }
@@ -75,6 +77,8 @@
   NSString *name = call.arguments[@"name"];
 
   int64_t metric = [_trace valueForIntMetric:name];
+
+  NSLog(@"getting metric native side with name: %@ and value: %d", name, metric);
   result(@(metric));
 }
 

--- a/packages/firebase_performance/ios/Classes/FLTTrace.m
+++ b/packages/firebase_performance/ios/Classes/FLTTrace.m
@@ -26,6 +26,7 @@
   } else if ([@"Trace#setMetric" isEqualToString:call.method]) {
     [self setMetric:call result:result];
   } else if ([@"Trace#incrementMetric" isEqualToString:call.method]) {
+    NSLog(@"incrementing on the native side");
     [self incrementMetric:call result:result];
   } else if ([@"Trace#getMetric" isEqualToString:call.method]) {
     [self getMetric:call result:result];


### PR DESCRIPTION
## Description

Perf tests are failing, this may be due to metrics being retrieved before the starting of the trace is complete.

This PR adds an await to the start of the trace so subsequent metric calls will be done after the trace is completely started.
