### PR TITLE
[firebase_auth] Added missing Exception to the reauthenticateWithCredential docs (#1448)

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -42,3 +42,4 @@ Debkanchan Samadder <debu.samadder@gmail.com>
 Audrius Karosevicius <audrius.karosevicius@gmail.com>
 Lukasz Piliszczuk <lukasz@intheloup.io>
 SoundReply Solutions GmbH <ch@soundreply.com>
+Michel Feinstein <michel@feinstein.com.br>

--- a/packages/firebase_auth/CHANGELOG.md
+++ b/packages/firebase_auth/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.14.0+11
+
+*  Added missing ERROR_WRONG_PASSWORD Exception to the `reauthenticateWithCredential` docs.
+
 ## 0.14.0+10
 
 * Formatted lists in member documentations for better readability.

--- a/packages/firebase_auth/lib/src/firebase_user.dart
+++ b/packages/firebase_auth/lib/src/firebase_user.dart
@@ -201,6 +201,7 @@ class FirebaseUser extends UserInfo {
   /// Errors:
   ///
   ///  * `ERROR_INVALID_CREDENTIAL` - If the [authToken] or [authTokenSecret] is malformed or has expired.
+  ///  * `ERROR_WRONG_PASSWORD` - If the password is invalid or the user does not have a password.
   ///  * `ERROR_USER_DISABLED` - If the user has been disabled (for example, in the Firebase console)
   ///  * `ERROR_USER_NOT_FOUND` - If the user has been deleted (for example, in the Firebase console)
   ///  * `ERROR_OPERATION_NOT_ALLOWED` - Indicates that Email & Password accounts are not enabled.

--- a/packages/firebase_auth/pubspec.yaml
+++ b/packages/firebase_auth/pubspec.yaml
@@ -4,7 +4,7 @@ description: Flutter plugin for Firebase Auth, enabling Android and iOS
   like Google, Facebook and Twitter.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/firebase_auth
-version: 0.14.0+10
+version: 0.14.0+11
 
 flutter:
   plugin:


### PR DESCRIPTION
## Description

Added missing ERROR_WRONG_PASSWORD Exception to the `reauthenticateWithCredential` docs.

## Related Issues

#1448

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] If the pull request affects only one plugin, the PR title starts with the name of the plugin in brackets (e.g. [cloud_firestore])
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
