### PR TITLE
[cloud_firestore] [firebase_performance] fix analyzer warnings

### DIFF
--- a/packages/cloud_firestore/CHANGELOG.md
+++ b/packages/cloud_firestore/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.12.10+2
+
+* Fixed analyzer warnings about unused field.
+
 ## 0.12.10+1
 
 * Formatted method documentations.

--- a/packages/cloud_firestore/CHANGELOG.md
+++ b/packages/cloud_firestore/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 0.12.10+2
 
-* Fixed analyzer warnings about unused field.
+* Fixed analyzer warnings about unused fields.
 
 ## 0.12.10+1
 

--- a/packages/cloud_firestore/lib/src/document_change.dart
+++ b/packages/cloud_firestore/lib/src/document_change.dart
@@ -23,7 +23,7 @@ enum DocumentChangeType {
 /// It contains the document affected and the type of change that occurred
 /// (added, modified, or removed).
 class DocumentChange {
-  DocumentChange._(Map<dynamic, dynamic> data, this._firestore)
+  DocumentChange._(Map<dynamic, dynamic> data, Firestore firestore)
       : oldIndex = data['oldIndex'],
         newIndex = data['newIndex'],
         document = DocumentSnapshot._(
@@ -31,13 +31,11 @@ class DocumentChange {
           _asStringKeyedMap(data['document']),
           SnapshotMetadata._(data["metadata"]["hasPendingWrites"],
               data["metadata"]["isFromCache"]),
-          _firestore,
+          firestore,
         ),
         type = DocumentChangeType.values.firstWhere((DocumentChangeType type) {
           return type.toString() == data['type'];
         });
-
-  final Firestore _firestore;
 
   /// The type of change that occurred (added, modified, or removed).
   final DocumentChangeType type;

--- a/packages/cloud_firestore/lib/src/query_snapshot.dart
+++ b/packages/cloud_firestore/lib/src/query_snapshot.dart
@@ -6,7 +6,7 @@ part of cloud_firestore;
 
 /// A QuerySnapshot contains zero or more DocumentSnapshot objects.
 class QuerySnapshot {
-  QuerySnapshot._(Map<dynamic, dynamic> data, this._firestore)
+  QuerySnapshot._(Map<dynamic, dynamic> data, Firestore firestore)
       : documents = List<DocumentSnapshot>.generate(data['documents'].length,
             (int index) {
           return DocumentSnapshot._(
@@ -16,14 +16,14 @@ class QuerySnapshot {
               data['metadatas'][index]['hasPendingWrites'],
               data['metadatas'][index]['isFromCache'],
             ),
-            _firestore,
+            firestore,
           );
         }),
         documentChanges = List<DocumentChange>.generate(
             data['documentChanges'].length, (int index) {
           return DocumentChange._(
             data['documentChanges'][index],
-            _firestore,
+            firestore,
           );
         }),
         metadata = SnapshotMetadata._(
@@ -39,6 +39,4 @@ class QuerySnapshot {
   final List<DocumentChange> documentChanges;
 
   final SnapshotMetadata metadata;
-
-  final Firestore _firestore;
 }

--- a/packages/cloud_firestore/pubspec.yaml
+++ b/packages/cloud_firestore/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for Cloud Firestore, a cloud-hosted, noSQL database 
   live synchronization and offline support on Android and iOS.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/cloud_firestore
-version: 0.12.10+1
+version: 0.12.10+2
 
 flutter:
   plugin:

--- a/packages/firebase_performance/CHANGELOG.md
+++ b/packages/firebase_performance/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.1+3
+
+* Fix analyzer warnings
+
 ## 0.3.1+2
 
 * Updated README instructions for contributing for consistency with other Flutterfire plugins.

--- a/packages/firebase_performance/CHANGELOG.md
+++ b/packages/firebase_performance/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 0.3.1+3
 
-* Fix analyzer warnings
+* Fixed analyzer warnings about unused fields.
 
 ## 0.3.1+2
 

--- a/packages/firebase_performance/lib/src/http_metric.dart
+++ b/packages/firebase_performance/lib/src/http_metric.dart
@@ -25,9 +25,6 @@ class HttpMetric extends PerformanceAttributes {
   final HttpMethod httpMethod;
 
   @override
-  bool _hasStarted = false;
-
-  @override
   bool _hasStopped = false;
 
   int _httpResponseCode;

--- a/packages/firebase_performance/lib/src/http_metric.dart
+++ b/packages/firebase_performance/lib/src/http_metric.dart
@@ -124,7 +124,6 @@ class HttpMetric extends PerformanceAttributes {
   Future<void> start() {
     if (_hasStopped) return Future<void>.value(null);
 
-    _hasStarted = true;
     return FirebasePerformance.channel.invokeMethod<void>(
       'HttpMetric#start',
       <String, dynamic>{'handle': _handle},

--- a/packages/firebase_performance/lib/src/performance_attributes.dart
+++ b/packages/firebase_performance/lib/src/performance_attributes.dart
@@ -17,7 +17,6 @@ abstract class PerformanceAttributes {
 
   final Map<String, String> _attributes = <String, String>{};
 
-  bool get _hasStarted;
   bool get _hasStopped;
 
   int get _handle;

--- a/packages/firebase_performance/lib/src/trace.dart
+++ b/packages/firebase_performance/lib/src/trace.dart
@@ -29,6 +29,8 @@ class Trace extends PerformanceAttributes {
 
   final Map<String, int> _metrics = <String, int>{};
 
+  bool _hasStarted = false;
+
   @override
   bool _hasStopped = false;
 

--- a/packages/firebase_performance/lib/src/trace.dart
+++ b/packages/firebase_performance/lib/src/trace.dart
@@ -30,9 +30,6 @@ class Trace extends PerformanceAttributes {
   final Map<String, int> _metrics = <String, int>{};
 
   @override
-  bool _hasStarted = false;
-
-  @override
   bool _hasStopped = false;
 
   @override

--- a/packages/firebase_performance/pubspec.yaml
+++ b/packages/firebase_performance/pubspec.yaml
@@ -4,7 +4,7 @@ description: Flutter plugin for Google Performance Monitoring for Firebase, an a
   iOS.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/firebase_performance
-version: 0.3.1+2
+version: 0.3.1+3
 
 dependencies:
   flutter:


### PR DESCRIPTION
Analyzer is complaining about fields that are unused. We can safely remove them.