### PR TITLE
[cloud_firestore] Fix test that used FirebaseApp.channel

### DIFF
--- a/packages/cloud_firestore/CHANGELOG.md
+++ b/packages/cloud_firestore/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.12.10+3
+
+* Fixed test that used `FirebaseApp.channel`.
+
 ## 0.12.10+2
 
 * Fixed analyzer warnings about unused fields.

--- a/packages/cloud_firestore/pubspec.yaml
+++ b/packages/cloud_firestore/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for Cloud Firestore, a cloud-hosted, noSQL database 
   live synchronization and offline support on Android and iOS.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/cloud_firestore
-version: 0.12.10+2
+version: 0.12.10+3
 
 flutter:
   plugin:

--- a/packages/cloud_firestore/test/cloud_firestore_test.dart
+++ b/packages/cloud_firestore/test/cloud_firestore_test.dart
@@ -28,10 +28,12 @@ void main() {
       "hasPendingWrites": false,
       "isFromCache": false,
     };
+    const MethodChannel firebaseCoreChannel = MethodChannel('plugins.flutter.io/firebase_core');
+
     setUp(() async {
       mockHandleId = 0;
       // Required for FirebaseApp.configure
-      FirebaseApp.channel.setMockMethodCallHandler(
+      firebaseCoreChannel.setMockMethodCallHandler(
         (MethodCall methodCall) async {},
       );
       app = await FirebaseApp.configure(

--- a/packages/cloud_firestore/test/cloud_firestore_test.dart
+++ b/packages/cloud_firestore/test/cloud_firestore_test.dart
@@ -28,7 +28,8 @@ void main() {
       "hasPendingWrites": false,
       "isFromCache": false,
     };
-    const MethodChannel firebaseCoreChannel = MethodChannel('plugins.flutter.io/firebase_core');
+    const MethodChannel firebaseCoreChannel =
+        MethodChannel('plugins.flutter.io/firebase_core');
 
     setUp(() async {
       mockHandleId = 0;


### PR DESCRIPTION
## Description

This fixes a test in `cloud_firestore` that set a mock handler on `FirebaseApp.channel`, which has been deleted.

## Related Issues

Fixes https://github.com/FirebaseExtended/flutterfire/issues/1475

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] If the pull request affects only one plugin, the PR title starts with the name of the plugin in brackets (e.g. [cloud_firestore])
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
