### PR TITLE
[firebase_messaging] Fix negated @available method on iOS

### DIFF
--- a/packages/firebase_messaging/CHANGELOG.md
+++ b/packages/firebase_messaging/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 6.0.2
+
+* Fix negated `available` fn in iOS implementation.
+
 ## 6.0.1
 
 * `FirebaseMessaging.configure` will throw an `ArgumentError` when `onBackgroundMessage` parameter

--- a/packages/firebase_messaging/ios/Classes/FirebaseMessagingPlugin.m
+++ b/packages/firebase_messaging/ios/Classes/FirebaseMessagingPlugin.m
@@ -84,7 +84,8 @@ static NSObject<FlutterPluginRegistrar> *_registrar;
                             result([NSNumber numberWithBool:granted]);
                           }
                         }];
-    } else {
+      [[UIApplication sharedApplication] registerForRemoteNotifications];
+    } else { // If iOS version is less than 10
       UIUserNotificationType notificationTypes = 0;
       if ([arguments[@"sound"] boolValue]) {
         notificationTypes |= UIUserNotificationTypeSound;
@@ -99,11 +100,7 @@ static NSObject<FlutterPluginRegistrar> *_registrar;
       UIUserNotificationSettings *settings =
           [UIUserNotificationSettings settingsForTypes:notificationTypes categories:nil];
       [[UIApplication sharedApplication] registerUserNotificationSettings:settings];
-    }
-
-    [[UIApplication sharedApplication] registerForRemoteNotifications];
-
-    if (!@available(iOS 10.0, *)) {
+      [[UIApplication sharedApplication] registerForRemoteNotifications];
       result([NSNumber numberWithBool:YES]);
     }
   } else if ([@"configure" isEqualToString:method]) {

--- a/packages/firebase_messaging/ios/Classes/FirebaseMessagingPlugin.m
+++ b/packages/firebase_messaging/ios/Classes/FirebaseMessagingPlugin.m
@@ -85,7 +85,7 @@ static NSObject<FlutterPluginRegistrar> *_registrar;
                           }
                         }];
       [[UIApplication sharedApplication] registerForRemoteNotifications];
-    } else { // If iOS version is less than 10
+    } else {  // If iOS version is less than 10
       UIUserNotificationType notificationTypes = 0;
       if ([arguments[@"sound"] boolValue]) {
         notificationTypes |= UIUserNotificationTypeSound;

--- a/packages/firebase_messaging/pubspec.yaml
+++ b/packages/firebase_messaging/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for Firebase Cloud Messaging, a cross-platform
   messaging solution that lets you reliably deliver messages on Android and iOS.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/firebase_messaging
-version: 6.0.1
+version: 6.0.2
 
 flutter:
   plugin:


### PR DESCRIPTION
This is a minor fix and cleanup so that when we stop supporting iOS < 10, we can remove the code easier.