### PR TITLE
[firebase_core] Switch away from quiver_hashcode

### DIFF
--- a/packages/firebase_core/firebase_core_platform_interface/CHANGELOG.md
+++ b/packages/firebase_core/firebase_core_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.1
+
+- Switch away from quiver_hashcode.
+
 ## 1.0.0
 
 - Initial open-source release.

--- a/packages/firebase_core/firebase_core_platform_interface/lib/src/firebase_options.dart
+++ b/packages/firebase_core/firebase_core_platform_interface/lib/src/firebase_options.dart
@@ -3,7 +3,7 @@
 // found in the LICENSE file.
 
 import 'package:meta/meta.dart' show required;
-import 'package:quiver_hashcode/hashcode.dart';
+import 'package:quiver/core.dart';
 
 /// The options used to configure a Firebase app.
 class FirebaseOptions {

--- a/packages/firebase_core/firebase_core_platform_interface/lib/src/platform_firebase_app.dart
+++ b/packages/firebase_core/firebase_core_platform_interface/lib/src/platform_firebase_app.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-import 'package:quiver_hashcode/hashcode.dart';
+import 'package:quiver/core.dart';
 
 import 'firebase_options.dart';
 

--- a/packages/firebase_core/firebase_core_platform_interface/pubspec.yaml
+++ b/packages/firebase_core/firebase_core_platform_interface/pubspec.yaml
@@ -10,7 +10,7 @@ dependencies:
   flutter:
     sdk: flutter
   meta: ^1.0.5
-  quiver_hashcode: ^2.0.0
+  quiver: ">=2.0.0 <3.0.0"
 
 dev_dependencies:
   flutter_test:

--- a/packages/firebase_core/firebase_core_platform_interface/pubspec.yaml
+++ b/packages/firebase_core/firebase_core_platform_interface/pubspec.yaml
@@ -4,7 +4,7 @@ author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/firebase_core/firebase_core_platform_interface
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 1.0.0
+version: 1.0.1
 
 dependencies:
   flutter:


### PR DESCRIPTION
This is not a breaking change. Just use a better supported library.