### PR TITLE
[firebase_messaging] Fix availability check on ios

### DIFF
--- a/packages/firebase_messaging/CHANGELOG.md
+++ b/packages/firebase_messaging/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 6.0.1
 
+* Fix the availability check when using ios < 10.
+
+## 6.0.1
+
 * `FirebaseMessaging.configure` will throw an `ArgumentError` when `onBackgroundMessage` parameter
 is not a top-level or static function.
 

--- a/packages/firebase_messaging/CHANGELOG.md
+++ b/packages/firebase_messaging/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 6.0.2
 
-* Fix the availability check when using ios < 10.
+* Fixed a build warning caused by availability check.
 
 ## 6.0.1
 

--- a/packages/firebase_messaging/CHANGELOG.md
+++ b/packages/firebase_messaging/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 6.0.1
+## 6.0.2
 
 * Fix the availability check when using ios < 10.
 

--- a/packages/firebase_messaging/ios/Classes/FirebaseMessagingPlugin.m
+++ b/packages/firebase_messaging/ios/Classes/FirebaseMessagingPlugin.m
@@ -84,6 +84,8 @@ static NSObject<FlutterPluginRegistrar> *_registrar;
                             result([NSNumber numberWithBool:granted]);
                           }
                         }];
+
+      [[UIApplication sharedApplication] registerForRemoteNotifications];
     } else {
       UIUserNotificationType notificationTypes = 0;
       if ([arguments[@"sound"] boolValue]) {
@@ -99,11 +101,8 @@ static NSObject<FlutterPluginRegistrar> *_registrar;
       UIUserNotificationSettings *settings =
           [UIUserNotificationSettings settingsForTypes:notificationTypes categories:nil];
       [[UIApplication sharedApplication] registerUserNotificationSettings:settings];
-    }
 
-    [[UIApplication sharedApplication] registerForRemoteNotifications];
-
-    if (!@available(iOS 10.0, *)) {
+      [[UIApplication sharedApplication] registerForRemoteNotifications];
       result([NSNumber numberWithBool:YES]);
     }
   } else if ([@"configure" isEqualToString:method]) {

--- a/packages/firebase_messaging/pubspec.yaml
+++ b/packages/firebase_messaging/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for Firebase Cloud Messaging, a cross-platform
   messaging solution that lets you reliably deliver messages on Android and iOS.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/firebase_messaging
-version: 6.0.1
+version: 6.0.2
 
 flutter:
   plugin:


### PR DESCRIPTION
## Description

The line 
```objc
if (!@available(iOS 10.0, *)) {
```
causes this warning: `@available does not guard availability here; use if (@available) instead`.

I'm replacing this logic to not use this line.
## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] If the pull request affects only one plugin, the PR title starts with the name of the plugin in brackets (e.g. [cloud_firestore])
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
