### PR TITLE
[firebase_crashlytics] No need for async as there's no await

### DIFF
--- a/packages/firebase_crashlytics/CHANGELOG.md
+++ b/packages/firebase_crashlytics/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.2+2
+
+* Removed the `async` from the `runZoned()` in the example, as there's no `await` to be executed.
+
 ## 0.1.2+1
 
 * Updated a confusing comment.

--- a/packages/firebase_crashlytics/example/lib/main.dart
+++ b/packages/firebase_crashlytics/example/lib/main.dart
@@ -17,7 +17,7 @@ void main() {
   // Pass all uncaught errors to Crashlytics.
   FlutterError.onError = Crashlytics.instance.recordFlutterError;
 
-  runZoned<Future<void>>(() async {
+  runZoned<Future<void>>(() {
     runApp(MyApp());
   }, onError: Crashlytics.instance.recordError);
 }

--- a/packages/firebase_crashlytics/pubspec.yaml
+++ b/packages/firebase_crashlytics/pubspec.yaml
@@ -2,7 +2,7 @@ name: firebase_crashlytics
 description:
   Flutter plugin for Firebase Crashlytics. It reports uncaught errors to the
   Firebase console.
-version: 0.1.2+1
+version: 0.1.2+2
 author: Flutter Team <flutter-dev@google.com>
 homepage: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/firebase_crashlytics
 


### PR DESCRIPTION
Removed the `async` from the `runZoned()` in the example, as there's no `await` to be executed.