### PR TITLE
[firebase_messaging] Make onIosSettingsRegistered callback on iOS >= 10

### DIFF
--- a/packages/firebase_messaging/CHANGELOG.md
+++ b/packages/firebase_messaging/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 6.0.3
+
+* Fix bug where `onIosSettingsRegistered` wasn't streamed on iOS >= 10.
+
 ## 6.0.2
 
 * Fixed a build warning caused by availability check.

--- a/packages/firebase_messaging/ios/Classes/FirebaseMessagingPlugin.m
+++ b/packages/firebase_messaging/ios/Classes/FirebaseMessagingPlugin.m
@@ -83,15 +83,23 @@ static NSObject<FlutterPluginRegistrar> *_registrar;
                             return;
                           }
                           result([NSNumber numberWithBool:granted]);
-                          // This works for iOS >= 10. See [application:didRegisterUserNotificationSettings:notificationSettings] for ios < 10.
-                          [[UNUserNotificationCenter currentNotificationCenter] getNotificationSettingsWithCompletionHandler:^(UNNotificationSettings *_Nonnull settings) {
-                            NSDictionary *settingsDictionary = @{
-                                 @"sound" : [NSNumber numberWithBool:settings.soundSetting == UNNotificationSettingEnabled],
-                                 @"badge" : [NSNumber numberWithBool:settings.badgeSetting == UNNotificationSettingEnabled],
-                                 @"alert" : [NSNumber numberWithBool:settings.alertSetting == UNNotificationSettingEnabled],
-                              };
-                            [self->_channel invokeMethod:@"onIosSettingsRegistered" arguments:settingsDictionary];
-                          }];
+                          // This works for iOS >= 10. See
+                          // [UIApplication:didRegisterUserNotificationSettings:notificationSettings]
+                          // for ios < 10.
+                          [[UNUserNotificationCenter currentNotificationCenter]
+                              getNotificationSettingsWithCompletionHandler:^(
+                                  UNNotificationSettings *_Nonnull settings) {
+                                NSDictionary *settingsDictionary = @{
+                                  @"sound" : [NSNumber numberWithBool:settings.soundSetting ==
+                                                                      UNNotificationSettingEnabled],
+                                  @"badge" : [NSNumber numberWithBool:settings.badgeSetting ==
+                                                                      UNNotificationSettingEnabled],
+                                  @"alert" : [NSNumber numberWithBool:settings.alertSetting ==
+                                                                      UNNotificationSettingEnabled],
+                                };
+                                [self->_channel invokeMethod:@"onIosSettingsRegistered"
+                                                   arguments:settingsDictionary];
+                              }];
                         }];
 
       [[UIApplication sharedApplication] registerForRemoteNotifications];
@@ -233,7 +241,8 @@ static NSObject<FlutterPluginRegistrar> *_registrar;
   [_channel invokeMethod:@"onToken" arguments:[FIRMessaging messaging].FCMToken];
 }
 
-// This will only be called for iOS < 10. For iOS >= 10, we make this call when we request permissions.
+// This will only be called for iOS < 10. For iOS >= 10, we make this call when we request
+// permissions.
 - (void)application:(UIApplication *)application
     didRegisterUserNotificationSettings:(UIUserNotificationSettings *)notificationSettings {
   NSDictionary *settingsDictionary = @{

--- a/packages/firebase_messaging/ios/Classes/FirebaseMessagingPlugin.m
+++ b/packages/firebase_messaging/ios/Classes/FirebaseMessagingPlugin.m
@@ -82,7 +82,6 @@ static NSObject<FlutterPluginRegistrar> *_registrar;
                             result(getFlutterError(error));
                             return;
                           }
-                          result([NSNumber numberWithBool:granted]);
                           // This works for iOS >= 10. See
                           // [UIApplication:didRegisterUserNotificationSettings:notificationSettings]
                           // for ios < 10.
@@ -100,6 +99,7 @@ static NSObject<FlutterPluginRegistrar> *_registrar;
                                 [self->_channel invokeMethod:@"onIosSettingsRegistered"
                                                    arguments:settingsDictionary];
                               }];
+                          result([NSNumber numberWithBool:granted]);
                         }];
 
       [[UIApplication sharedApplication] registerForRemoteNotifications];

--- a/packages/firebase_messaging/pubspec.yaml
+++ b/packages/firebase_messaging/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for Firebase Cloud Messaging, a cross-platform
   messaging solution that lets you reliably deliver messages on Android and iOS.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/firebase_messaging
-version: 6.0.2
+version: 6.0.3
 
 flutter:
   plugin:


### PR DESCRIPTION
## Description

In iOS < 10, we would have to wait for an `UIApplication` callback `[UIApplication :didRegisterUserNotificationSettings:notificationSettings]` to get which settings were authorized. 

In iOS >= 10, you should call [requestAuthorizationWithOptions:completionHandler:](https://developer.apple.com/documentation/usernotifications/unusernotificationcenter/1649527-requestauthorizationwithoptions?language=objc) to get the authorized settings.

This PR makes the callback when using iOS >= 10 so that the PR is backwards compatible (iOS 8+).

## Related Issues

Fixes https://github.com/FirebaseExtended/flutterfire/issues/1508

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] If the pull request affects only one plugin, the PR title starts with the name of the plugin in brackets (e.g. [cloud_firestore])
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
