### PR TITLE
[firebase_auth] Fix crash with null additionalUserInfo

### DIFF
--- a/packages/firebase_auth/firebase_auth_platform_interface/CHANGELOG.md
+++ b/packages/firebase_auth/firebase_auth_platform_interface/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.1.1
+
+- Fixed crash when platform returns an auth result where `additionalUserInfo`
+  is not provided.
+
 ## 1.1.0
 
 - Added type `PlatformOAuthCredential` for generic OAuth providers.

--- a/packages/firebase_auth/firebase_auth_platform_interface/lib/src/method_channel_firebase_auth.dart
+++ b/packages/firebase_auth/firebase_auth_platform_interface/lib/src/method_channel_firebase_auth.dart
@@ -446,6 +446,9 @@ PlatformAuthResult _decodeAuthResult(Map<dynamic, dynamic> data) {
 
 PlatformAdditionalUserInfo _decodeAdditionalUserInfo(
     Map<dynamic, dynamic> data) {
+  if (data == null) {
+    return null;
+  }
   return PlatformAdditionalUserInfo(
     isNewUser: data['isNewUser'],
     username: data['username'],

--- a/packages/firebase_auth/firebase_auth_platform_interface/pubspec.yaml
+++ b/packages/firebase_auth/firebase_auth_platform_interface/pubspec.yaml
@@ -1,5 +1,6 @@
 name: firebase_auth_platform_interface
 description: A common platform interface for the firebase_auth plugin.
+author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/firebase_auth/firebase_auth_platform_interface
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes

--- a/packages/firebase_auth/firebase_auth_platform_interface/pubspec.yaml
+++ b/packages/firebase_auth/firebase_auth_platform_interface/pubspec.yaml
@@ -1,10 +1,9 @@
 name: firebase_auth_platform_interface
 description: A common platform interface for the firebase_auth plugin.
-author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/firebase_auth/firebase_auth_platform_interface
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 1.1.0
+version: 1.1.1
 
 dependencies:
   flutter:

--- a/packages/firebase_auth/firebase_auth_platform_interface/test/method_channel_firebase_auth_test.dart
+++ b/packages/firebase_auth/firebase_auth_platform_interface/test/method_channel_firebase_auth_test.dart
@@ -210,7 +210,6 @@ void main() {
     });
 
     test('signInAnonymously with null additionalUserInfo', () async {
-      final PlatformAuthResult result = await auth.signInAnonymously(appName);
       MethodChannelFirebaseAuth.channel
           .setMockMethodCallHandler((MethodCall call) async {
         log.add(call);
@@ -218,7 +217,9 @@ void main() {
           'user': kMockUser,
         };
       });
+      final PlatformAuthResult result = await auth.signInAnonymously(appName);
       verifyUser(result.user);
+      expect(result.additionalUserInfo, isNull);
       expect(
         log,
         <Matcher>[

--- a/packages/firebase_auth/firebase_auth_platform_interface/test/method_channel_firebase_auth_test.dart
+++ b/packages/firebase_auth/firebase_auth_platform_interface/test/method_channel_firebase_auth_test.dart
@@ -209,6 +209,25 @@ void main() {
       );
     });
 
+    test('signInAnonymously with null additionalUserInfo', () async {
+      final PlatformAuthResult result = await auth.signInAnonymously(appName);
+      MethodChannelFirebaseAuth.channel
+          .setMockMethodCallHandler((MethodCall call) async {
+        log.add(call);
+        return <String, dynamic>{
+          'user': kMockUser,
+        };
+      });
+      verifyUser(result.user);
+      expect(
+        log,
+        <Matcher>[
+          isMethodCall('signInAnonymously',
+              arguments: <String, String>{'app': appName}),
+        ],
+      );
+    });
+
     test('sendLinkToEmail', () async {
       await auth.sendLinkToEmail(
         appName,


### PR DESCRIPTION
## Description

Fixes bug where we crashed if the platform returned an auth result with no `additionalUserInfo`.

## Related Issues

Fixes https://github.com/FirebaseExtended/flutterfire/issues/1580

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] If the pull request affects only one plugin, the PR title starts with the name of the plugin in brackets (e.g. [cloud_firestore])
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
