### PR TITLE
[cloud_messaging] Added step for Android instructions

### DIFF
--- a/packages/firebase_messaging/CHANGELOG.md
+++ b/packages/firebase_messaging/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 6.0.6
+
+* Updated README instructions for Android.
+
 ## 6.0.5
 
 * Add import for UserNotifications on iOS.

--- a/packages/firebase_messaging/README.md
+++ b/packages/firebase_messaging/README.md
@@ -61,7 +61,7 @@ for more.
 
 By default background messaging is not enabled. To handle messages in the background:
 
-1. Add an Application.java class to your app in the same directory as your `MainActivity.java`. This is typically found in `<app-name>/android/app/src/main/java/<app-organization-path>/`.
+1. Add an `Application.java` class to your app in the same directory as your `MainActivity.java`. This is typically found in `<app-name>/android/app/src/main/java/<app-organization-path>/`.
 
     ```
     package io.flutter.plugins.firebasemessagingexample;
@@ -84,6 +84,10 @@ By default background messaging is not enabled. To handle messages in the backgr
         GeneratedPluginRegistrant.registerWith(registry);
       }
     }
+    ```
+1. In `Application.java`, make sure to change `package io.flutter.plugins.firebasemessagingexample;` to your package's identifier. Your package's identifier should be something like `com.domain.myapplication`.
+    ```
+    package com.domain.myapplication;
     ```
 1. Set name property of application in `AndroidManifest.xml`. This is typically found in `<app-name>/android/app/src/main/`.
     ```

--- a/packages/firebase_messaging/pubspec.yaml
+++ b/packages/firebase_messaging/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for Firebase Cloud Messaging, a cross-platform
   messaging solution that lets you reliably deliver messages on Android and iOS.
 author: Flutter Team <flutter-dev@googlegroups.com>
 homepage: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/firebase_messaging
-version: 6.0.5
+version: 6.0.6
 
 flutter:
   plugin:


### PR DESCRIPTION
## Description
Added extra step for Android setup in Firebase Cloud Messaging readme because I had problems with my app crashing and it was because I didn't realize I had to change the package name. This commit adds this extra step to the readme.

## Related Issues

*Replace this paragraph with a list of issues related to this PR from the [issue database](https://github.com/flutter/flutter/issues). Indicate, which of these issues are resolved or fixed by this PR. Note that you'll have to prefix the issue numbers with flutter/flutter#.*

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] If the pull request affects only one plugin, the PR title starts with the name of the plugin in brackets (e.g. [cloud_firestore])
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.
