### PR TITLE
[firebase_core] Put the 'dart:io' import behind a configurable import

### DIFF
--- a/packages/firebase_core/firebase_core/CHANGELOG.md
+++ b/packages/firebase_core/firebase_core/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.4.3+1
+
+* Move `Platform.isIOS` check behind a configurable import so that pub.dev registers
+  this as a Web plugin.
+
 ## 0.4.3
 
 * Enable the `web` implementation by default.

--- a/packages/firebase_core/firebase_core/lib/firebase_core.dart
+++ b/packages/firebase_core/firebase_core/lib/firebase_core.dart
@@ -4,14 +4,7 @@
 
 library firebase_core;
 
-import 'dart:async';
-import 'dart:io' show Platform;
-
-import 'package:firebase_core_platform_interface/firebase_core_platform_interface.dart';
-import 'package:flutter/foundation.dart' show kIsWeb;
-import 'package:meta/meta.dart';
-
 export 'package:firebase_core_platform_interface/firebase_core_platform_interface.dart'
     show FirebaseOptions;
 
-part 'src/firebase_app.dart';
+export 'src/firebase_app.dart';

--- a/packages/firebase_core/firebase_core/lib/firebase_core.dart
+++ b/packages/firebase_core/firebase_core/lib/firebase_core.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-library firebase_core;
-
 export 'package:firebase_core_platform_interface/firebase_core_platform_interface.dart'
     show FirebaseOptions;
 

--- a/packages/firebase_core/firebase_core/lib/src/default_app_name.dart
+++ b/packages/firebase_core/firebase_core/lib/src/default_app_name.dart
@@ -1,0 +1,6 @@
+// Copyright 2019 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+/// The default app name.
+const String firebaseDefaultAppName = '[DEFAULT]';

--- a/packages/firebase_core/firebase_core/lib/src/default_app_name_io.dart
+++ b/packages/firebase_core/firebase_core/lib/src/default_app_name_io.dart
@@ -1,0 +1,9 @@
+// Copyright 2019 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+import 'dart:io';
+
+/// The default app name.
+final String firebaseDefaultAppName =
+    Platform.isIOS ? '__FIRAPP_DEFAULT' : '[DEFAULT]';

--- a/packages/firebase_core/firebase_core/lib/src/firebase_app.dart
+++ b/packages/firebase_core/firebase_core/lib/src/firebase_app.dart
@@ -2,7 +2,13 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-part of firebase_core;
+import 'dart:async';
+
+import 'package:firebase_core_platform_interface/firebase_core_platform_interface.dart';
+import 'package:meta/meta.dart';
+
+import 'default_app_name.dart'
+  if (dart.library.io) 'default_app_name_io.dart';
 
 class FirebaseApp {
   // TODO(jackson): We could assert here that an app with this name was configured previously.
@@ -11,8 +17,7 @@ class FirebaseApp {
   /// The name of this app.
   final String name;
 
-  static final String defaultAppName =
-      (!kIsWeb && Platform.isIOS) ? '__FIRAPP_DEFAULT' : '[DEFAULT]';
+  static final String defaultAppName = firebaseDefaultAppName;
 
   /// A copy of the options for this app. These are non-modifiable.
   ///

--- a/packages/firebase_core/firebase_core/lib/src/firebase_app.dart
+++ b/packages/firebase_core/firebase_core/lib/src/firebase_app.dart
@@ -7,8 +7,7 @@ import 'dart:async';
 import 'package:firebase_core_platform_interface/firebase_core_platform_interface.dart';
 import 'package:meta/meta.dart';
 
-import 'default_app_name.dart'
-  if (dart.library.io) 'default_app_name_io.dart';
+import 'default_app_name.dart' if (dart.library.io) 'default_app_name_io.dart';
 
 class FirebaseApp {
   // TODO(jackson): We could assert here that an app with this name was configured previously.

--- a/packages/firebase_core/firebase_core/pubspec.yaml
+++ b/packages/firebase_core/firebase_core/pubspec.yaml
@@ -2,7 +2,7 @@ name: firebase_core
 description: Flutter plugin for Firebase Core, enabling connecting to multiple
   Firebase apps.
 homepage: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/firebase_core/firebase_core
-version: 0.4.3
+version: 0.4.3+1
 
 flutter:
   plugin:


### PR DESCRIPTION
## Description

This should make the plugin register as supporting Web on pub.dev.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] If the pull request affects only one plugin, the PR title starts with the name of the plugin in brackets (e.g. [cloud_firestore])
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
