### PR TITLE
Re-enable CI on stable

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -16,11 +16,7 @@ task:
   matrix:
     - name: publishable
       script:
-        # Temporarily disabling CI on stable to allow using new Flutter features closely
-        # before a new release.
-        # TODO(cyanglaz): re-enable this
-        # https://github.com/flutter/flutter/issues/46258
-        - flutter channel master
+        - flutter channel stable
         - ./script/check_publish.sh
     - name: format
       install_script:
@@ -33,11 +29,7 @@ task:
       env:
         matrix:
           CHANNEL: "master"
-          # Temporarily disabling CI on stable to allow using new Flutter features closely
-          # before a new release.
-          # TODO(cyanglaz): re-enable this
-          # https://github.com/flutter/flutter/issues/46258
-          # CHANNEL: "stable"
+          CHANNEL: "stable"
       test_script:
         # TODO(jackson): Allow web plugins once supported on stable
         # https://github.com/flutter/flutter/issues/42864
@@ -53,11 +45,7 @@ task:
           PLUGIN_SHARDING: "--shardIndex 1 --shardCount 2"
         matrix:
           CHANNEL: "master"
-          # Temporarily disabling CI on stable to allow using new Flutter features closely
-          # before a new release.
-          # TODO(cyanglaz): re-enable this
-          # https://github.com/flutter/flutter/issues/46258
-          # CHANNEL: "stable"
+          CHANNEL: "stable"
         GCLOUD_FIREBASE_TESTLAB_KEY: ENCRYPTED[fd81ffb7c44af2f8a1ae55e470c69690c1ec7e90aba49d18635fa4f3c72b6807034287e9e697f64e37ab836a66ba9eab]
       script:
         # TODO(jackson): Allow web plugins once supported on stable
@@ -114,11 +102,7 @@ task:
           PLUGIN_SHARDING: "--shardIndex 3 --shardCount 4"
         matrix:
           CHANNEL: "master"
-          # Temporarily disabling CI on stable to allow using new Flutter features closely
-          # before a new release.
-          # TODO(cyanglaz): re-enable this
-          # https://github.com/flutter/flutter/issues/46258
-          # CHANNEL: "stable"
+          CHANNEL: "stable"
       build_script:
         # TODO(jackson): Allow web plugins once supported on stable
         # https://github.com/flutter/flutter/issues/42864


### PR DESCRIPTION
Stable CI was temporarily disabled waiting for the next stable release, now that it's out re-enabling.

flutter/flutter#46258