### PR TITLE
Fix analysis failures in cloud_functions

### DIFF
--- a/packages/cloud_functions/CHANGELOG.md
+++ b/packages/cloud_functions/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.4.1+6
+
+* Fix analysis failures
+
 ## 0.4.1+5
 
 * Remove the deprecated `author:` field from pubspec.yaml

--- a/packages/cloud_functions/example/test/cloud_functions_test.dart
+++ b/packages/cloud_functions/example/test/cloud_functions_test.dart
@@ -4,7 +4,7 @@
 
 import 'package:flutter_test/flutter_test.dart';
 
-import '../lib/main.dart';
+import 'package:cloud_functions_example/main.dart';
 
 void main() {
   testWidgets('CloudFunctions example widget test',

--- a/packages/cloud_functions/example/test_driver/cloud_functions_test.dart
+++ b/packages/cloud_functions/example/test_driver/cloud_functions_test.dart
@@ -7,5 +7,5 @@ import 'package:flutter_driver/flutter_driver.dart';
 Future<void> main() async {
   final FlutterDriver driver = await FlutterDriver.connect();
   await driver.requestData(null, timeout: const Duration(minutes: 1));
-  driver.close();
+  await driver.close();
 }

--- a/packages/cloud_functions/pubspec.yaml
+++ b/packages/cloud_functions/pubspec.yaml
@@ -1,6 +1,6 @@
 name: cloud_functions
 description: Flutter plugin for Cloud Functions.
-version: 0.4.1+5
+version: 0.4.1+6
 homepage: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/cloud_functions
 
 flutter:


### PR DESCRIPTION
Fixes some analysis failures in cloud_firestore.

This PR demonstrates that our CI isn't turning red on documentation failures (there are 8 public members that lack documentation)