### PR TITLE
[firebase_core_web] add non op android folder

### DIFF
--- a/packages/firebase_core/firebase_core_web/CHANGELOG.md
+++ b/packages/firebase_core/firebase_core_web/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.1+1
+
+* Add an android/ folder with no-op implementation to workaround https://github.com/flutter/flutter/issues/46898
+
 ## 0.1.1
 
 * Require Flutter SDK 1.12.13+hotfix.4 or greater.

--- a/packages/firebase_core/firebase_core_web/android/.gitignore
+++ b/packages/firebase_core/firebase_core_web/android/.gitignore
@@ -1,0 +1,8 @@
+*.iml
+.gradle
+/local.properties
+/.idea/workspace.xml
+/.idea/libraries
+.DS_Store
+/build
+/captures

--- a/packages/firebase_core/firebase_core_web/android/build.gradle
+++ b/packages/firebase_core/firebase_core_web/android/build.gradle
@@ -26,7 +26,6 @@ android {
 
     defaultConfig {
         minSdkVersion 16
-        testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
     }
     lintOptions {
         disable 'InvalidPackage'

--- a/packages/firebase_core/firebase_core_web/android/build.gradle
+++ b/packages/firebase_core/firebase_core_web/android/build.gradle
@@ -1,0 +1,34 @@
+group 'io.flutter.plugins.firebase_core_web'
+version '1.0'
+
+buildscript {
+    repositories {
+        google()
+        jcenter()
+    }
+
+    dependencies {
+        classpath 'com.android.tools.build:gradle:3.5.0'
+    }
+}
+
+rootProject.allprojects {
+    repositories {
+        google()
+        jcenter()
+    }
+}
+
+apply plugin: 'com.android.library'
+
+android {
+    compileSdkVersion 28
+
+    defaultConfig {
+        minSdkVersion 16
+        testInstrumentationRunner "android.support.test.runner.AndroidJUnitRunner"
+    }
+    lintOptions {
+        disable 'InvalidPackage'
+    }
+}

--- a/packages/firebase_core/firebase_core_web/android/gradle.properties
+++ b/packages/firebase_core/firebase_core_web/android/gradle.properties
@@ -1,0 +1,2 @@
+org.gradle.jvmargs=-Xmx1536M
+android.enableR8=true

--- a/packages/firebase_core/firebase_core_web/android/gradle/wrapper/gradle-wrapper.properties
+++ b/packages/firebase_core/firebase_core_web/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,0 +1,5 @@
+distributionBase=GRADLE_USER_HOME
+distributionPath=wrapper/dists
+zipStoreBase=GRADLE_USER_HOME
+zipStorePath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.2-all.zip

--- a/packages/firebase_core/firebase_core_web/android/settings.gradle
+++ b/packages/firebase_core/firebase_core_web/android/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'firebase_core_web'

--- a/packages/firebase_core/firebase_core_web/android/src/main/AndroidManifest.xml
+++ b/packages/firebase_core/firebase_core_web/android/src/main/AndroidManifest.xml
@@ -1,0 +1,3 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+  package="io.flutter.plugins.firebase_core_web">
+</manifest>

--- a/packages/firebase_core/firebase_core_web/android/src/main/java/io/flutter/plugins/firebase_core_web/FirebaseCoreWebPlugin.java
+++ b/packages/firebase_core/firebase_core_web/android/src/main/java/io/flutter/plugins/firebase_core_web/FirebaseCoreWebPlugin.java
@@ -1,0 +1,31 @@
+package io.flutter.plugins.firebase_core_web;
+
+import android.support.annotation.NonNull;
+import io.flutter.embedding.engine.plugins.FlutterPlugin;
+import io.flutter.plugin.common.MethodCall;
+import io.flutter.plugin.common.MethodChannel.MethodCallHandler;
+import io.flutter.plugin.common.MethodChannel.Result;
+import io.flutter.plugin.common.PluginRegistry.Registrar;
+
+/** FirebaseCoreWebPlugin */
+public class FirebaseCoreWebPlugin implements FlutterPlugin, MethodCallHandler {
+  @Override
+  public void onAttachedToEngine(@NonNull FlutterPluginBinding flutterPluginBinding) {}
+
+  // This static function is optional and equivalent to onAttachedToEngine. It supports the old
+  // pre-Flutter-1.12 Android projects. You are encouraged to continue supporting
+  // plugin registration via this function while apps migrate to use the new Android APIs
+  // post-flutter-1.12 via https://flutter.dev/go/android-project-migration.
+  //
+  // It is encouraged to share logic between onAttachedToEngine and registerWith to keep
+  // them functionally equivalent. Only one of onAttachedToEngine or registerWith will be called
+  // depending on the user's project. onAttachedToEngine or registerWith must both be defined
+  // in the same class.
+  public static void registerWith(Registrar registrar) {}
+
+  @Override
+  public void onMethodCall(@NonNull MethodCall call, @NonNull Result result) {}
+
+  @Override
+  public void onDetachedFromEngine(@NonNull FlutterPluginBinding binding) {}
+}

--- a/packages/firebase_core/firebase_core_web/android/src/main/java/io/flutter/plugins/firebase_core_web/FirebaseCoreWebPlugin.java
+++ b/packages/firebase_core/firebase_core_web/android/src/main/java/io/flutter/plugins/firebase_core_web/FirebaseCoreWebPlugin.java
@@ -2,20 +2,14 @@ package io.flutter.plugins.firebase_core_web;
 
 import android.support.annotation.NonNull;
 import io.flutter.embedding.engine.plugins.FlutterPlugin;
-import io.flutter.plugin.common.MethodCall;
-import io.flutter.plugin.common.MethodChannel.MethodCallHandler;
-import io.flutter.plugin.common.MethodChannel.Result;
 import io.flutter.plugin.common.PluginRegistry.Registrar;
 
 /** FirebaseCoreWebPlugin */
-public class FirebaseCoreWebPlugin implements FlutterPlugin, MethodCallHandler {
+public class FirebaseCoreWebPlugin implements FlutterPlugin {
   @Override
   public void onAttachedToEngine(@NonNull FlutterPluginBinding flutterPluginBinding) {}
 
   public static void registerWith(Registrar registrar) {}
-
-  @Override
-  public void onMethodCall(@NonNull MethodCall call, @NonNull Result result) {}
 
   @Override
   public void onDetachedFromEngine(@NonNull FlutterPluginBinding binding) {}

--- a/packages/firebase_core/firebase_core_web/android/src/main/java/io/flutter/plugins/firebase_core_web/FirebaseCoreWebPlugin.java
+++ b/packages/firebase_core/firebase_core_web/android/src/main/java/io/flutter/plugins/firebase_core_web/FirebaseCoreWebPlugin.java
@@ -1,6 +1,5 @@
 package io.flutter.plugins.firebase_core_web;
 
-import android.support.annotation.NonNull;
 import io.flutter.embedding.engine.plugins.FlutterPlugin;
 import io.flutter.plugin.common.PluginRegistry.Registrar;
 

--- a/packages/firebase_core/firebase_core_web/android/src/main/java/io/flutter/plugins/firebase_core_web/FirebaseCoreWebPlugin.java
+++ b/packages/firebase_core/firebase_core_web/android/src/main/java/io/flutter/plugins/firebase_core_web/FirebaseCoreWebPlugin.java
@@ -12,15 +12,6 @@ public class FirebaseCoreWebPlugin implements FlutterPlugin, MethodCallHandler {
   @Override
   public void onAttachedToEngine(@NonNull FlutterPluginBinding flutterPluginBinding) {}
 
-  // This static function is optional and equivalent to onAttachedToEngine. It supports the old
-  // pre-Flutter-1.12 Android projects. You are encouraged to continue supporting
-  // plugin registration via this function while apps migrate to use the new Android APIs
-  // post-flutter-1.12 via https://flutter.dev/go/android-project-migration.
-  //
-  // It is encouraged to share logic between onAttachedToEngine and registerWith to keep
-  // them functionally equivalent. Only one of onAttachedToEngine or registerWith will be called
-  // depending on the user's project. onAttachedToEngine or registerWith must both be defined
-  // in the same class.
   public static void registerWith(Registrar registrar) {}
 
   @Override

--- a/packages/firebase_core/firebase_core_web/pubspec.yaml
+++ b/packages/firebase_core/firebase_core_web/pubspec.yaml
@@ -1,7 +1,7 @@
 name: firebase_core_web
 description: The web implementation of firebase_core
 homepage: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/firebase_core/firebase_core_web
-version: 0.1.1
+version: 0.1.1+1
 
 flutter:
   plugin:


### PR DESCRIPTION
## Description

Add a non-op android folder to avoid build errors.
The current flutter dev channel has a bug that it requires all plugins to have at least a non-op android folder to build.

## Related Issues

https://github.com/flutter/flutter/issues/46898

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] If the pull request affects only one plugin, the PR title starts with the name of the plugin in brackets (e.g. [cloud_firestore])
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
