### PR TITLE
[firebase_auth_web] Removed onMethodCall override and related imports.

### DIFF
--- a/packages/firebase_auth/firebase_auth_web/android/src/main/java/io/flutter/plugins/firebaseauth_web/FirebaseAuthWebPlugin.java
+++ b/packages/firebase_auth/firebase_auth_web/android/src/main/java/io/flutter/plugins/firebaseauth_web/FirebaseAuthWebPlugin.java
@@ -1,8 +1,6 @@
 package io.flutter.plugins.firebaseauth_web;
 
 import io.flutter.embedding.engine.plugins.FlutterPlugin;
-import io.flutter.plugin.common.MethodCall;
-import io.flutter.plugin.common.MethodChannel.Result;
 import io.flutter.plugin.common.PluginRegistry.Registrar;
 
 /** FirebaseAuthWebPlugin */
@@ -11,9 +9,6 @@ public class FirebaseAuthWebPlugin implements FlutterPlugin {
   public void onAttachedToEngine(FlutterPluginBinding flutterPluginBinding) {}
 
   public static void registerWith(Registrar registrar) {}
-
-  @Override
-  public void onMethodCall(MethodCall call, Result result) {}
 
   @Override
   public void onDetachedFromEngine(FlutterPluginBinding binding) {}


### PR DESCRIPTION
## Description

Removed onMethodCall override and related imports.

## Related Issues

(Part 2 of: https://github.com/FirebaseExtended/flutterfire/pull/1628)

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] If the pull request affects only one plugin, the PR title starts with the name of the plugin in brackets (e.g. [cloud_firestore])
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
