### PR TITLE
[firebase_storage] Removed "i am working" print statements

### DIFF
--- a/packages/firebase_storage/CHANGELOG.md
+++ b/packages/firebase_storage/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.1.1
+
+* Remove unnecessary debug print statements like "i am working".
+
 ## 3.1.0
 
 * Added error handling to `StorageFileDownloadTask` and added propagation of errors to the Future returned by the `writeToFile` method in `StorageReference`. 

--- a/packages/firebase_storage/CHANGELOG.md
+++ b/packages/firebase_storage/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 3.1.1
 
-* Remove unnecessary debug print statements like "i am working".
+* Removed unnecessary debug print statements ("i am working").
 
 ## 3.1.0
 

--- a/packages/firebase_storage/lib/src/storage_reference.dart
+++ b/packages/firebase_storage/lib/src/storage_reference.dart
@@ -158,9 +158,6 @@ class StorageReference {
 
   /// Retrieves metadata associated with an object at this [StorageReference].
   Future<StorageMetadata> getMetadata() async {
-    print('i am working');
-    print(_pathComponents);
-    print('i am working');
     return StorageMetadata._fromMap(await FirebaseStorage.channel
         .invokeMapMethod<String, dynamic>(
             "StorageReference#getMetadata", <String, String>{

--- a/packages/firebase_storage/pubspec.yaml
+++ b/packages/firebase_storage/pubspec.yaml
@@ -2,7 +2,7 @@ name: firebase_storage
 description: Flutter plugin for Firebase Cloud Storage, a powerful, simple, and
   cost-effective object storage service for Android and iOS.
 homepage: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/firebase_storage
-version: 3.1.0
+version: 3.1.1
 
 flutter:
   plugin:


### PR DESCRIPTION
## Description

I assume that these were accidentally left in with https://github.com/FirebaseExtended/flutterfire/pull/1295.

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] If the pull request affects only one plugin, the PR title starts with the name of the plugin in brackets (e.g. [cloud_firestore])
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

- [x] No, this is *not* a breaking change.