### PR TITLE
Update firebase_auth version for release

### DIFF
--- a/packages/firebase_auth/firebase_auth/CHANGELOG.md
+++ b/packages/firebase_auth/firebase_auth/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.15.2+1
+## 0.15.3
 
 * Add support for OAuth Authentication for iOS and Android to solve generic providers authentication.
 

--- a/packages/firebase_auth/firebase_auth/pubspec.yaml
+++ b/packages/firebase_auth/firebase_auth/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for Firebase Auth, enabling Android and iOS
   authentication using passwords, phone numbers and identity providers
   like Google, Facebook and Twitter.
 homepage: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/firebase_auth/firebase_auth
-version: 0.15.2+1
+version: 0.15.3
 
 flutter:
   plugin:


### PR DESCRIPTION
## Description

https://github.com/FirebaseExtended/flutterfire/pull/1526 added OAuth support to firebase_auth. I overlooked this in the review, but since this is adding new API surface area, it shouldn't be patch update -- it should at least be a minor update.

I thought about making it a breaking change since the Android `api` dependency changed to 'com.google.firebase:firebase-auth:19.2.0': https://github.com/FirebaseExtended/flutterfire/pull/1526/files#diff-d8d76dca3eb1a8679bd5baa6e8b330c3

We may want to move this to being an implementation dependency, see https://github.com/FirebaseExtended/flutterfire/pull/39

We'll be bumping this plugin to 1.0 soon but I think we're not quite done making breaking changes yet.