### PR TITLE
[firebase_dynamic_links] Add steps for android specific integration

### DIFF
--- a/packages/firebase_dynamic_links/README.md
+++ b/packages/firebase_dynamic_links/README.md
@@ -79,23 +79,44 @@ final Uri shortUrl = shortenedLink.shortUrl;
 
 You can receive a Dynamic Link containing a deep link that takes the user to specific content within your app:
 
-1. In the [Firebase Console](https://console.firebase.google.com), open the Dynamic Links section.
+- In the [Firebase Console](https://console.firebase.google.com), open the Dynamic Links section.
   - Accept the terms of service if you are prompted to do so.
   - Take note of your project's Dynamic Links URL prefix, which is displayed at the top of the Dynamic Links page. You need your project's Dynamic Links URL prefix to programmatically create Dynamic Links. A Dynamic Links URL prefix looks like `https://YOUR_SUBDOMAIN.page.link`.
 
-Receiving dynamic links on *iOS* requires a couple more steps than *Android*. If you only want to receive dynamic links on *Android*, skip to step 4. You can also follow a video on the next two steps [here.](https://youtu.be/sFPo296OQqk?t=2m40s)
+### Android specific (optional)
 
-2. In the **Info** tab of your *iOS* app's Xcode project:
+- If you want to let the user open the the dynamic link directly in your app add in your `$YOUR_APP$/android/app/src/main/AndroidManifest.xml`
+
+```
+<intent-filter>
+    <action android:name="android.intent.action.VIEW" />
+    <category android:name="android.intent.category.DEFAULT" />
+    <category android:name="android.intent.category.BROWSABLE" />
+
+    <!--Change YOUR_HOST with the one you get from the firebase console-->
+    <data
+        android:host="YOUR_HOST"
+        android:scheme="https" />
+</intent-filter>
+```
+
+### IOS specific
+
+- In the **Info** tab of your *iOS* app's Xcode project:
   - Create a new **URL Type** to be used for Dynamic Links.
   - Set the **Identifier** field to a unique value and the **URL Schemes** field to be your bundle identifier, which is the default URL scheme used by Dynamic Links.
 
-3. In the **Capabilities** tab of your app's Xcode project, enable **Associated Domains** and add the following to the **Associated Domains** list:
+- In the **Capabilities** tab of your app's Xcode project, enable **Associated Domains** and add the following to the **Associated Domains** list:
 
 ```
 applinks:YOUR_SUBDOMAIN.page.link
 ```
 
-4. To receive a dynamic link, call the `getInitialLink()` method from `FirebaseDynamicLinks` which gets the link that opened the app (or null if it was not opened via a dynamic link)
+You can also follow a video [here.](https://youtu.be/sFPo296OQqk?t=2m40s)
+
+### Test the implementation
+
+To receive a dynamic link, call the `getInitialLink()` method from `FirebaseDynamicLinks` which gets the link that opened the app (or null if it was not opened via a dynamic link)
 and configure listeners for link callbacks when the application is active or in background calling `onLink`.
 
 ```dart


### PR DESCRIPTION
## Description
I added an optional step in the `README` that will help people better integrate with Android, providing the intent that will make android proposing the app as possible option to open the link directly without passing from the browser.

## Checklist
Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] If the pull request affects only one plugin, the PR title starts with the name of the plugin in brackets (e.g. [cloud_firestore])
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.