### PR TITLE
[firebase_auth] support confirmPasswordReset

### DIFF
--- a/packages/firebase_auth/firebase_auth_platform_interface/CHANGELOG.md
+++ b/packages/firebase_auth/firebase_auth_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.1.3
+
+- Added support for `confirmPasswordReset`
+
 ## 1.1.2
 
 - Remove the deprecated `author:` field from pubspec.yaml

--- a/packages/firebase_auth/firebase_auth_platform_interface/lib/firebase_auth_platform_interface.dart
+++ b/packages/firebase_auth/firebase_auth_platform_interface/lib/firebase_auth_platform_interface.dart
@@ -231,4 +231,9 @@ abstract class FirebaseAuthPlatform {
   }) {
     throw UnimplementedError('verifyPhoneNumber() is not implemented');
   }
+
+  /// Completes the password reset process, given a confirmation code and new password.
+  Future<void> confirmPasswordReset(String oobCode, String newPassword) {
+    throw UnimplementedError('confirmPasswordReset() is not implemented');
+  }
 }

--- a/packages/firebase_auth/firebase_auth_platform_interface/lib/src/method_channel_firebase_auth.dart
+++ b/packages/firebase_auth/firebase_auth_platform_interface/lib/src/method_channel_firebase_auth.dart
@@ -352,6 +352,14 @@ class MethodChannelFirebaseAuth extends FirebaseAuthPlatform {
     return channel.invokeMethod<void>('verifyPhoneNumber', params);
   }
 
+  @override
+  Future<void> confirmPasswordReset(String oobCode, String newPassword) {
+    return channel.invokeMethod('confirmPasswordReset', <String, String>{
+      'oobCode': oobCode,
+      'newPassword': newPassword,
+    });
+  }
+
   Future<void> _callHandler(MethodCall call) async {
     switch (call.method) {
       case 'onAuthStateChanged':
@@ -468,7 +476,7 @@ PlatformIdTokenResult _decodeIdTokenResult(Map<String, dynamic> data) {
   );
 }
 
-/// A utilily class that collects the callbacks for a [verifyPhoneNumber] call.
+/// A utility class that collects the callbacks for a [verifyPhoneNumber] call.
 class _PhoneAuthCallbacks {
   const _PhoneAuthCallbacks(
     this.verificationCompleted,

--- a/packages/firebase_auth/firebase_auth_platform_interface/pubspec.yaml
+++ b/packages/firebase_auth/firebase_auth_platform_interface/pubspec.yaml
@@ -3,7 +3,7 @@ description: A common platform interface for the firebase_auth plugin.
 homepage: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/firebase_auth/firebase_auth_platform_interface
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 1.1.2
+version: 1.1.3
 
 dependencies:
   flutter:

--- a/packages/firebase_auth/firebase_auth_platform_interface/test/method_channel_firebase_auth_test.dart
+++ b/packages/firebase_auth/firebase_auth_platform_interface/test/method_channel_firebase_auth_test.dart
@@ -25,6 +25,7 @@ const String kMockVerificationId = '12345';
 const String kMockSmsCode = '123456';
 const String kMockLanguage = 'en';
 const String kMockIdTokenResultSignInProvider = 'password';
+const String kMockOobCode = 'oobcode';
 const Map<dynamic, dynamic> kMockIdTokenResultClaims = <dynamic, dynamic>{
   'claim1': 'value1',
 };
@@ -1330,6 +1331,23 @@ void main() {
             arguments: <String, String>{
               'language': kMockLanguage,
               'app': appName,
+            },
+          ),
+        ],
+      );
+    });
+
+    test('confirmPasswordReset', () async {
+      await auth.confirmPasswordReset(kMockOobCode, kMockPassword);
+
+      expect(
+        log,
+        <Matcher>[
+          isMethodCall(
+            'confirmPasswordReset',
+            arguments: <String, String>{
+              'oobCode': kMockOobCode,
+              'newPassword': kMockPassword,
             },
           ),
         ],


### PR DESCRIPTION
## Description

This PR lays the foundation for a future PR to be able to handle the whole password reset flow from within the app.

## Related Issues

#1739 

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] If the pull request affects only one plugin, the PR title starts with the name of the plugin in brackets (e.g. [cloud_firestore])
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
