### PR TITLE
[firebase_auth] Correct method signature for confirmPasswordReset 

### DIFF
--- a/packages/firebase_auth/firebase_auth_platform_interface/CHANGELOG.md
+++ b/packages/firebase_auth/firebase_auth_platform_interface/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## 1.1.4
 
-- Correct support for `confirmPasswordReset`
+- **Breaking change**: Added missing `app` parameter to `confirmPasswordReset`.
+  (This is an exception to the usual policy of avoiding breaking changes since
+  `confirmPasswordReset` is a new API and doesn't have clients yet.)
 
 ## 1.1.3
 

--- a/packages/firebase_auth/firebase_auth_platform_interface/CHANGELOG.md
+++ b/packages/firebase_auth/firebase_auth_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.1.4
+
+- Correct support for `confirmPasswordReset`
+
 ## 1.1.3
 
 - Added support for `confirmPasswordReset`

--- a/packages/firebase_auth/firebase_auth_platform_interface/lib/firebase_auth_platform_interface.dart
+++ b/packages/firebase_auth/firebase_auth_platform_interface/lib/firebase_auth_platform_interface.dart
@@ -233,7 +233,11 @@ abstract class FirebaseAuthPlatform {
   }
 
   /// Completes the password reset process, given a confirmation code and new password.
-  Future<void> confirmPasswordReset(String oobCode, String newPassword) {
+  Future<void> confirmPasswordReset(
+    String app,
+    String oobCode,
+    String newPassword,
+  ) {
     throw UnimplementedError('confirmPasswordReset() is not implemented');
   }
 }

--- a/packages/firebase_auth/firebase_auth_platform_interface/lib/src/method_channel_firebase_auth.dart
+++ b/packages/firebase_auth/firebase_auth_platform_interface/lib/src/method_channel_firebase_auth.dart
@@ -353,8 +353,13 @@ class MethodChannelFirebaseAuth extends FirebaseAuthPlatform {
   }
 
   @override
-  Future<void> confirmPasswordReset(String oobCode, String newPassword) {
+  Future<void> confirmPasswordReset(
+    String app,
+    String oobCode,
+    String newPassword,
+  ) {
     return channel.invokeMethod('confirmPasswordReset', <String, String>{
+      'app': app,
       'oobCode': oobCode,
       'newPassword': newPassword,
     });

--- a/packages/firebase_auth/firebase_auth_platform_interface/pubspec.yaml
+++ b/packages/firebase_auth/firebase_auth_platform_interface/pubspec.yaml
@@ -3,7 +3,7 @@ description: A common platform interface for the firebase_auth plugin.
 homepage: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/firebase_auth/firebase_auth_platform_interface
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 1.1.3
+version: 1.1.4
 
 dependencies:
   flutter:

--- a/packages/firebase_auth/firebase_auth_platform_interface/test/method_channel_firebase_auth_test.dart
+++ b/packages/firebase_auth/firebase_auth_platform_interface/test/method_channel_firebase_auth_test.dart
@@ -1338,7 +1338,7 @@ void main() {
     });
 
     test('confirmPasswordReset', () async {
-      await auth.confirmPasswordReset(kMockOobCode, kMockPassword);
+      await auth.confirmPasswordReset(appName, kMockOobCode, kMockPassword);
 
       expect(
         log,
@@ -1346,6 +1346,7 @@ void main() {
           isMethodCall(
             'confirmPasswordReset',
             arguments: <String, String>{
+              'app': appName,
               'oobCode': kMockOobCode,
               'newPassword': kMockPassword,
             },


### PR DESCRIPTION
## Description

The `FirebaseAuthPlatform.confirmPasswordReset` method should accept `String app` as an argument to be consistent with the rest of the interface (and existing implementations, particularly for `firebase_auth_web`).

cc: @lanmonster, @hterkelsen 

## Related Issues

#1778 

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] If the pull request affects only one plugin, the PR title starts with the name of the plugin in brackets (e.g. [cloud_firestore])
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
