### PR TITLE
[firebase_auth_platform_interface] Fix typo in the MethodChannel implementation.

### DIFF
--- a/packages/firebase_auth/firebase_auth_platform_interface/CHANGELOG.md
+++ b/packages/firebase_auth/firebase_auth_platform_interface/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 1.1.4
 
-* Fixed typo on private method name.
+- Fixed typo on private method name.
 
 ## 1.1.4
 
@@ -10,20 +10,20 @@
 
 ## 1.1.3
 
-* Added support for `confirmPasswordReset`
+- Added support for `confirmPasswordReset`
 
 ## 1.1.2
 
-* Remove the deprecated `author:` field from pubspec.yaml
+- Remove the deprecated `author:` field from pubspec.yaml
 
 ## 1.1.1
 
-* Fixed crash when platform returns an auth result where `additionalUserInfo` is not provided.
+- Fixed crash when platform returns an auth result where `additionalUserInfo` is not provided.
 
 ## 1.1.0
 
-* Added type `PlatformOAuthCredential` for generic OAuth providers.
+- Added type `PlatformOAuthCredential` for generic OAuth providers.
 
 ## 1.0.0
 
-* Initial open-source release.
+- Initial open-source release.

--- a/packages/firebase_auth/firebase_auth_platform_interface/CHANGELOG.md
+++ b/packages/firebase_auth/firebase_auth_platform_interface/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.1.4
+## 1.1.5
 
 - Fixed typo on private method name.
 
@@ -18,7 +18,8 @@
 
 ## 1.1.1
 
-- Fixed crash when platform returns an auth result where `additionalUserInfo` is not provided.
+- Fixed crash when platform returns an auth result where `additionalUserInfo`
+  is not provided.
 
 ## 1.1.0
 

--- a/packages/firebase_auth/firebase_auth_platform_interface/CHANGELOG.md
+++ b/packages/firebase_auth/firebase_auth_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.1.3+1
+
+* Fixed typo on private method name.
+
 ## 1.1.4
 
 - **Breaking change**: Added missing `app` parameter to `confirmPasswordReset`.
@@ -6,21 +10,20 @@
 
 ## 1.1.3
 
-- Added support for `confirmPasswordReset`
+* Added support for `confirmPasswordReset`
 
 ## 1.1.2
 
-- Remove the deprecated `author:` field from pubspec.yaml
+* Remove the deprecated `author:` field from pubspec.yaml
 
 ## 1.1.1
 
-- Fixed crash when platform returns an auth result where `additionalUserInfo`
-  is not provided.
+* Fixed crash when platform returns an auth result where `additionalUserInfo` is not provided.
 
 ## 1.1.0
 
-- Added type `PlatformOAuthCredential` for generic OAuth providers.
+* Added type `PlatformOAuthCredential` for generic OAuth providers.
 
 ## 1.0.0
 
-- Initial open-source release.
+* Initial open-source release.

--- a/packages/firebase_auth/firebase_auth_platform_interface/CHANGELOG.md
+++ b/packages/firebase_auth/firebase_auth_platform_interface/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.1.3+1
+## 1.1.4
 
 * Fixed typo on private method name.
 

--- a/packages/firebase_auth/firebase_auth_platform_interface/lib/src/method_channel_firebase_auth.dart
+++ b/packages/firebase_auth/firebase_auth_platform_interface/lib/src/method_channel_firebase_auth.dart
@@ -368,7 +368,7 @@ class MethodChannelFirebaseAuth extends FirebaseAuthPlatform {
   Future<void> _callHandler(MethodCall call) async {
     switch (call.method) {
       case 'onAuthStateChanged':
-        _onAuthStageChangedHandler(call);
+        _onAuthStateChangedHandler(call);
         break;
       case 'phoneVerificationCompleted':
         final int handle = call.arguments['handle'];
@@ -409,7 +409,7 @@ class MethodChannelFirebaseAuth extends FirebaseAuthPlatform {
     }
   }
 
-  void _onAuthStageChangedHandler(MethodCall call) {
+  void _onAuthStateChangedHandler(MethodCall call) {
     final Map<dynamic, dynamic> data = call.arguments['user'];
     final int id = call.arguments['id'];
 

--- a/packages/firebase_auth/firebase_auth_platform_interface/pubspec.yaml
+++ b/packages/firebase_auth/firebase_auth_platform_interface/pubspec.yaml
@@ -3,7 +3,7 @@ description: A common platform interface for the firebase_auth plugin.
 homepage: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/firebase_auth/firebase_auth_platform_interface
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 1.1.4
+version: 1.1.5
 
 dependencies:
   flutter:


### PR DESCRIPTION
## Description

Fixed typo in private method of the MethodChannel implementation of the plugin.

```
$ flutter test
00:07 +59: All tests passed!
```

## Related Issues

* https://github.com/flutter/flutter/issues/46045

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] If the pull request affects only one plugin, the PR title starts with the name of the plugin in brackets (e.g. [cloud_firestore])
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
