### PR TITLE
[firebase_auth_web] Add null check to _fromJsUser.

### DIFF
--- a/packages/firebase_auth/firebase_auth_web/CHANGELOG.md
+++ b/packages/firebase_auth/firebase_auth_web/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.2
+
+* Prevent `null` users (unauthenticated) from breaking the `onAuthStateChanged` Stream.
+
 ## 0.1.1+3
 
 * Fix the tests on dart2js.

--- a/packages/firebase_auth/firebase_auth_web/CHANGELOG.md
+++ b/packages/firebase_auth/firebase_auth_web/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.1.2
+## 0.1.1+4
 
 * Prevent `null` users (unauthenticated) from breaking the `onAuthStateChanged` Stream.
 * Migrate tests from jsify to package:js.

--- a/packages/firebase_auth/firebase_auth_web/CHANGELOG.md
+++ b/packages/firebase_auth/firebase_auth_web/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 0.1.2
 
 * Prevent `null` users (unauthenticated) from breaking the `onAuthStateChanged` Stream.
+* Migrate tests from jsify to package:js.
 
 ## 0.1.1+3
 

--- a/packages/firebase_auth/firebase_auth_web/lib/firebase_auth_web.dart
+++ b/packages/firebase_auth/firebase_auth_web/lib/firebase_auth_web.dart
@@ -42,6 +42,9 @@ class FirebaseAuthWeb extends FirebaseAuthPlatform {
   }
 
   PlatformUser _fromJsUser(firebase.User user) {
+    if (user == null) {
+      return null;
+    }
     return PlatformUser(
       providerId: user.providerId,
       uid: user.uid,
@@ -154,9 +157,6 @@ class FirebaseAuthWeb extends FirebaseAuthPlatform {
   Future<PlatformUser> getCurrentUser(String app) async {
     final firebase.Auth auth = _getAuth(app);
     final firebase.User currentUser = auth.currentUser;
-    if (currentUser == null) {
-      return null;
-    }
     return _fromJsUser(currentUser);
   }
 

--- a/packages/firebase_auth/firebase_auth_web/pubspec.yaml
+++ b/packages/firebase_auth/firebase_auth_web/pubspec.yaml
@@ -1,7 +1,7 @@
 name: firebase_auth_web
 description: The web implementation of firebase_auth
 homepage: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/firebase_auth/firebase_auth_web
-version: 0.1.1+3
+version: 0.1.2
 
 flutter:
   plugin:

--- a/packages/firebase_auth/firebase_auth_web/pubspec.yaml
+++ b/packages/firebase_auth/firebase_auth_web/pubspec.yaml
@@ -1,7 +1,7 @@
 name: firebase_auth_web
 description: The web implementation of firebase_auth
 homepage: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/firebase_auth/firebase_auth_web
-version: 0.1.2
+version: 0.1.1+4
 
 flutter:
   plugin:

--- a/packages/firebase_auth/firebase_auth_web/test/firebase_auth_web_test.dart
+++ b/packages/firebase_auth/firebase_auth_web/test/firebase_auth_web_test.dart
@@ -4,7 +4,7 @@
 @TestOn('chrome')
 
 import 'dart:async';
-import 'dart:js' as js;
+import 'dart:js' show allowInterop;
 
 import 'package:flutter_test/flutter_test.dart';
 import 'package:firebase_auth/firebase_auth.dart';
@@ -17,11 +17,11 @@ import 'mock/firebase_mock.dart';
 
 void main() {
   group('$FirebaseAuthWeb', () {
-
     setUp(() {
       firebaseMock = FirebaseMock(
-        app: js.allowInterop((String name) => FirebaseAppMock(
-          name: name, 
+          app: allowInterop(
+        (String name) => FirebaseAppMock(
+          name: name,
           options: FirebaseAppOptionsMock(appId: '123'),
         ),
       ));
@@ -31,11 +31,11 @@ void main() {
     });
 
     test('signInAnonymously calls Firebase APIs', () async {
-      firebaseMock.auth = js.allowInterop((_) => FirebaseAuthMock(
-        signInAnonymously: js.allowInterop(() {
-          return _jsPromise(_fakeUserCredential());
-        }),
-      ));
+      firebaseMock.auth = allowInterop((_) => FirebaseAuthMock(
+            signInAnonymously: allowInterop(() {
+              return _jsPromise(_fakeUserCredential());
+            }),
+          ));
 
       FirebaseAuth auth = FirebaseAuth.instance;
       AuthResult result = await auth.signInAnonymously();
@@ -44,8 +44,7 @@ void main() {
 
     group('onAuthStateChanged', () {
       final List seenUsers = [];
-      final Completer<Function> nextUserCallback =
-          Completer<Function>();
+      final Completer<Function> nextUserCallback = Completer<Function>();
 
       final List<dynamic> streamValues = [_fakeRawUser(), null, _fakeRawUser()];
       final List<dynamic> expectedValueMatchers = [
@@ -55,15 +54,15 @@ void main() {
       ];
 
       test('non authenticated user present in stream', () async {
-        firebaseMock.auth = js.allowInterop((_) => FirebaseAuthMock(
-          onAuthStateChanged: js.allowInterop(
-              (Function nextUserCb, Function errorCb) {
-            if (!nextUserCallback.isCompleted) {
-              nextUserCallback.complete(nextUserCb);
-            }
-            return js.allowInterop(() {});
-          }),
-        ));
+        firebaseMock.auth = allowInterop((_) => FirebaseAuthMock(
+              onAuthStateChanged:
+                  allowInterop((Function nextUserCb, Function errorCb) {
+                if (!nextUserCallback.isCompleted) {
+                  nextUserCallback.complete(nextUserCb);
+                }
+                return allowInterop(() {});
+              }),
+            ));
 
         FirebaseAuth auth = FirebaseAuth.instance;
 
@@ -85,7 +84,7 @@ void main() {
 }
 
 Promise _jsPromise(dynamic value) {
-  return Promise(js.allowInterop((void resolve(dynamic result), Function reject) {
+  return Promise(allowInterop((void resolve(dynamic result), Function reject) {
     resolve(value);
   }));
 }

--- a/packages/firebase_auth/firebase_auth_web/test/firebase_auth_web_test.dart
+++ b/packages/firebase_auth/firebase_auth_web/test/firebase_auth_web_test.dart
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 @TestOn('chrome')
 
+import 'dart:async';
 import 'dart:js' as js;
 
 import 'package:flutter_test/flutter_test.dart';
@@ -42,6 +43,50 @@ void main() {
       AuthResult result = await auth.signInAnonymously();
       expect(result, isNotNull);
     });
+
+    group('onAuthStateChanged', () {
+      final List seenUsers = [];
+      final Completer<js.JsFunction> nextUserCallback =
+          Completer<js.JsFunction>();
+
+      final List<dynamic> streamValues = [_fakeRawUser(), null, _fakeRawUser()];
+      final List<dynamic> expectedValueMatchers = [
+        isA<FirebaseUser>(),
+        isNull,
+        isA<FirebaseUser>()
+      ];
+
+      test('non authenticated user present in stream', () async {
+        js.context['firebase']['auth'] = js.allowInterop((dynamic app) {
+          return js.JsObject.jsify(
+            <String, dynamic>{
+              'onAuthStateChanged': js.allowInterop(
+                  (js.JsFunction nextUserCb, js.JsFunction errorCb) {
+                if (!nextUserCallback.isCompleted) {
+                  nextUserCallback.complete(nextUserCb);
+                }
+                return js.allowInterop(() {});
+              }),
+            },
+          );
+        });
+
+        FirebaseAuth auth = FirebaseAuth.instance;
+
+        // Subscribe our spy function
+        auth.onAuthStateChanged
+            .listen((FirebaseUser user) => seenUsers.add(user));
+
+        // Capture the JS function that lets us push users to the Stream from JS.
+        js.JsFunction nextUser = await nextUserCallback.future;
+
+        streamValues.forEach((streamValue) => nextUser.apply([streamValue]));
+
+        for (int i = 0; i < expectedValueMatchers.length; i++) {
+          expect(seenUsers[i], expectedValueMatchers[i]);
+        }
+      });
+    });
   });
 }
 
@@ -64,5 +109,16 @@ js.JsObject _fakeUserCredential() {
       'providerData': <dynamic>[],
     },
     'additionalUserInfo': <String, dynamic>{},
+  });
+}
+
+js.JsObject _fakeRawUser() {
+  return js.JsObject.jsify(<String, dynamic>{
+    'providerId': 'email',
+    'metadata': <String, dynamic>{
+      'creationTime': 'Wed, 04 Dec 2019 18:19:11 GMT',
+      'lastSignInTime': 'Wed, 04 Dec 2019 18:19:11 GMT',
+    },
+    'providerData': <dynamic>[],
   });
 }

--- a/packages/firebase_auth/firebase_auth_web/test/mock/firebase_mock.dart
+++ b/packages/firebase_auth/firebase_auth_web/test/mock/firebase_mock.dart
@@ -1,0 +1,83 @@
+@JS()
+library firebase_mock;
+
+import 'package:js/js.dart';
+
+@JS()
+@anonymous
+class FirebaseAppOptionsMock {
+  external factory FirebaseAppOptionsMock({ String appId });
+  external String get appId;
+}
+
+@JS()
+@anonymous
+class FirebaseAppMock {
+  external factory FirebaseAppMock({ String name, FirebaseAppOptionsMock options });
+  external String get name;
+  external FirebaseAppOptionsMock get options;
+}
+
+@JS()
+@anonymous
+class FirebaseAuthMock {
+  external factory FirebaseAuthMock({ 
+    Function signInAnonymously, 
+    Function onAuthStateChanged, 
+  });
+  external Function get signInAnonymously;
+  external Function get onAuthStateChanged;
+}
+
+@JS()
+@anonymous
+class FirebaseMock {
+  external factory FirebaseMock({ Function app });
+  external Function get app;
+
+  external set auth(Function auth);
+  external Function get auth;
+}
+
+@JS()
+class Promise<T> {
+  external Promise(void executor(void resolve(T result), Function reject));
+  external Promise then(void onFulfilled(T result), [Function onRejected]);
+}
+
+@JS()
+@anonymous
+class MockUserMetadata {
+  external factory MockUserMetadata({ String creationTime, String lastSignInTime });
+  external String get creationTime;
+  external String get lastSignInTime;
+}
+
+@JS()
+@anonymous
+class MockUser {
+  external factory MockUser({ String providerId, MockUserMetadata metadata, List providerData });
+  external String get providerId;
+  external MockUserMetadata get metadata;
+  external List get providerData;
+}
+
+@JS()
+@anonymous
+class MockAdditionalUserInfo {
+    external factory MockAdditionalUserInfo();
+}
+
+@JS()
+@anonymous
+class MockUserCredential {
+  external factory MockUserCredential({ MockUser user, MockAdditionalUserInfo additionalUserInfo });
+  external MockUser get user;
+  external MockAdditionalUserInfo get additionalUserInfo;
+}
+
+// Wire to the global 'window.firebase' object.
+@JS('firebase')
+external set firebaseMock(FirebaseMock mock);
+@JS('firebase')
+external FirebaseMock get firebaseMock;

--- a/packages/firebase_auth/firebase_auth_web/test/mock/firebase_mock.dart
+++ b/packages/firebase_auth/firebase_auth_web/test/mock/firebase_mock.dart
@@ -6,14 +6,17 @@ import 'package:js/js.dart';
 @JS()
 @anonymous
 class FirebaseAppOptionsMock {
-  external factory FirebaseAppOptionsMock({ String appId });
+  external factory FirebaseAppOptionsMock({String appId});
   external String get appId;
 }
 
 @JS()
 @anonymous
 class FirebaseAppMock {
-  external factory FirebaseAppMock({ String name, FirebaseAppOptionsMock options });
+  external factory FirebaseAppMock({
+    String name,
+    FirebaseAppOptionsMock options,
+  });
   external String get name;
   external FirebaseAppOptionsMock get options;
 }
@@ -21,9 +24,9 @@ class FirebaseAppMock {
 @JS()
 @anonymous
 class FirebaseAuthMock {
-  external factory FirebaseAuthMock({ 
-    Function signInAnonymously, 
-    Function onAuthStateChanged, 
+  external factory FirebaseAuthMock({
+    Function signInAnonymously,
+    Function onAuthStateChanged,
   });
   external Function get signInAnonymously;
   external Function get onAuthStateChanged;
@@ -32,7 +35,7 @@ class FirebaseAuthMock {
 @JS()
 @anonymous
 class FirebaseMock {
-  external factory FirebaseMock({ Function app });
+  external factory FirebaseMock({Function app});
   external Function get app;
 
   external set auth(Function auth);
@@ -48,7 +51,10 @@ class Promise<T> {
 @JS()
 @anonymous
 class MockUserMetadata {
-  external factory MockUserMetadata({ String creationTime, String lastSignInTime });
+  external factory MockUserMetadata({
+    String creationTime,
+    String lastSignInTime,
+  });
   external String get creationTime;
   external String get lastSignInTime;
 }
@@ -56,7 +62,11 @@ class MockUserMetadata {
 @JS()
 @anonymous
 class MockUser {
-  external factory MockUser({ String providerId, MockUserMetadata metadata, List providerData });
+  external factory MockUser({
+    String providerId,
+    MockUserMetadata metadata,
+    List providerData,
+  });
   external String get providerId;
   external MockUserMetadata get metadata;
   external List get providerData;
@@ -65,13 +75,16 @@ class MockUser {
 @JS()
 @anonymous
 class MockAdditionalUserInfo {
-    external factory MockAdditionalUserInfo();
+  external factory MockAdditionalUserInfo();
 }
 
 @JS()
 @anonymous
 class MockUserCredential {
-  external factory MockUserCredential({ MockUser user, MockAdditionalUserInfo additionalUserInfo });
+  external factory MockUserCredential({
+    MockUser user,
+    MockAdditionalUserInfo additionalUserInfo,
+  });
   external MockUser get user;
   external MockAdditionalUserInfo get additionalUserInfo;
 }


### PR DESCRIPTION
## Description

Prevent `null` users (unauthenticated) from breaking the `onAuthStateChanged` stream.

## Related Issues

* https://github.com/FirebaseExtended/flutterfire/issues/1685

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] If the pull request affects only one plugin, the PR title starts with the name of the plugin in brackets (e.g. [cloud_firestore])
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
