### PR TITLE
[firebase_auth_web] Fix firebase auth test by wrapping Dart functions in js.allowInterop

### DIFF
--- a/packages/firebase_auth/firebase_auth_web/CHANGELOG.md
+++ b/packages/firebase_auth/firebase_auth_web/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.1+3
+
+* Fix the tests on dart2js.
+
 ## 0.1.1+2
 
 * Update setup instructions in the README.

--- a/packages/firebase_auth/firebase_auth_web/pubspec.yaml
+++ b/packages/firebase_auth/firebase_auth_web/pubspec.yaml
@@ -1,7 +1,7 @@
 name: firebase_auth_web
 description: The web implementation of firebase_auth
 homepage: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/firebase_auth/firebase_auth_web
-version: 0.1.1+2
+version: 0.1.1+3
 
 flutter:
   plugin:

--- a/packages/firebase_auth/firebase_auth_web/test/firebase_auth_web_test.dart
+++ b/packages/firebase_auth/firebase_auth_web/test/firebase_auth_web_test.dart
@@ -32,9 +32,9 @@ void main() {
       js.context['firebase']['auth'] = js.allowInterop((dynamic app) {
         return js.JsObject.jsify(
           <String, dynamic>{
-            'signInAnonymously': () {
+            'signInAnonymously': js.allowInterop(() {
               return _jsPromise(_fakeUserCredential());
-            },
+            }),
           },
         );
       });
@@ -47,9 +47,9 @@ void main() {
 
 js.JsObject _jsPromise(dynamic value) {
   return js.JsObject.jsify(<String, dynamic>{
-    'then': (js.JsFunction f) {
-      f.apply(<dynamic>[value]);
-    },
+    'then': js.allowInterop((js.JsFunction resolve, js.JsFunction reject) {
+      resolve.apply(<dynamic>[value]);
+    }),
   });
 }
 


### PR DESCRIPTION
## Description

Fix firebase auth test by wrapping Dart functions in js.allowInterop
And also fix the Promise.then mock. The JS version of Promise.then takes
two parameters.

Dart functions need to be wrapped in js.allowInterop to be called from
JavaScript. The current test is failing on dart2js.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] If the pull request affects only one plugin, the PR title starts with the name of the plugin in brackets (e.g. [cloud_firestore])
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.