### PR TITLE
[firebase_remote_config] Added fallback value strategy by adding optional orElse argument

### DIFF
--- a/packages/firebase_remote_config/CHANGELOG.md
+++ b/packages/firebase_remote_config/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.4.0
+
+* Added fallback strategy for getting values by optional adding function argument `orElse`  
+in `getString`, `getInt`, `getDouble`, `getBool` and `getValue`
+
 ## 0.3.0+1
 
 * Remove the deprecated `author:` field from pubspec.yaml

--- a/packages/firebase_remote_config/lib/src/remote_config.dart
+++ b/packages/firebase_remote_config/lib/src/remote_config.dart
@@ -174,60 +174,76 @@ class RemoteConfig extends ChangeNotifier {
 
   /// Gets the value corresponding to the [key] as a String.
   ///
-  /// If there is no parameter with corresponding [key] then the default
-  /// String value is returned.
-  String getString(String key) {
+  /// If there is no parameter with the corresponding [key],
+  /// then the function argument [orElse] is called, which can
+  /// specify the default value. If [orElse] is not specified,
+  /// a string default value is returned.
+  String getString(String key, {String Function() orElse}) {
     if (_parameters.containsKey(key)) {
       return _parameters[key].asString();
     } else {
-      return defaultValueForString;
+      return orElse?.call() ?? defaultValueForString;
     }
   }
 
   /// Gets the value corresponding to the [key] as an int.
   ///
-  /// If there is no parameter with corresponding [key] then the default
-  /// int value is returned.
-  int getInt(String key) {
+  /// If there is no parameter with the corresponding [key],
+  /// then the function argument [orElse] is called, which can
+  /// specify the default value. If [orElse] is not specified,
+  /// a int default value is returned.
+  int getInt(String key, {int Function() orElse}) {
     if (_parameters.containsKey(key)) {
       return _parameters[key].asInt();
     } else {
-      return defaultValueForInt;
+      return orElse?.call() ?? defaultValueForInt;
     }
   }
 
   /// Gets the value corresponding to the [key] as a double.
   ///
-  /// If there is no parameter with corresponding [key] then the default double
-  /// value is returned.
-  double getDouble(String key) {
+  /// If there is no parameter with the corresponding [key],
+  /// then the function argument [orElse] is called, which can
+  /// specify the default value. If [orElse] is not specified,
+  /// a double default value is returned.
+  double getDouble(String key, {double Function() orElse}) {
     if (_parameters.containsKey(key)) {
       return _parameters[key].asDouble();
     } else {
-      return defaultValueForDouble;
+      return orElse?.call() ?? defaultValueForDouble;
     }
   }
 
   /// Gets the value corresponding to the [key] as a bool.
   ///
-  /// If there is no parameter with corresponding [key] then the default bool
-  /// value is returned.
-  bool getBool(String key) {
+  /// If there is no parameter with the corresponding [key],
+  /// then the function argument [orElse] is called, which can
+  /// specify the default value. If [orElse] is not specified,
+  /// a bool default value is returned.
+  bool getBool(String key, {bool Function() orElse}) {
     if (_parameters.containsKey(key)) {
       return _parameters[key].asBool();
     } else {
-      return defaultValueForBool;
+      return orElse?.call() ?? defaultValueForBool;
     }
   }
 
   /// Gets the [RemoteConfigValue] corresponding to the [key].
   ///
-  /// If there is no parameter with corresponding key then a [RemoteConfigValue]
-  /// with a null value and static source is returned.
-  RemoteConfigValue getValue(String key) {
+  /// If there is no parameter with the corresponding [key],
+  /// then the function argument [orElse] is called, which can
+  /// specify the default value. If [orElse] is not specified,
+  /// a [RemoteConfigValue] with a null value and static source is returned..
+  RemoteConfigValue getValue(
+    String key, {
+    List<int> Function() orElse,
+  }) {
     if (_parameters.containsKey(key)) {
       return _parameters[key];
     } else {
+      if (orElse != null) {
+        return RemoteConfigValue._(orElse(), ValueSource.valueDefault);
+      }
       return RemoteConfigValue._(null, ValueSource.valueStatic);
     }
   }

--- a/packages/firebase_remote_config/pubspec.yaml
+++ b/packages/firebase_remote_config/pubspec.yaml
@@ -2,7 +2,7 @@ name: firebase_remote_config
 description: Flutter plugin for Firebase Remote Config. Update your application look and feel and behaviour without
   re-releasing.
 homepage: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/firebase_remote_config
-version: 0.3.0+1
+version: 0.4.0
 
 dependencies:
   flutter:

--- a/packages/firebase_remote_config/test/firebase_remote_config_test.dart
+++ b/packages/firebase_remote_config/test/firebase_remote_config_test.dart
@@ -217,6 +217,31 @@ void main() {
       });
     });
 
+    test('fallback', () {
+      final key = 'not_existing_key';
+      // String
+      expect(remoteConfig.getString(key, orElse: () => 'result'), 'result');
+      expect(remoteConfig.getString(key), RemoteConfig.defaultValueForString);
+      // int
+      expect(remoteConfig.getInt(key, orElse: () => 111), 111);
+      expect(remoteConfig.getInt(key), RemoteConfig.defaultValueForInt);
+      // double
+      expect(remoteConfig.getDouble(key, orElse: () => 1.23), 1.23);
+      expect(remoteConfig.getDouble(key), RemoteConfig.defaultValueForDouble);
+      // bool
+      expect(remoteConfig.getBool(key, orElse: () => true), true);
+      expect(remoteConfig.getBool(key), RemoteConfig.defaultValueForBool);
+      // RemoteConfigValue
+      final List<int> aSymbol = [97]; // utf8 encoded "a" character
+      final fallbackValue = remoteConfig.getValue(key, orElse: () => aSymbol);
+      expect(fallbackValue.asString(), 'a');
+      expect(fallbackValue.source, ValueSource.valueDefault);
+
+      final defaultValue = remoteConfig.getValue(key);
+      expect(defaultValue.asString(), RemoteConfig.defaultValueForString);
+      expect(defaultValue.source, ValueSource.valueStatic);
+    });
+
     test('setConfigSettings', () async {
       expect(remoteConfig.remoteConfigSettings.debugMode, true);
       final RemoteConfigSettings remoteConfigSettings =


### PR DESCRIPTION
## Description

Added fallback strategy for getting values by optional adding function argument `orElse`  
in `getString`, `getInt`, `getDouble`, `getBool` and `getValue` like a `List().firstWhere(null, orElse: () => /* fallback */);`

Before:
```dart
await remoteConfig.setDefaults(<String, dynamic>{
    'foo': 'bar',
    'first': true,
    'last': 123,
});

remoteConfig.getString('foo');
remoteConfig.getBool('first');
remoteConfig.getInt('last');

// Cannot be override not existing key
remoteConfig.getString('not_existing_string'); // always return empty string ''
```

After:
```dart
remoteConfig.getString('foo', orElse: () => 'bar');
remoteConfig.getBool('first',  orElse: () => true);
remoteConfig.getInt('last',  orElse: () => 123);

// Can be override not existing key
remoteConfig.getString('not_existing_string', orElse: () => 'overridden value');
```

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] If the pull request affects only one plugin, the PR title starts with the name of the plugin in brackets (e.g. [cloud_firestore])
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
