### PR TITLE
[firebase_crashlytics] Fix parsing of traces that don't contain a line number

### DIFF
--- a/packages/firebase_crashlytics/lib/src/firebase_crashlytics.dart
+++ b/packages/firebase_crashlytics/lib/src/firebase_crashlytics.dart
@@ -162,32 +162,25 @@ class Crashlytics {
     for (String line in lines) {
       final List<String> lineParts = line.split(RegExp('\\s+'));
       try {
-        final String fileName = lineParts[0];
-        final String lineNumber = lineParts[1].contains(":")
-            ? lineParts[1].substring(0, lineParts[1].indexOf(":")).trim()
-            : lineParts[1];
+        final String fileName = lineParts.first;
+
+        // Sometimes the trace looks like [<file>,<methodField>] and doesn't contain a line field
+        final String lineNumber =
+            lineParts.length > 2 ? lineParts[1].split(":").first : "0";
 
         final Map<String, String> element = <String, String>{
           'file': fileName,
           'line': lineNumber,
         };
 
-        // The next section would throw an exception in some cases if there was no stop here.
-        if (lineParts.length < 3) {
-          elements.add(element);
-          continue;
-        }
+        final List<String> methodField = lineParts.last.split(".");
 
-        if (lineParts[2].contains(".")) {
-          final String className =
-              lineParts[2].substring(0, lineParts[2].indexOf(".")).trim();
-          final String methodName =
-              lineParts[2].substring(lineParts[2].indexOf(".") + 1).trim();
+        final String className = methodField.first.trim();
+        element['class'] = className;
 
-          element['class'] = className;
+        if (methodField.length > 1) {
+          final String methodName = methodField.last.trim();
           element['method'] = methodName;
-        } else {
-          element['method'] = lineParts[2];
         }
 
         elements.add(element);

--- a/packages/firebase_crashlytics/lib/src/firebase_crashlytics.dart
+++ b/packages/firebase_crashlytics/lib/src/firebase_crashlytics.dart
@@ -175,12 +175,12 @@ class Crashlytics {
 
         final List<String> methodField = lineParts.last.split(".");
 
-        final String className = methodField.first.trim();
-        element['class'] = className;
+        final String methodName = methodField.last.trim();
+        element['method'] = methodName;
 
         if (methodField.length > 1) {
-          final String methodName = methodField.last.trim();
-          element['method'] = methodName;
+          final String className = methodField.first.trim();
+          element['class'] = className;
         }
 
         elements.add(element);


### PR DESCRIPTION

## Description

Sometimes the traces don't contain a line number which made the parsing fail, it should now be fixed.

## Related Issues

Might be related to #1288

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] If the pull request affects only one plugin, the PR title starts with the name of the plugin in brackets (e.g. [cloud_firestore])
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
