### PR TITLE
Ensure Firestore example widgets are initialized

### DIFF
--- a/packages/cloud_firestore/cloud_firestore/example/lib/main.dart
+++ b/packages/cloud_firestore/cloud_firestore/example/lib/main.dart
@@ -9,6 +9,7 @@ import 'package:firebase_core/firebase_core.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 
 Future<void> main() async {
+  WidgetsFlutterBinding.ensureInitialized();
   final FirebaseApp app = await FirebaseApp.configure(
     name: 'test',
     options: const FirebaseOptions(


### PR DESCRIPTION
Firestore example risks widgets not being initialized resulting in an exception eg: `E/flutter (32544): [ERROR:flutter/lib/ui/ui_dart_state.cc(157)] Unhandled Exception: ServicesBinding.defaultBinaryMessenger was accessed before the binding was initialized.`. This PR adds `WidgetsFlutterBinding.ensureInitialized()` to ensure that this exception is avoided.