### PR TITLE
[cloud_functions] Fix method channel name

### DIFF
--- a/packages/cloud_functions/cloud_functions_platform_interface/CHANGELOG.md
+++ b/packages/cloud_functions/cloud_functions_platform_interface/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.0.0+1
+## 1.0.1
 
 * Fix plugin name in MethodChannel
 

--- a/packages/cloud_functions/cloud_functions_platform_interface/CHANGELOG.md
+++ b/packages/cloud_functions/cloud_functions_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.0+1
+
+* Fix plugin name in MethodChannel
+
 ## 1.0.0
 
 Initial release

--- a/packages/cloud_functions/cloud_functions_platform_interface/lib/src/method_channel_cloud_functions.dart
+++ b/packages/cloud_functions/cloud_functions_platform_interface/lib/src/method_channel_cloud_functions.dart
@@ -9,7 +9,7 @@ class MethodChannelCloudFunctions extends CloudFunctionsPlatform {
   /// The [MethodChannel] to which calls will be delegated.
   @visibleForTesting
   static const MethodChannel channel = MethodChannel(
-    'plugins.flutter.io/cloud_functions',
+    'cloud_functions',
   );
 
   /// Invokes the specified cloud function.

--- a/packages/cloud_functions/cloud_functions_platform_interface/lib/src/method_channel_cloud_functions.dart
+++ b/packages/cloud_functions/cloud_functions_platform_interface/lib/src/method_channel_cloud_functions.dart
@@ -7,6 +7,8 @@ part of cloud_functions_platform_interface;
 /// [CloudFunctionsPlatform] implementation that delegates to a [MethodChannel].
 class MethodChannelCloudFunctions extends CloudFunctionsPlatform {
   /// The [MethodChannel] to which calls will be delegated.
+  /// Note that this name must match the name used in the platform (iOS/Android)
+  /// plugin.
   @visibleForTesting
   static const MethodChannel channel = MethodChannel(
     'cloud_functions',

--- a/packages/cloud_functions/cloud_functions_platform_interface/pubspec.yaml
+++ b/packages/cloud_functions/cloud_functions_platform_interface/pubspec.yaml
@@ -3,7 +3,7 @@ description: A common platform interface for the cloud_functions plugin.
 homepage: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/cloud_functions/cloud_functions_platform_interface
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 1.0.0
+version: 1.0.0+1
 
 dependencies:
   flutter:

--- a/packages/cloud_functions/cloud_functions_platform_interface/pubspec.yaml
+++ b/packages/cloud_functions/cloud_functions_platform_interface/pubspec.yaml
@@ -3,7 +3,7 @@ description: A common platform interface for the cloud_functions plugin.
 homepage: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/cloud_functions/cloud_functions_platform_interface
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 1.0.0+1
+version: 1.0.1
 
 dependencies:
   flutter:


### PR DESCRIPTION
## Description

In implementing the `MethodChannelCloudFunctions` I assigned the wrong name to the channel. This meant that the tests passed (because the channel was being invoked) but that when the cloud_functions plugin with iOS or Android implementations was used, the invocation would fail because the channel wouldn't be found.

This change fixes the method channel name so that it matches the name being registered by the iOS and Android plugins.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] If the pull request affects only one plugin, the PR title starts with the name of the plugin in brackets (e.g. [cloud_firestore])
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [x] No, this is *not* a breaking change.
