### PR TITLE
[cloud_functions] No implementation found for method CloudFunctions#call

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -45,3 +45,4 @@ SoundReply Solutions GmbH <ch@soundreply.com>
 Michel Feinstein <michel@feinstein.com.br>
 Tobias Löfstrand <tobias@leafnode.se>
 Stephen Beitzel <sbeitzel@pobox.com>
+Mark Veenstra <markdark81@gmail.com>

--- a/packages/cloud_functions/cloud_functions/CHANGELOG.md
+++ b/packages/cloud_functions/cloud_functions/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.4.1+8
+
+* Fixes the `No implementation found for method CloudFunctions#call`
+
 ## 0.4.1+7
 
 * Update to use the platform interface to execute calls.

--- a/packages/cloud_functions/cloud_functions/android/src/main/java/io/flutter/plugins/firebase/cloudfunctions/CloudFunctionsPlugin.java
+++ b/packages/cloud_functions/cloud_functions/android/src/main/java/io/flutter/plugins/firebase/cloudfunctions/CloudFunctionsPlugin.java
@@ -25,7 +25,8 @@ import java.util.concurrent.TimeUnit;
 public class CloudFunctionsPlugin implements MethodCallHandler {
   /** Plugin registration. */
   public static void registerWith(Registrar registrar) {
-    final MethodChannel channel = new MethodChannel(registrar.messenger(), "plugins.flutter.io/cloud_functions");
+    final MethodChannel channel =
+        new MethodChannel(registrar.messenger(), "plugins.flutter.io/cloud_functions");
     channel.setMethodCallHandler(new CloudFunctionsPlugin());
   }
 

--- a/packages/cloud_functions/cloud_functions/android/src/main/java/io/flutter/plugins/firebase/cloudfunctions/CloudFunctionsPlugin.java
+++ b/packages/cloud_functions/cloud_functions/android/src/main/java/io/flutter/plugins/firebase/cloudfunctions/CloudFunctionsPlugin.java
@@ -25,7 +25,7 @@ import java.util.concurrent.TimeUnit;
 public class CloudFunctionsPlugin implements MethodCallHandler {
   /** Plugin registration. */
   public static void registerWith(Registrar registrar) {
-    final MethodChannel channel = new MethodChannel(registrar.messenger(), "cloud_functions");
+    final MethodChannel channel = new MethodChannel(registrar.messenger(), "plugins.flutter.io/cloud_functions");
     channel.setMethodCallHandler(new CloudFunctionsPlugin());
   }
 

--- a/packages/cloud_functions/cloud_functions/ios/Classes/CloudFunctionsPlugin.m
+++ b/packages/cloud_functions/cloud_functions/ios/Classes/CloudFunctionsPlugin.m
@@ -15,7 +15,7 @@
 
 + (void)registerWithRegistrar:(NSObject<FlutterPluginRegistrar> *)registrar {
   FlutterMethodChannel *channel =
-      [FlutterMethodChannel methodChannelWithName:@"cloud_functions"
+      [FlutterMethodChannel methodChannelWithName:@"plugins.flutter.io/cloud_functions"
                                   binaryMessenger:[registrar messenger]];
   CloudFunctionsPlugin *instance = [[CloudFunctionsPlugin alloc] init];
   [registrar addMethodCallDelegate:instance channel:channel];

--- a/packages/cloud_functions/cloud_functions/pubspec.yaml
+++ b/packages/cloud_functions/cloud_functions/pubspec.yaml
@@ -1,6 +1,6 @@
 name: cloud_functions
 description: Flutter plugin for Cloud Functions.
-version: 0.4.1+7
+version: 0.4.1+8
 homepage: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/cloud_functions/cloud_functions
 
 flutter:


### PR DESCRIPTION
## Description

Solves the error `No implementation found for method CloudFunctions#call` introduced in the `0.4.1+7` release

## Related Issues

#1866 

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] If the pull request affects only one plugin, the PR title starts with the name of the plugin in brackets (e.g. [cloud_firestore])
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]). **NO CHANGES**
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

It even solves a break from the `0.4.1+7` release

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
