### PR TITLE
[cloud_functions] Integration test on iOS should turn build red on failure

### DIFF
--- a/packages/cloud_functions/cloud_functions/CHANGELOG.md
+++ b/packages/cloud_functions/cloud_functions/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.4.1+8
+
+* Ensure that integration test failures on iOS turn the build red.
+
 ## 0.4.1+7
 
 * Update to use the platform interface to execute calls.

--- a/packages/cloud_functions/cloud_functions/example/pubspec.yaml
+++ b/packages/cloud_functions/cloud_functions/example/pubspec.yaml
@@ -12,6 +12,7 @@ dependencies:
   firebase_core: ^0.4.0
 
 dev_dependencies:
+  e2e: ^0.2.1
   flutter_test:
     sdk: flutter
   flutter_driver:

--- a/packages/cloud_functions/cloud_functions/example/test/cloud_functions.dart
+++ b/packages/cloud_functions/cloud_functions/example/test/cloud_functions.dart
@@ -3,17 +3,15 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'dart:async';
-import 'package:flutter_driver/driver_extension.dart';
+import 'package:e2e/e2e.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:cloud_functions/cloud_functions.dart';
 
 void main() {
-  final Completer<String> completer = Completer<String>();
-  enableFlutterDriverExtension(handler: (_) => completer.future);
-  tearDownAll(() => completer.complete(null));
+  E2EWidgetsFlutterBinding.ensureInitialized();
 
   group('$CloudFunctions', () {
-    test('call', () async {
+    testWidgets('call', (_) async {
       // default timeout
       final HttpsCallable callable =
           CloudFunctions.instance.getHttpsCallable(functionName: 'repeat');

--- a/packages/cloud_functions/cloud_functions/example/test/cloud_functions.dart
+++ b/packages/cloud_functions/cloud_functions/example/test/cloud_functions.dart
@@ -2,7 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'dart:async';
 import 'package:e2e/e2e.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:cloud_functions/cloud_functions.dart';

--- a/packages/cloud_functions/cloud_functions/example/test_driver/cloud_functions_test.dart
+++ b/packages/cloud_functions/cloud_functions/example/test_driver/cloud_functions_test.dart
@@ -2,11 +2,15 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+import 'dart:async';
+import 'dart:io';
+
 import 'package:flutter_driver/flutter_driver.dart';
 
 Future<void> main() async {
   final FlutterDriver driver = await FlutterDriver.connect();
-  await driver.requestData(null, timeout: const Duration(minutes: 1));
+  final String result =
+      await driver.requestData(null, timeout: const Duration(minutes: 1));
   await driver.close();
   exit(result == 'pass' ? 0 : 1);
 }

--- a/packages/cloud_functions/cloud_functions/example/test_driver/cloud_functions_test.dart
+++ b/packages/cloud_functions/cloud_functions/example/test_driver/cloud_functions_test.dart
@@ -8,4 +8,5 @@ Future<void> main() async {
   final FlutterDriver driver = await FlutterDriver.connect();
   await driver.requestData(null, timeout: const Duration(minutes: 1));
   await driver.close();
+  exit(result == 'pass' ? 0 : 1);
 }

--- a/packages/cloud_functions/cloud_functions/pubspec.yaml
+++ b/packages/cloud_functions/cloud_functions/pubspec.yaml
@@ -13,6 +13,7 @@ flutter:
         pluginClass: CloudFunctionsPlugin
 
 dependencies:
+  e2e: ^0.2.1
   meta: ^1.1.6
   flutter:
     sdk: flutter

--- a/packages/cloud_functions/cloud_functions/pubspec.yaml
+++ b/packages/cloud_functions/cloud_functions/pubspec.yaml
@@ -1,6 +1,6 @@
 name: cloud_functions
 description: Flutter plugin for Cloud Functions.
-version: 0.4.1+7
+version: 0.4.1+8
 homepage: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/cloud_functions/cloud_functions
 
 flutter:


### PR DESCRIPTION
Ensures that iOS test failures are caught by our CI.

Related issue: https://github.com/FirebaseExtended/flutterfire/issues/1866