### PR TITLE
Fix fallthrough bug

### DIFF
--- a/packages/firebase_auth/firebase_auth/CHANGELOG.md
+++ b/packages/firebase_auth/firebase_auth/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.15.4+1
+
+* Fix fallthrough bug in Android code.
+
 ## 0.15.4
 
 * Add support for `confirmPasswordReset` on Android and iOS.

--- a/packages/firebase_auth/firebase_auth/android/src/main/java/io/flutter/plugins/firebaseauth/FirebaseAuthPlugin.java
+++ b/packages/firebase_auth/firebase_auth/android/src/main/java/io/flutter/plugins/firebaseauth/FirebaseAuthPlugin.java
@@ -167,6 +167,7 @@ public class FirebaseAuthPlugin implements MethodCallHandler {
         break;
       case "confirmPasswordReset":
         handleConfirmPasswordReset(call, result, getAuth(call));
+        break;
       default:
         result.notImplemented();
         break;

--- a/packages/firebase_auth/firebase_auth/pubspec.yaml
+++ b/packages/firebase_auth/firebase_auth/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for Firebase Auth, enabling Android and iOS
   authentication using passwords, phone numbers and identity providers
   like Google, Facebook and Twitter.
 homepage: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/firebase_auth/firebase_auth
-version: 0.15.4
+version: 0.15.4+1
 
 flutter:
   plugin:


### PR DESCRIPTION
This was caught during google3 roll. When `confirmPasswordReset` is called, it will throw a `notImplemented` error since there's no break in the case statement.