### PR TITLE
[firebase_core] Updated documentation for FirebaseOptions.apiKey

### DIFF
--- a/packages/firebase_core/firebase_core_platform_interface/lib/src/firebase_options.dart
+++ b/packages/firebase_core/firebase_core_platform_interface/lib/src/firebase_options.dart
@@ -40,7 +40,7 @@ class FirebaseOptions {
   /// "AIzaSyDdVgKwhZl0sTTTLZ7iTmt1r3N2cJLnaDk", used to identify your app to
   /// Google servers.
   ///
-  /// This property is required on Android.
+  /// This property is required on Android and iOS.
   final String apiKey;
 
   /// The iOS bundle ID for the application. Defaults to


### PR DESCRIPTION
## Description

Due to changes in the newest version of [firebase-ios-sdk](https://github.com/firebase/firebase-ios-sdk) plugin, now `FirebaseOptions.apiKey` is required also on iOS. Not passing this property in the Dart code results with an error:
```
Could not configure Firebase Installations due to invalid FirebaseApp options. The following parameters are nil or empty: `FirebaseOptions.APIKey`
```

Link to the change in iOS plugin: https://github.com/firebase/firebase-ios-sdk/blob/master/FirebaseInstallations/Source/Library/FIRInstallations.m#L127
Link to the PR with change: https://github.com/firebase/firebase-ios-sdk/pull/4683

## Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] If the pull request affects only one plugin, the PR title starts with the name of the plugin in brackets (e.g. [cloud_firestore])
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [X] All existing and new tests are passing.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [X] I read and followed the [Flutter Style Guide].
- [ ] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [ ] I updated CHANGELOG.md to add a description of the change.
- [X] I signed the [CLA].
- [X] I am willing to follow-up on review comments in a timely manner.

## Breaking Change
- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [X] No, this is *not* a breaking change.
