### PR TITLE
[cloud_functions] create no-op stubs for iOS/Android in cloud_functions_web

### DIFF
--- a/packages/cloud_functions/cloud_functions_web/.metadata
+++ b/packages/cloud_functions/cloud_functions_web/.metadata
@@ -1,0 +1,10 @@
+# This file tracks properties of this Flutter project.
+# Used by Flutter tool to assess capabilities and perform upgrades etc.
+#
+# This file should be version controlled and should not be manually edited.
+
+version:
+  revision: 659dc8129d4edb9166e9a0d600439d135740933f
+  channel: beta
+
+project_type: plugin

--- a/packages/cloud_functions/cloud_functions_web/CHANGELOG.md
+++ b/packages/cloud_functions/cloud_functions_web/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.0.0+1
+## 1.0.1
 
 Add no-op plugin implementations for iOS and Android to enable builds.
 

--- a/packages/cloud_functions/cloud_functions_web/CHANGELOG.md
+++ b/packages/cloud_functions/cloud_functions_web/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.0+1
+
+Add no-op plugin implementations for iOS and Android to enable builds.
+
 ## 1.0.0
 
 Initial release

--- a/packages/cloud_functions/cloud_functions_web/android/.gitignore
+++ b/packages/cloud_functions/cloud_functions_web/android/.gitignore
@@ -1,0 +1,8 @@
+*.iml
+.gradle
+/local.properties
+/.idea/workspace.xml
+/.idea/libraries
+.DS_Store
+/build
+/captures

--- a/packages/cloud_functions/cloud_functions_web/android/build.gradle
+++ b/packages/cloud_functions/cloud_functions_web/android/build.gradle
@@ -32,7 +32,6 @@ android {
     }
     defaultConfig {
         minSdkVersion 16
-        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
     lintOptions {
         disable 'InvalidPackage'

--- a/packages/cloud_functions/cloud_functions_web/android/build.gradle
+++ b/packages/cloud_functions/cloud_functions_web/android/build.gradle
@@ -1,0 +1,44 @@
+group 'io.flutter.plugins.cloud_functions_web'
+version '1.0'
+
+buildscript {
+    ext.kotlin_version = '1.3.50'
+    repositories {
+        google()
+        jcenter()
+    }
+
+    dependencies {
+        classpath 'com.android.tools.build:gradle:3.5.0'
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
+    }
+}
+
+rootProject.allprojects {
+    repositories {
+        google()
+        jcenter()
+    }
+}
+
+apply plugin: 'com.android.library'
+apply plugin: 'kotlin-android'
+
+android {
+    compileSdkVersion 28
+
+    sourceSets {
+        main.java.srcDirs += 'src/main/kotlin'
+    }
+    defaultConfig {
+        minSdkVersion 16
+        testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
+    }
+    lintOptions {
+        disable 'InvalidPackage'
+    }
+}
+
+dependencies {
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+}

--- a/packages/cloud_functions/cloud_functions_web/android/gradle.properties
+++ b/packages/cloud_functions/cloud_functions_web/android/gradle.properties
@@ -1,0 +1,4 @@
+org.gradle.jvmargs=-Xmx1536M
+android.enableR8=true
+android.useAndroidX=true
+android.enableJetifier=true

--- a/packages/cloud_functions/cloud_functions_web/android/gradle.properties
+++ b/packages/cloud_functions/cloud_functions_web/android/gradle.properties
@@ -1,4 +1,2 @@
 org.gradle.jvmargs=-Xmx1536M
 android.enableR8=true
-android.useAndroidX=true
-android.enableJetifier=true

--- a/packages/cloud_functions/cloud_functions_web/android/gradle/wrapper/gradle-wrapper.properties
+++ b/packages/cloud_functions/cloud_functions_web/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,0 +1,5 @@
+distributionBase=GRADLE_USER_HOME
+distributionPath=wrapper/dists
+zipStoreBase=GRADLE_USER_HOME
+zipStorePath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.2-all.zip

--- a/packages/cloud_functions/cloud_functions_web/android/settings.gradle
+++ b/packages/cloud_functions/cloud_functions_web/android/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'cloud_functions_web'

--- a/packages/cloud_functions/cloud_functions_web/android/src/main/AndroidManifest.xml
+++ b/packages/cloud_functions/cloud_functions_web/android/src/main/AndroidManifest.xml
@@ -1,0 +1,3 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+  package="io.flutter.plugins.cloud_functions_web">
+</manifest>

--- a/packages/cloud_functions/cloud_functions_web/android/src/main/kotlin/com/example/cloud_functions_web/CloudFunctionsWebPlugin.kt
+++ b/packages/cloud_functions/cloud_functions_web/android/src/main/kotlin/com/example/cloud_functions_web/CloudFunctionsWebPlugin.kt
@@ -1,0 +1,31 @@
+package com.example.cloud_functions_web
+
+import androidx.annotation.NonNull;
+import io.flutter.embedding.engine.plugins.FlutterPlugin
+import io.flutter.plugin.common.MethodCall
+import io.flutter.plugin.common.MethodChannel
+import io.flutter.plugin.common.MethodChannel.MethodCallHandler
+import io.flutter.plugin.common.MethodChannel.Result
+import io.flutter.plugin.common.PluginRegistry.Registrar
+
+/** CloudFunctionsWebPlugin */
+public class CloudFunctionsWebPlugin: FlutterPlugin, MethodCallHandler {
+  override fun onAttachedToEngine(@NonNull flutterPluginBinding: FlutterPlugin.FlutterPluginBinding) { }
+
+  // This static function is optional and equivalent to onAttachedToEngine. It supports the old
+  // pre-Flutter-1.12 Android projects. You are encouraged to continue supporting
+  // plugin registration via this function while apps migrate to use the new Android APIs
+  // post-flutter-1.12 via https://flutter.dev/go/android-project-migration.
+  //
+  // It is encouraged to share logic between onAttachedToEngine and registerWith to keep
+  // them functionally equivalent. Only one of onAttachedToEngine or registerWith will be called
+  // depending on the user's project. onAttachedToEngine or registerWith must both be defined
+  // in the same class.
+  companion object {
+    @JvmStatic
+    fun registerWith(registrar: Registrar) { }
+  }
+
+  override fun onDetachedFromEngine(@NonNull binding: FlutterPlugin.FlutterPluginBinding) {
+  }
+}

--- a/packages/cloud_functions/cloud_functions_web/android/src/main/kotlin/io/flutter/plugins/cloud_functions_web/CloudFunctionsWebPlugin.kt
+++ b/packages/cloud_functions/cloud_functions_web/android/src/main/kotlin/io/flutter/plugins/cloud_functions_web/CloudFunctionsWebPlugin.kt
@@ -1,6 +1,5 @@
-package com.example.cloud_functions_web
+package io.flutter.plugins.cloud_functions_web
 
-import androidx.annotation.NonNull;
 import io.flutter.embedding.engine.plugins.FlutterPlugin
 import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
@@ -10,7 +9,7 @@ import io.flutter.plugin.common.PluginRegistry.Registrar
 
 /** CloudFunctionsWebPlugin */
 public class CloudFunctionsWebPlugin: FlutterPlugin, MethodCallHandler {
-  override fun onAttachedToEngine(@NonNull flutterPluginBinding: FlutterPlugin.FlutterPluginBinding) { }
+  override fun onAttachedToEngine(flutterPluginBinding: FlutterPlugin.FlutterPluginBinding) { }
 
   // This static function is optional and equivalent to onAttachedToEngine. It supports the old
   // pre-Flutter-1.12 Android projects. You are encouraged to continue supporting
@@ -26,6 +25,6 @@ public class CloudFunctionsWebPlugin: FlutterPlugin, MethodCallHandler {
     fun registerWith(registrar: Registrar) { }
   }
 
-  override fun onDetachedFromEngine(@NonNull binding: FlutterPlugin.FlutterPluginBinding) {
+  override fun onDetachedFromEngine(binding: FlutterPlugin.FlutterPluginBinding) {
   }
 }

--- a/packages/cloud_functions/cloud_functions_web/ios/cloud_functions_web.podspec
+++ b/packages/cloud_functions/cloud_functions_web/ios/cloud_functions_web.podspec
@@ -1,0 +1,23 @@
+#
+# To learn more about a Podspec see http://guides.cocoapods.org/syntax/podspec.html.
+# Run `pod lib lint cloud_functions_web.podspec' to validate before publishing.
+#
+Pod::Spec.new do |s|
+  s.name             = 'cloud_functions_web'
+  s.version          = '1.0.0'
+  s.summary          = 'No-op implementation of cloud_functions_web plugin to avoid iOS build issues'
+  s.description      = <<-DESC
+Stub/fake cloud_functions_web plugin
+                       DESC
+  s.homepage         = 'https://github.com/FirebaseExtended/flutterfire/tree/master/packages/cloud_functions/cloud_functions_web'
+  s.license          = { :file => '../LICENSE' }
+  s.author           = { 'Flutter Team' => 'flutter-dev@googlegroups.com' }
+  s.source           = { :path => '.' }
+  s.source_files = 'Classes/**/*'
+  s.dependency 'Flutter'
+  s.platform = :ios, '8.0'
+
+  # Flutter.framework does not contain a i386 slice. Only x86_64 simulators are supported.
+  s.pod_target_xcconfig = { 'DEFINES_MODULE' => 'YES', 'VALID_ARCHS[sdk=iphonesimulator*]' => 'x86_64' }
+  s.swift_version = '5.0'
+end

--- a/packages/cloud_functions/cloud_functions_web/pubspec.yaml
+++ b/packages/cloud_functions/cloud_functions_web/pubspec.yaml
@@ -1,7 +1,7 @@
 name: cloud_functions_web
 description: The web implementation of cloud_functions
 homepage: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/cloud_functions/cloud_functions_web
-version: 1.0.0
+version: 1.0.0+1
 
 flutter:
   plugin:

--- a/packages/cloud_functions/cloud_functions_web/pubspec.yaml
+++ b/packages/cloud_functions/cloud_functions_web/pubspec.yaml
@@ -1,7 +1,7 @@
 name: cloud_functions_web
 description: The web implementation of cloud_functions
 homepage: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/cloud_functions/cloud_functions_web
-version: 1.0.0+1
+version: 1.0.1
 
 flutter:
   plugin:


### PR DESCRIPTION
## Description

To make builds work for iOS and Android, this PR adds no-op plugin stubs for the `cloud_functions_web` plugin for those platforms.

## Related Issues

flutter/flutter#45299

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] If the pull request affects only one plugin, the PR title starts with the name of the plugin in brackets (e.g. [cloud_firestore])
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [x] No, this is *not* a breaking change.
