### PR TITLE
[cloud_firestore] Fix crashes when using DocumentReference with Query

### DIFF
--- a/packages/cloud_firestore/cloud_firestore/CHANGELOG.md
+++ b/packages/cloud_firestore/cloud_firestore/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.13.1+1
+
+* Fixed crashes when using `Query#where` with `DocumentReference` objects
+
 ## 0.13.1
 
 * Migrate to `cloud_firestore_platform_interface`.

--- a/packages/cloud_firestore/cloud_firestore/example/test_driver/cloud_firestore.dart
+++ b/packages/cloud_firestore/cloud_firestore/example/test_driver/cloud_firestore.dart
@@ -372,5 +372,67 @@ void main() {
       expect(snapshot1.documentID, 'la');
       expect(snapshot2.documentID, 'tokyo');
     });
+
+    test('Query.whereArrayContainsAny using DocumentReference', () async {
+      final CollectionReference ref = firestore.collection('messages');
+      await ref.document('test-docRef-1').setData({"message": "1"});
+      await ref.document('test-docRef-2').setData({"message": "2"});
+
+      await ref.document('test-docRef').setData(<String, dynamic>{
+        'children': <DocumentReference>[
+          ref.document("test-docRef-1"),
+          ref.document("test-docRef-2")
+        ],
+      });
+
+      final QuerySnapshot snapshot = await ref.where('children',
+          arrayContainsAny: <DocumentReference>[
+            ref.document("test-docRef-1"),
+            ref.document("test-docRef-2")
+          ]).getDocuments();
+      final List<DocumentSnapshot> results = snapshot.documents;
+      expect(results.length, 1);
+      final DocumentSnapshot actual = results[0];
+      expect(actual.documentID, 'test-docRef');
+    });
+
+    test('Query.whereIn using DocumentReference', () async {
+      final CollectionReference ref = firestore.collection('messages');
+      await ref.document('test-docRef-1').setData({"message": "1"});
+      await ref.document('test-docRef-2').setData({"message": "2"});
+
+      final QuerySnapshot snapshot = await ref.where(FieldPath.documentId,
+          whereIn: <DocumentReference>[
+            ref.document("test-docRef-1"),
+            ref.document("test-docRef-2")
+          ]).getDocuments();
+      final List<DocumentSnapshot> results = snapshot.documents;
+      expect(results.length, 2);
+      expect(results.where((item) => item.documentID == "test-docRef-1").length,
+          equals(1));
+      expect(results.where((item) => item.documentID == "test-docRef-2").length,
+          equals(1));
+    });
+
+    test('Query.arrayContains using DocumentReference', () async {
+      final CollectionReference ref = firestore.collection('messages');
+      await ref.document('test-docRef-1').setData({"message": "1"});
+      await ref.document('test-docRef-2').setData({"message": "2"});
+
+      await ref.document('test-docRef').setData(<String, dynamic>{
+        'children': <DocumentReference>[
+          ref.document("test-docRef-1"),
+          ref.document("test-docRef-2")
+        ],
+      });
+
+      final QuerySnapshot snapshot = await ref
+          .where('children', arrayContains: ref.document("test-docRef-1"))
+          .getDocuments();
+      final List<DocumentSnapshot> results = snapshot.documents;
+      expect(results.length, 1);
+      final DocumentSnapshot actual = results[0];
+      expect(actual.documentID, 'test-docRef');
+    });
   });
 }

--- a/packages/cloud_firestore/cloud_firestore/lib/src/query.dart
+++ b/packages/cloud_firestore/cloud_firestore/lib/src/query.dart
@@ -66,15 +66,17 @@ class Query {
     bool isNull,
   }) =>
       Query._(
-          _delegate.where(field,
-              isEqualTo: isEqualTo,
-              isLessThan: isLessThan,
-              isLessThanOrEqualTo: isLessThanOrEqualTo,
-              isGreaterThan: isGreaterThan,
-              isGreaterThanOrEqualTo: isGreaterThanOrEqualTo,
-              arrayContainsAny: arrayContainsAny,
-              arrayContains: arrayContains,
-              whereIn: whereIn,
+          _delegate.where(_CodecUtility.valueEncode(field),
+              isEqualTo: _CodecUtility.valueEncode(isEqualTo),
+              isLessThan: _CodecUtility.valueEncode(isLessThan),
+              isLessThanOrEqualTo:
+                  _CodecUtility.valueEncode(isLessThanOrEqualTo),
+              isGreaterThan: _CodecUtility.valueEncode(isGreaterThan),
+              isGreaterThanOrEqualTo:
+                  _CodecUtility.valueEncode(isGreaterThanOrEqualTo),
+              arrayContainsAny: _CodecUtility.valueEncode(arrayContainsAny),
+              arrayContains: _CodecUtility.valueEncode(arrayContains),
+              whereIn: _CodecUtility.valueEncode(whereIn),
               isNull: isNull),
           firestore);
 

--- a/packages/cloud_firestore/cloud_firestore/pubspec.yaml
+++ b/packages/cloud_firestore/cloud_firestore/pubspec.yaml
@@ -3,7 +3,7 @@ description:
   Flutter plugin for Cloud Firestore, a cloud-hosted, noSQL database with
   live synchronization and offline support on Android and iOS.
 homepage: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/cloud_firestore/cloud_firestore
-version: 0.13.1
+version: 0.13.1+1
 
 flutter:
   plugin:


### PR DESCRIPTION
## Description

This fix ensures that all values passed to `Query#where` is encoded properly before the query get passed to the platform interface. 

## Related Issues

#1954 

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] If the pull request affects only one plugin, the PR title starts with the name of the plugin in brackets (e.g. [cloud_firestore])
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
