### PR TITLE
Added InAppMessaging dependency in ios

### DIFF
--- a/packages/firebase_in_app_messaging/ios/firebase_in_app_messaging.podspec
+++ b/packages/firebase_in_app_messaging/ios/firebase_in_app_messaging.podspec
@@ -17,6 +17,7 @@ Flutter plugin for Firebase In-App Messaging.
   s.dependency 'Flutter'
   s.dependency 'Firebase'
   s.dependency 'Firebase/InAppMessagingDisplay'
+  s.dependency 'Firebase/InAppMessaging'
   s.static_framework = true
 
   s.ios.deployment_target = '8.0'


### PR DESCRIPTION
## Description

**Describe the bug**
Add 'Firebase/InAppMessaging' dependency to firebase_in_app_messaging IOS.

**Reason:**
FIRInAppMessaging is used in this library but it is not to the dependency thus it gives compile time error.

## Related Issues

Fixes #1956 issue