### PR TITLE
[cloud_firestore_web] Fix fileName prop in pubspec.yaml

### DIFF
--- a/packages/cloud_firestore/cloud_firestore_web/CHANGELOG.md
+++ b/packages/cloud_firestore/cloud_firestore_web/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.0+1
+
+- Fix `fileName` prop in pubspec.yaml
+
 ## 0.1.0
 
 - Initial release

--- a/packages/cloud_firestore/cloud_firestore_web/pubspec.yaml
+++ b/packages/cloud_firestore/cloud_firestore_web/pubspec.yaml
@@ -1,14 +1,14 @@
 name: cloud_firestore_web
 description: The web implementation of cloud_firestore
 homepage: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/cloud_firestore/cloud_firestore_web
-version: 0.1.0
+version: 0.1.0+1
 
 flutter:
   plugin:
     platforms:
       web:
         pluginClass: FirestoreWeb
-        fileName: firestore_web.dart
+        fileName: cloud_firestore_web.dart
 
 dependencies:
   flutter:


### PR DESCRIPTION
## Description

During a file renaming a pubspec.yaml property slipped through the cracks. This change fixes it.

## Related Issues

Fixes https://github.com/FirebaseExtended/flutterfire/issues/1973

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] If the pull request affects only one plugin, the PR title starts with the name of the plugin in brackets (e.g. [cloud_firestore])
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
