### PR TITLE
[firebase_messaging] Add macOS support

### DIFF
--- a/packages/firebase_messaging/lib/firebase_messaging.dart
+++ b/packages/firebase_messaging/lib/firebase_messaging.dart
@@ -81,7 +81,7 @@ class FirebaseMessaging {
   FutureOr<bool> requestNotificationPermissions([
     IosNotificationSettings iosSettings = const IosNotificationSettings(),
   ]) {
-    if (!_platform.isIOS) {
+    if (!(_platform.isIOS || _platform.isMacOS)) {
       return null;
     }
     return _channel.invokeMethod<bool>(

--- a/packages/firebase_messaging/macos/Classes/FLTFirebaseMessagingPlugin.h
+++ b/packages/firebase_messaging/macos/Classes/FLTFirebaseMessagingPlugin.h
@@ -1,0 +1,8 @@
+// Copyright 2017 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#import <FlutterMacOS/FlutterMacOS.h>
+
+@interface FLTFirebaseMessagingPlugin : NSObject <FlutterPlugin>
+@end

--- a/packages/firebase_messaging/macos/Classes/FLTFirebaseMessagingPlugin.m
+++ b/packages/firebase_messaging/macos/Classes/FLTFirebaseMessagingPlugin.m
@@ -1,0 +1,256 @@
+// Copyright 2017 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#import <UserNotifications/UserNotifications.h>
+
+#import "FLTFirebaseMessagingPlugin.h"
+#import "UserAgent.h"
+
+#import "Firebase/Firebase.h"
+
+@interface FLTFirebaseMessagingPlugin () <FIRMessagingDelegate>
+@end
+
+static FlutterError *getFlutterError(NSError *error) {
+  if (error == nil) return nil;
+  return [FlutterError errorWithCode:[NSString stringWithFormat:@"Error %ld", (long)error.code]
+                             message:error.domain
+                             details:error.localizedDescription];
+}
+
+static NSObject<FlutterPluginRegistrar> *_registrar;
+
+@implementation FLTFirebaseMessagingPlugin {
+  FlutterMethodChannel *_channel;
+  NSDictionary *_launchNotification;
+  BOOL _resumingFromBackground;
+}
+
++ (void)registerWithRegistrar:(NSObject<FlutterPluginRegistrar> *)registrar {
+  _registrar = registrar;
+  FlutterMethodChannel *channel =
+      [FlutterMethodChannel methodChannelWithName:@"plugins.flutter.io/firebase_messaging"
+                                  binaryMessenger:[registrar messenger]];
+  FLTFirebaseMessagingPlugin *instance =
+      [[FLTFirebaseMessagingPlugin alloc] initWithChannel:channel];
+  //TODO: Enable when https://github.com/flutter/flutter/issues/41471 is done.
+  //[registrar addApplicationDelegate:instance];
+  [registrar addMethodCallDelegate:instance channel:channel];
+
+  SEL sel = NSSelectorFromString(@"registerLibrary:withVersion:");
+  if ([FIRApp respondsToSelector:sel]) {
+    [FIRApp performSelector:sel withObject:LIBRARY_NAME withObject:LIBRARY_VERSION];
+  }
+}
+
+- (instancetype)initWithChannel:(FlutterMethodChannel *)channel {
+  self = [super init];
+
+  if (self) {
+    _channel = channel;
+    _resumingFromBackground = NO;
+    if (![FIRApp appNamed:@"__FIRAPP_DEFAULT"]) {
+      NSLog(@"Configuring the default Firebase app...");
+      [FIRApp configure];
+      NSLog(@"Configured the default Firebase app %@.", [FIRApp defaultApp].name);
+    }
+    [FIRMessaging messaging].delegate = self;
+  }
+  return self;
+}
+
+- (void)handleMethodCall:(FlutterMethodCall *)call result:(FlutterResult)result {
+  NSString *method = call.method;
+  if ([@"requestNotificationPermissions" isEqualToString:method]) {
+    NSDictionary *arguments = call.arguments;
+    if (@available(macOS 10.14, iOS 10.0, *)) {
+      UNAuthorizationOptions authOptions = 0;
+      NSNumber *provisional = arguments[@"provisional"];
+      if ([arguments[@"sound"] boolValue]) {
+        authOptions |= UNAuthorizationOptionSound;
+      }
+      if ([arguments[@"alert"] boolValue]) {
+        authOptions |= UNAuthorizationOptionAlert;
+      }
+      if ([arguments[@"badge"] boolValue]) {
+        authOptions |= UNAuthorizationOptionBadge;
+      }
+
+      NSNumber *isAtLeastVersion12;
+      if (@available(macOS 10.14, iOS 12, *)) {
+        isAtLeastVersion12 = [NSNumber numberWithBool:YES];
+        if ([provisional boolValue]) authOptions |= UNAuthorizationOptionProvisional;
+      } else {
+        isAtLeastVersion12 = [NSNumber numberWithBool:NO];
+      }
+
+      [[UNUserNotificationCenter currentNotificationCenter]
+          requestAuthorizationWithOptions:authOptions
+                        completionHandler:^(BOOL granted, NSError *_Nullable error) {
+                          if (error) {
+                            result(getFlutterError(error));
+                            return;
+                          }
+                          // This works for iOS >= 10. See
+                          // [UIApplication:didRegisterUserNotificationSettings:notificationSettings]
+                          // for ios < 10.
+                          [[UNUserNotificationCenter currentNotificationCenter]
+                              getNotificationSettingsWithCompletionHandler:^(
+                                  UNNotificationSettings *_Nonnull settings) {
+                                NSDictionary *settingsDictionary = @{
+                                  @"sound" : [NSNumber numberWithBool:settings.soundSetting ==
+                                                                      UNNotificationSettingEnabled],
+                                  @"badge" : [NSNumber numberWithBool:settings.badgeSetting ==
+                                                                      UNNotificationSettingEnabled],
+                                  @"alert" : [NSNumber numberWithBool:settings.alertSetting ==
+                                                                      UNNotificationSettingEnabled],
+                                  @"provisional" :
+                                      [NSNumber numberWithBool:granted && [provisional boolValue] &&
+                                                               isAtLeastVersion12],
+                                };
+                                [self->_channel invokeMethod:@"onIosSettingsRegistered"
+                                                   arguments:settingsDictionary];
+                              }];
+                          result([NSNumber numberWithBool:granted]);
+                        }];
+
+      [[NSApplication sharedApplication] registerForRemoteNotifications];
+    } else {
+      /*
+      UIUserNotificationType notificationTypes = 0;
+      if ([arguments[@"sound"] boolValue]) {
+        notificationTypes |= UIUserNotificationTypeSound;
+      }
+      if ([arguments[@"alert"] boolValue]) {
+        notificationTypes |= UIUserNotificationTypeAlert;
+      }
+      if ([arguments[@"badge"] boolValue]) {
+        notificationTypes |= UIUserNotificationTypeBadge;
+      }
+
+      UIUserNotificationSettings *settings =
+          [UIUserNotificationSettings settingsForTypes:notificationTypes categories:nil];
+      [[UIApplication sharedApplication] registerUserNotificationSettings:settings];
+
+      [[UIApplication sharedApplication] registerForRemoteNotifications];
+      result([NSNumber numberWithBool:YES]);
+       */
+    }
+  } else
+  if ([@"configure" isEqualToString:method]) {
+    [FIRMessaging messaging].shouldEstablishDirectChannel = true;
+      if (@available(macOS 10.14, *)) {
+          [[NSApplication sharedApplication] registerForRemoteNotifications];
+      } else {
+          [[NSApplication sharedApplication] registerForRemoteNotificationTypes:NSRemoteNotificationTypeSound | NSRemoteNotificationTypeAlert | NSRemoteNotificationTypeBadge];
+      }
+    if (_launchNotification != nil) {
+      [_channel invokeMethod:@"onLaunch" arguments:_launchNotification];
+    }
+    result(nil);
+  } else if ([@"subscribeToTopic" isEqualToString:method]) {
+    NSString *topic = call.arguments;
+    [[FIRMessaging messaging] subscribeToTopic:topic
+                                    completion:^(NSError *error) {
+                                      result(getFlutterError(error));
+                                    }];
+  } else if ([@"unsubscribeFromTopic" isEqualToString:method]) {
+    NSString *topic = call.arguments;
+    [[FIRMessaging messaging] unsubscribeFromTopic:topic
+                                        completion:^(NSError *error) {
+                                          result(getFlutterError(error));
+                                        }];
+  } else if ([@"getToken" isEqualToString:method]) {
+    [[FIRInstanceID instanceID]
+        instanceIDWithHandler:^(FIRInstanceIDResult *_Nullable instanceIDResult,
+                                NSError *_Nullable error) {
+          if (error != nil) {
+            NSLog(@"getToken, error fetching instanceID: %@", error);
+            result(nil);
+          } else {
+            result(instanceIDResult.token);
+          }
+        }];
+  } else if ([@"deleteInstanceID" isEqualToString:method]) {
+    [[FIRInstanceID instanceID] deleteIDWithHandler:^void(NSError *_Nullable error) {
+      if (error.code != 0) {
+        NSLog(@"deleteInstanceID, error: %@", error);
+        result([NSNumber numberWithBool:NO]);
+      } else {
+          [[NSApplication sharedApplication] unregisterForRemoteNotifications];
+        result([NSNumber numberWithBool:YES]);
+      }
+    }];
+  } else if ([@"autoInitEnabled" isEqualToString:method]) {
+    BOOL value = [[FIRMessaging messaging] isAutoInitEnabled];
+    result([NSNumber numberWithBool:value]);
+  } else if ([@"setAutoInitEnabled" isEqualToString:method]) {
+    NSNumber *value = call.arguments;
+    [FIRMessaging messaging].autoInitEnabled = value.boolValue;
+    result(nil);
+  } else {
+    result(FlutterMethodNotImplemented);
+  }
+}
+
+- (void)applicationReceivedRemoteMessage:(FIRMessagingRemoteMessage *)remoteMessage {
+  [self didReceiveRemoteNotification:remoteMessage.appData];
+}
+
+- (void)didReceiveRemoteNotification:(NSDictionary *)userInfo {
+  if (_resumingFromBackground) {
+    [_channel invokeMethod:@"onResume" arguments:userInfo];
+  } else {
+    [_channel invokeMethod:@"onMessage" arguments:userInfo];
+  }
+}
+
+#pragma mark - AppDelegate
+
+- (void)applicationDidFinishLaunching:(NSNotification *)notification {
+  if (notification != nil) {
+    _launchNotification = notification.userInfo[NSApplicationLaunchUserNotificationKey];
+  }
+}
+
+- (void)applicationDidEnterBackground:(NSApplication *)application {
+  _resumingFromBackground = YES;
+}
+
+- (void)applicationDidBecomeActive:(NSApplication *)application {
+  _resumingFromBackground = NO;
+  // Clears push notifications from the notification center, with the
+  // side effect of resetting the badge count. We need to clear notifications
+  // because otherwise the user could tap notifications in the notification
+  // center while the app is in the foreground, and we wouldn't be able to
+  // distinguish that case from the case where a message came in and the
+  // user dismissed the notification center without tapping anything.
+  // TODO(goderbauer): Revisit this behavior once we provide an API for managing
+  // the badge number, or if we add support for running Dart in the background.
+  // Setting badgeNumber to 0 is a no-op (= notifications will not be cleared)
+  // if it is already 0,
+  // therefore the next line is setting it to 1 first before clearing it again
+  // to remove all
+  // notifications.
+  //application.applicationIconBadgeNumber = 1;
+  //application.applicationIconBadgeNumber = 0;
+}
+
+- (BOOL)application:(NSApplication *)application
+    didReceiveRemoteNotification:(NSDictionary *)userInfo {
+  [self didReceiveRemoteNotification:userInfo];
+  return YES;
+}
+
+- (void)messaging:(nonnull FIRMessaging *)messaging
+    didReceiveRegistrationToken:(nonnull NSString *)fcmToken {
+  [_channel invokeMethod:@"onToken" arguments:fcmToken];
+}
+
+- (void)messaging:(FIRMessaging *)messaging
+    didReceiveMessage:(FIRMessagingRemoteMessage *)remoteMessage {
+  [_channel invokeMethod:@"onMessage" arguments:remoteMessage.appData];
+}
+@end
+

--- a/packages/firebase_messaging/macos/Classes/UserAgent.h
+++ b/packages/firebase_messaging/macos/Classes/UserAgent.h
@@ -1,0 +1,3 @@
+// Generated file, do not edit
+#define LIBRARY_VERSION @"6.0.10"
+#define LIBRARY_NAME @"flutter-fire-fcm"

--- a/packages/firebase_messaging/macos/firebase_messaging.podspec
+++ b/packages/firebase_messaging/macos/firebase_messaging.podspec
@@ -1,0 +1,33 @@
+#
+# To learn more about a Podspec see http://guides.cocoapods.org/syntax/podspec.html
+#
+
+require 'yaml'
+pubspec = YAML.load_file(File.join('..', 'pubspec.yaml'))
+libraryVersion = pubspec['version'].gsub('+', '-')
+
+Pod::Spec.new do |s|
+  s.name             = 'firebase_messaging'
+  s.version          = '0.0.1'
+  s.summary          = 'Firebase Cloud Messaging plugin for Flutter.'
+  s.description      = <<-DESC
+Firebase Cloud Messaging plugin for Flutter.
+                       DESC
+  s.homepage         = 'https://github.com/FirebaseExtended/flutterfire/tree/master/packages/firebase_messaging'
+  s.license          = { :file => '../LICENSE' }
+  s.author           = { 'Flutter Team' => 'flutter-dev@googlegroups.com' }
+  s.source           = { :path => '.' }
+  s.source_files = 'Classes/**/*'
+  s.public_header_files = 'Classes/**/*.h'
+  s.dependency 'FlutterMacOS'
+  s.dependency 'Firebase/Core'
+  s.dependency 'Firebase/Messaging'
+  s.static_framework = true
+  s.osx.deployment_target = '10.11'
+
+  s.prepare_command = <<-CMD
+      echo // Generated file, do not edit > Classes/UserAgent.h
+      echo "#define LIBRARY_VERSION @\\"#{libraryVersion}\\"" >> Classes/UserAgent.h
+      echo "#define LIBRARY_NAME @\\"flutter-fire-fcm\\"" >> Classes/UserAgent.h
+    CMD
+end

--- a/packages/firebase_messaging/pubspec.yaml
+++ b/packages/firebase_messaging/pubspec.yaml
@@ -12,6 +12,8 @@ flutter:
         pluginClass: FirebaseMessagingPlugin
       ios:
         pluginClass: FLTFirebaseMessagingPlugin
+      macos:
+        pluginClass: FLTFirebaseMessagingPlugin
 
 dependencies:
   meta: ^1.0.4


### PR DESCRIPTION
## Description

Add macOS support.

TODO:
- [ ] Properly share code between iOS and macOS. Currently I just removed parts which are not available from macOS.
- [ ] Add tests

## Related Issues

https://github.com/FirebaseExtended/flutterfire/issues/1653

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] If the pull request affects only one plugin, the PR title starts with the name of the plugin in brackets (e.g. [cloud_firestore])
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
