### PR TITLE
[cloud_firestore_web] Remove unit test that was only testing dart-lang.

### DIFF
--- a/packages/cloud_firestore/cloud_firestore_web/CHANGELOG.md
+++ b/packages/cloud_firestore/cloud_firestore_web/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.0+3
+
+- Removed unit test that was only testing dart-lang behavior.
+
 ## 0.1.0+2
 
 - Update documentation about this package being the endorsed platform for web.

--- a/packages/cloud_firestore/cloud_firestore_web/pubspec.yaml
+++ b/packages/cloud_firestore/cloud_firestore_web/pubspec.yaml
@@ -1,7 +1,7 @@
 name: cloud_firestore_web
 description: The web implementation of cloud_firestore
 homepage: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/cloud_firestore/cloud_firestore_web
-version: 0.1.0+2
+version: 0.1.0+3
 
 flutter:
   plugin:

--- a/packages/cloud_firestore/cloud_firestore_web/test/field_value_factory_web_test.dart
+++ b/packages/cloud_firestore/cloud_firestore_web/test/field_value_factory_web_test.dart
@@ -35,15 +35,6 @@ void main() {
       expect(actualDouble.data, isInstanceOf<web.FieldValue>());
     });
 
-    test(
-        "increment throws when attempting to increment something that is not a number",
-        () {
-      expect(() {
-        dynamic malformed = "nope";
-        factory.increment(malformed);
-      }, throwsA(isA<TypeError>()));
-    });
-
     test("serverTimestamp", () {
       final FieldValueWeb actual = factory.serverTimestamp();
       expect(actual.data, isInstanceOf<web.FieldValue>());


### PR DESCRIPTION
## Description

The problematic test was attempting to coerce a wrong type into a function call, and that causes problems in environments where linting is more strict. Remove the test, since it's not actually testing our functionality, but dart-lang's.

## Related Issues

Fixes https://github.com/FirebaseExtended/flutterfire/issues/1991

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] If the pull request affects only one plugin, the PR title starts with the name of the plugin in brackets (e.g. [cloud_firestore])
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
