### PR TITLE
[cloud_firestore] Fix firebase <-> firestore typo in platform_interface README

### DIFF
--- a/packages/cloud_firestore/cloud_firestore_platform_interface/README.md
+++ b/packages/cloud_firestore/cloud_firestore_platform_interface/README.md
@@ -8,7 +8,7 @@ same interface.
 
 # Usage
 
-To implement a new platform-specific implementation of `cloud_firebase`, extend
+To implement a new platform-specific implementation of `cloud_firestore`, extend
 [`FirestorePlatform`][2] with an implementation that performs the
 platform-specific behavior, and when you register your plugin, set the default
 `FirestorePlatform` by calling


### PR DESCRIPTION
## Description

Just fixed a small typo

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] If the pull request affects only one plugin, the PR title starts with the name of the plugin in brackets (e.g. [cloud_firestore])
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
