### PR TITLE
[firebase_ml_vision] Fix calculation of center of validRect on Android (Example)

### DIFF
--- a/packages/firebase_ml_vision/example/lib/material_barcode_scanner.dart
+++ b/packages/firebase_ml_vision/example/lib/material_barcode_scanner.dart
@@ -210,11 +210,11 @@ class _MaterialBarcodeScannerState extends State<MaterialBarcodeScanner>
         data.size.height - padding.top - padding.bottom;
 
     // Width & height are flipped from CameraController.previewSize on iOS
-    final double imageHeight = defaultTargetPlatform == TargetPlatform.iOS
-        ? imageSize.height
-        : imageSize.width;
+    if (defaultTargetPlatform != TargetPlatform.iOS) {
+      imageSize = Size(imageSize.height, imageSize.width);
+    }
 
-    final double imageScale = imageHeight / maxLogicalHeight;
+    final double imageScale = imageSize.height / maxLogicalHeight;
     final double halfWidth = imageScale * widget.validRectangle.width / 2;
     final double halfHeight = imageScale * widget.validRectangle.height / 2;
 


### PR DESCRIPTION
## Description

The sample of firebase_ml_vision does not work correctly on Android. The rectangle that validates if the barcode is inside the on-screen rectangle is calculated wrongly. If a barcode is inside the on-screen rectangle, it is discarded. If you place the barcode on the right side above the rectangle, it is approved.

## Related Issues

No related issues

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] If the pull request affects only one plugin, the PR title starts with the name of the plugin in brackets (e.g. [cloud_firestore])
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [X] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [ ] I updated CHANGELOG.md to add a description of the change.
- [X] I signed the [CLA].
- [X] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [X] No, this is *not* a breaking change.