### PR TITLE
[firebase_crashlytics] Add missing documentation for android installation in README.md

### DIFF
--- a/packages/firebase_crashlytics/CHANGELOG.md
+++ b/packages/firebase_crashlytics/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.3+1
+
+* Add missing instructions for android installation
+
 ## 0.1.3
 
 * Add macOS support

--- a/packages/firebase_crashlytics/README.md
+++ b/packages/firebase_crashlytics/README.md
@@ -40,7 +40,7 @@ dependencies {
 }
 ```
 
-2. Apply the following plugins in the `[project]/android/app/build.gradle` file.
+3. Apply the following plugins in the `[project]/android/app/build.gradle` file.
 ```gradle
 // ADD THIS AT THE BOTTOM
 apply plugin: 'io.fabric'
@@ -52,6 +52,13 @@ apply plugin: 'com.google.gms.google-services'
 java.lang.IllegalStateException:
 Default FirebaseApp is not initialized in this process [package name].
 Make sure to call FirebaseApp.initializeApp(Context) first.
+```
+
+4. Add the following implementation to the `[project]/android/app/build.gradle` file.
+```gradle
+dependencies {
+    implementation 'com.crashlytics.sdk.android:crashlytics:2.9.9'
+}
 ```
 
 *Note:* When you are debugging on Android, use a device or AVD with Google Play services.

--- a/packages/firebase_crashlytics/pubspec.yaml
+++ b/packages/firebase_crashlytics/pubspec.yaml
@@ -2,7 +2,7 @@ name: firebase_crashlytics
 description:
   Flutter plugin for Firebase Crashlytics. It reports uncaught errors to the
   Firebase console.
-version: 0.1.3
+version: 0.1.3+1
 homepage: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/firebase_crashlytics
 
 environment:


### PR DESCRIPTION
## Description

This PR adds the missing documentation for `firebase_crashlytics` plugin installation on android.

## Related Issues

- relates to #1376
- closes #1153

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] If the pull request affects only one plugin, the PR title starts with the name of the plugin in brackets (e.g. [cloud_firestore])
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
