### PR TITLE
Add pedantic to all Firebase plugins

### DIFF
--- a/packages/cloud_firestore/cloud_firestore/CHANGELOG.md
+++ b/packages/cloud_firestore/cloud_firestore/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.13.3+1
+
+* Make the pedantic dev_dependency explicit.
+
 ## 0.13.3
 
 * Add macOS support

--- a/packages/cloud_firestore/cloud_firestore/example/pubspec.yaml
+++ b/packages/cloud_firestore/cloud_firestore/example/pubspec.yaml
@@ -9,6 +9,7 @@ dependencies:
   firebase_core: "^0.4.4"
 
 dev_dependencies:
+  pedantic: ^1.8.0
   flutter_driver:
     sdk: flutter
   test: any

--- a/packages/cloud_firestore/cloud_firestore/pubspec.yaml
+++ b/packages/cloud_firestore/cloud_firestore/pubspec.yaml
@@ -3,7 +3,7 @@ description:
   Flutter plugin for Cloud Firestore, a cloud-hosted, noSQL database with
   live synchronization and offline support on Android and iOS.
 homepage: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/cloud_firestore/cloud_firestore
-version: 0.13.3
+version: 0.13.3+1
 
 flutter:
   plugin:
@@ -32,6 +32,7 @@ dependencies:
   cloud_firestore_web: ^0.1.0+1
 
 dev_dependencies:
+  pedantic: ^1.8.0
   flutter_test:
     sdk: flutter
   flutter_driver:

--- a/packages/cloud_firestore/cloud_firestore_platform_interface/CHANGELOG.md
+++ b/packages/cloud_firestore/cloud_firestore_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.1
+
+* Make the pedantic dev_dependency explicit.
+
 ## [1.0.0]
 
 * Created Platform Interface

--- a/packages/cloud_firestore/cloud_firestore_platform_interface/CHANGELOG.md
+++ b/packages/cloud_firestore/cloud_firestore_platform_interface/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.0.1
+## [1.0.1]
 
 * Make the pedantic dev_dependency explicit.
 

--- a/packages/cloud_firestore/cloud_firestore_platform_interface/pubspec.yaml
+++ b/packages/cloud_firestore/cloud_firestore_platform_interface/pubspec.yaml
@@ -1,6 +1,6 @@
 name: cloud_firestore_platform_interface
 description: A common platform interface for the cloud_firestore plugin.
-version: 1.0.0
+version: 1.0.1
 homepage: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/cloud_firestore/cloud_firestore_platform_interface
 
 dependencies:
@@ -12,6 +12,7 @@ dependencies:
   plugin_platform_interface: ^1.0.0
 
 dev_dependencies:
+  pedantic: ^1.8.0
   flutter_test:
     sdk: flutter
   mockito: ^4.1.1

--- a/packages/cloud_firestore/cloud_firestore_web/CHANGELOG.md
+++ b/packages/cloud_firestore/cloud_firestore_web/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.0+4
+
+* Make the pedantic dev_dependency explicit.
+
 ## 0.1.0+3
 
 - Removed unit test that was only testing dart-lang behavior.

--- a/packages/cloud_firestore/cloud_firestore_web/pubspec.yaml
+++ b/packages/cloud_firestore/cloud_firestore_web/pubspec.yaml
@@ -1,7 +1,7 @@
 name: cloud_firestore_web
 description: The web implementation of cloud_firestore
 homepage: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/cloud_firestore/cloud_firestore_web
-version: 0.1.0+3
+version: 0.1.0+4
 
 flutter:
   plugin:
@@ -23,6 +23,7 @@ dependencies:
   js: ^0.6.1
 
 dev_dependencies:
+  pedantic: ^1.8.0
   flutter_test:
     sdk: flutter
   firebase_core_platform_interface: ^1.0.0

--- a/packages/cloud_functions/cloud_functions/CHANGELOG.md
+++ b/packages/cloud_functions/cloud_functions/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.4.2+1
+
+* Make the pedantic dev_dependency explicit.
+
 ## 0.4.2
 
 * Add macOS support

--- a/packages/cloud_functions/cloud_functions/example/pubspec.yaml
+++ b/packages/cloud_functions/cloud_functions/example/pubspec.yaml
@@ -12,6 +12,7 @@ dependencies:
   firebase_core: ^0.4.4
 
 dev_dependencies:
+  pedantic: ^1.8.0
   flutter_test:
     sdk: flutter
   flutter_driver:

--- a/packages/cloud_functions/cloud_functions/example/pubspec.yaml
+++ b/packages/cloud_functions/cloud_functions/example/pubspec.yaml
@@ -1,7 +1,5 @@
 name: cloud_functions_example
 description: Demonstrates how to use the cloud_functions plugin.
-version: 1.0.1
-author: Flutter Team <flutter-dev@googlegroups.com>
 
 dependencies:
   flutter:

--- a/packages/cloud_functions/cloud_functions/pubspec.yaml
+++ b/packages/cloud_functions/cloud_functions/pubspec.yaml
@@ -1,6 +1,6 @@
 name: cloud_functions
 description: Flutter plugin for Cloud Functions.
-version: 0.4.2
+version: 0.4.2+1
 homepage: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/cloud_functions/cloud_functions
 
 flutter:
@@ -25,6 +25,7 @@ dependencies:
   cloud_functions_web: ^1.0.2
 
 dev_dependencies:
+  pedantic: ^1.8.0
   flutter_test:
     sdk: flutter
   flutter_driver:

--- a/packages/cloud_functions/cloud_functions_platform_interface/CHANGELOG.md
+++ b/packages/cloud_functions/cloud_functions_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.1
+
+* Make the pedantic dev_dependency explicit.
+
 ## 1.0.0
 
 Initial release

--- a/packages/cloud_functions/cloud_functions_platform_interface/pubspec.yaml
+++ b/packages/cloud_functions/cloud_functions_platform_interface/pubspec.yaml
@@ -3,7 +3,7 @@ description: A common platform interface for the cloud_functions plugin.
 homepage: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/cloud_functions/cloud_functions_platform_interface
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 1.0.0
+version: 1.0.1
 
 dependencies:
   flutter:
@@ -13,6 +13,7 @@ dependencies:
   plugin_platform_interface: ^1.0.1
 
 dev_dependencies:
+  pedantic: ^1.8.0
   flutter_test:
     sdk: flutter
   mockito: ^4.1.1

--- a/packages/cloud_functions/cloud_functions_web/CHANGELOG.md
+++ b/packages/cloud_functions/cloud_functions_web/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.4
+
+* Make the pedantic dev_dependency explicit.
+
 ## 1.0.3
 
 Update README with real version numbers.

--- a/packages/cloud_functions/cloud_functions_web/pubspec.yaml
+++ b/packages/cloud_functions/cloud_functions_web/pubspec.yaml
@@ -1,7 +1,7 @@
 name: cloud_functions_web
 description: The web implementation of cloud_functions
 homepage: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/cloud_functions/cloud_functions_web
-version: 1.0.3
+version: 1.0.4
 
 flutter:
   plugin:
@@ -21,6 +21,7 @@ dependencies:
   meta: ^1.1.7
 
 dev_dependencies:
+  pedantic: ^1.8.0
   flutter_test:
     sdk: flutter
   firebase_core_platform_interface: ^1.0.2

--- a/packages/firebase_admob/CHANGELOG.md
+++ b/packages/firebase_admob/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.9.1+2
+
+* Make the pedantic dev_dependency explicit.
+
 ## 0.9.1+1
 
 * Enable custom parameters for rewarded video server-side verification callbacks.

--- a/packages/firebase_admob/example/pubspec.yaml
+++ b/packages/firebase_admob/example/pubspec.yaml
@@ -9,6 +9,7 @@ dependencies:
   firebase_core: ^0.4.2+1
 
 dev_dependencies:
+  pedantic: ^1.8.0
   e2e: ^0.2.1
   flutter_driver:
     sdk: flutter

--- a/packages/firebase_admob/pubspec.yaml
+++ b/packages/firebase_admob/pubspec.yaml
@@ -2,7 +2,7 @@ name: firebase_admob
 description: Flutter plugin for Firebase AdMob, supporting
   banner, interstitial (full-screen), and rewarded video ads
 homepage: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/firebase_admob
-version: 0.9.1+1
+version: 0.9.1+2
 
 flutter:
   plugin:
@@ -21,6 +21,7 @@ dependencies:
   firebase_core: ^0.4.2+1
 
 dev_dependencies:
+  pedantic: ^1.8.0
   e2e: ^0.2.1
   flutter_driver:
     sdk: flutter

--- a/packages/firebase_analytics/firebase_analytics/CHANGELOG.md
+++ b/packages/firebase_analytics/firebase_analytics/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 5.0.12
+
+* Make the pedantic dev_dependency explicit.
+
 ## 5.0.11
 
 * Fix overrides a deprecated API.

--- a/packages/firebase_analytics/firebase_analytics/example/pubspec.yaml
+++ b/packages/firebase_analytics/firebase_analytics/example/pubspec.yaml
@@ -10,6 +10,7 @@ dependencies:
   e2e: ^0.2.1
 
 dev_dependencies:
+  pedantic: ^1.8.0
   flutter_test:
     sdk: flutter
   flutter_driver:

--- a/packages/firebase_analytics/firebase_analytics/pubspec.yaml
+++ b/packages/firebase_analytics/firebase_analytics/pubspec.yaml
@@ -2,7 +2,7 @@ name: firebase_analytics
 description: Flutter plugin for Google Analytics for Firebase, an app measurement
   solution that provides insight on app usage and user engagement on Android and iOS.
 homepage: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/firebase_analytics/firebase_analytics
-version: 5.0.11
+version: 5.0.12
 
 flutter:
   plugin:
@@ -19,6 +19,7 @@ dependencies:
     sdk: flutter
 
 dev_dependencies:
+  pedantic: ^1.8.0
   e2e: ^0.2.1
   mockito: 3.0.0
   flutter_test:

--- a/packages/firebase_analytics/firebase_analytics_platform_interface/CHANGELOG.md
+++ b/packages/firebase_analytics/firebase_analytics_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.2
+
+* Make the pedantic dev_dependency explicit.
+
 ## 1.0.1
 
 * Remove the deprecated `author:` field from pubspec.yaml

--- a/packages/firebase_analytics/firebase_analytics_platform_interface/pubspec.yaml
+++ b/packages/firebase_analytics/firebase_analytics_platform_interface/pubspec.yaml
@@ -3,7 +3,7 @@ description: A common platform interface for the firebase_analytics plugin.
 homepage: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/firebase_analytics/firebase_analytics_platform_interface
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 1.0.1
+version: 1.0.2
 
 dependencies:
   flutter:
@@ -11,6 +11,7 @@ dependencies:
   meta: ^1.0.5
 
 dev_dependencies:
+  pedantic: ^1.8.0
   flutter_test:
     sdk: flutter
   mockito: ^4.1.1

--- a/packages/firebase_auth/firebase_auth/CHANGELOG.md
+++ b/packages/firebase_auth/firebase_auth/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.15.5+1
+
+* Make the pedantic dev_dependency explicit.
+
 ## 0.15.5
 
 * Add macOS support

--- a/packages/firebase_auth/firebase_auth/example/pubspec.yaml
+++ b/packages/firebase_auth/firebase_auth/example/pubspec.yaml
@@ -13,6 +13,7 @@ dependencies:
   uuid: ^2.0.2
 
 dev_dependencies:
+  pedantic: ^1.8.0
   flutter_driver:
     sdk: flutter
   test: any

--- a/packages/firebase_auth/firebase_auth/pubspec.yaml
+++ b/packages/firebase_auth/firebase_auth/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for Firebase Auth, enabling Android and iOS
   authentication using passwords, phone numbers and identity providers
   like Google, Facebook and Twitter.
 homepage: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/firebase_auth/firebase_auth
-version: 0.15.5
+version: 0.15.5+1
 
 flutter:
   plugin:
@@ -33,6 +33,7 @@ dependencies:
     sdk: flutter
 
 dev_dependencies:
+  pedantic: ^1.8.0
   async: ^2.3.0
   google_sign_in: ^3.0.4
   firebase_dynamic_links: ^0.3.0

--- a/packages/firebase_auth/firebase_auth_platform_interface/CHANGELOG.md
+++ b/packages/firebase_auth/firebase_auth_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.1.6
+
+* Make the pedantic dev_dependency explicit.
+
 ## 1.1.5
 
 - Fixed typo on private method name.

--- a/packages/firebase_auth/firebase_auth_platform_interface/pubspec.yaml
+++ b/packages/firebase_auth/firebase_auth_platform_interface/pubspec.yaml
@@ -3,7 +3,7 @@ description: A common platform interface for the firebase_auth plugin.
 homepage: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/firebase_auth/firebase_auth_platform_interface
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 1.1.5
+version: 1.1.6
 
 dependencies:
   flutter:
@@ -11,6 +11,7 @@ dependencies:
   meta: ^1.0.5
 
 dev_dependencies:
+  pedantic: ^1.8.0
   flutter_test:
     sdk: flutter
   mockito: ^4.1.1

--- a/packages/firebase_auth/firebase_auth_web/CHANGELOG.md
+++ b/packages/firebase_auth/firebase_auth_web/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.2+2
+
+* Make the pedantic dev_dependency explicit.
+
 ## 0.1.2+1
 
 * Require `firebase_core_web` from hosted

--- a/packages/firebase_auth/firebase_auth_web/pubspec.yaml
+++ b/packages/firebase_auth/firebase_auth_web/pubspec.yaml
@@ -1,7 +1,7 @@
 name: firebase_auth_web
 description: The web implementation of firebase_auth
 homepage: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/firebase_auth/firebase_auth_web
-version: 0.1.2+1
+version: 0.1.2+2
 
 flutter:
   plugin:
@@ -22,6 +22,7 @@ dependencies:
   js: ^0.6.1
 
 dev_dependencies:
+  pedantic: ^1.8.0
   flutter_test:
     sdk: flutter
   firebase_auth:

--- a/packages/firebase_core/firebase_core/CHANGELOG.md
+++ b/packages/firebase_core/firebase_core/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.4.4+1
+
+* Make the pedantic dev_dependency explicit.
+
 ## 0.4.4
 
 * Add macOS support

--- a/packages/firebase_core/firebase_core/example/pubspec.yaml
+++ b/packages/firebase_core/firebase_core/example/pubspec.yaml
@@ -10,6 +10,7 @@ dependencies:
   cupertino_icons: ^0.1.0
 
 dev_dependencies:
+  pedantic: ^1.8.0
   e2e: ^0.2.1
   flutter_test:
     sdk: flutter

--- a/packages/firebase_core/firebase_core/pubspec.yaml
+++ b/packages/firebase_core/firebase_core/pubspec.yaml
@@ -2,7 +2,7 @@ name: firebase_core
 description: Flutter plugin for Firebase Core, enabling connecting to multiple
   Firebase apps.
 homepage: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/firebase_core/firebase_core
-version: 0.4.4
+version: 0.4.4+1
 
 flutter:
   plugin:
@@ -30,6 +30,7 @@ dependencies:
   firebase_core_web: ^0.1.1
 
 dev_dependencies:
+  pedantic: ^1.8.0
   e2e: ^0.2.1
   flutter_driver:
     sdk: flutter

--- a/packages/firebase_core/firebase_core_platform_interface/CHANGELOG.md
+++ b/packages/firebase_core/firebase_core_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.3
+
+* Make the pedantic dev_dependency explicit.
+
 ## 1.0.2
 
 - Remove the deprecated `author:` field from pubspec.yaml

--- a/packages/firebase_core/firebase_core_platform_interface/pubspec.yaml
+++ b/packages/firebase_core/firebase_core_platform_interface/pubspec.yaml
@@ -3,7 +3,7 @@ description: A common platform interface for the firebase_core plugin.
 homepage: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/firebase_core/firebase_core_platform_interface
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 1.0.2
+version: 1.0.3
 
 dependencies:
   flutter:
@@ -12,6 +12,7 @@ dependencies:
   quiver: ">=2.0.0 <3.0.0"
 
 dev_dependencies:
+  pedantic: ^1.8.0
   flutter_test:
     sdk: flutter
   mockito: ^4.1.1

--- a/packages/firebase_core/firebase_core_web/CHANGELOG.md
+++ b/packages/firebase_core/firebase_core_web/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.1+3
+
+* Make the pedantic dev_dependency explicit.
+
 ## 0.1.1+2
 
 * Update setup instructions in the README.

--- a/packages/firebase_core/firebase_core_web/pubspec.yaml
+++ b/packages/firebase_core/firebase_core_web/pubspec.yaml
@@ -1,7 +1,7 @@
 name: firebase_core_web
 description: The web implementation of firebase_core
 homepage: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/firebase_core/firebase_core_web
-version: 0.1.1+2
+version: 0.1.1+3
 
 flutter:
   plugin:
@@ -21,6 +21,7 @@ dependencies:
   js: ^0.6.1
 
 dev_dependencies:
+  pedantic: ^1.8.0
   flutter_test:
     sdk: flutter
   firebase_core: ^0.4.2+1

--- a/packages/firebase_crashlytics/CHANGELOG.md
+++ b/packages/firebase_crashlytics/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.3+1
+
+* Make the pedantic dev_dependency explicit.
+
 ## 0.1.3
 
 * Add macOS support

--- a/packages/firebase_crashlytics/example/pubspec.yaml
+++ b/packages/firebase_crashlytics/example/pubspec.yaml
@@ -14,6 +14,7 @@ dependencies:
     path: ../
 
 dev_dependencies:
+  pedantic: ^1.8.0
   e2e: ^0.2.1
   flutter_test:
     sdk: flutter

--- a/packages/firebase_crashlytics/pubspec.yaml
+++ b/packages/firebase_crashlytics/pubspec.yaml
@@ -2,7 +2,7 @@ name: firebase_crashlytics
 description:
   Flutter plugin for Firebase Crashlytics. It reports uncaught errors to the
   Firebase console.
-version: 0.1.3
+version: 0.1.3+1
 homepage: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/firebase_crashlytics
 
 environment:
@@ -15,6 +15,7 @@ dependencies:
   stack_trace: ^1.9.3
 
 dev_dependencies:
+  pedantic: ^1.8.0
   e2e: ^0.2.1
   flutter_test:
     sdk: flutter

--- a/packages/firebase_database/CHANGELOG.md
+++ b/packages/firebase_database/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.1.2
+
+* Make the pedantic dev_dependency explicit.
+
 ## 3.1.1
 
 * Remove the deprecated `author:` field from pubspec.yaml

--- a/packages/firebase_database/example/pubspec.yaml
+++ b/packages/firebase_database/example/pubspec.yaml
@@ -9,6 +9,7 @@ dependencies:
   firebase_core: ^0.4.1
 
 dev_dependencies:
+  pedantic: ^1.8.0
   flutter_driver:
     sdk: flutter
   test: any

--- a/packages/firebase_database/pubspec.yaml
+++ b/packages/firebase_database/pubspec.yaml
@@ -2,7 +2,7 @@ name: firebase_database
 description: Flutter plugin for Firebase Database, a cloud-hosted NoSQL database
   with realtime data syncing across Android and iOS clients, and offline access.
 homepage: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/firebase_database
-version: 3.1.1
+version: 3.1.2
 
 flutter:
   plugin:
@@ -20,6 +20,7 @@ dependencies:
   firebase_core: ^0.4.0
 
 dev_dependencies:
+  pedantic: ^1.8.0
   test: ^1.3.0
   mockito: ^3.0.0
   flutter_test:

--- a/packages/firebase_dynamic_links/CHANGELOG.md
+++ b/packages/firebase_dynamic_links/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.5.0+10
+
+* Make the pedantic dev_dependency explicit.
+
 ## 0.5.0+9
 
 * Remove the deprecated `author:` field from pubspec.yaml

--- a/packages/firebase_dynamic_links/example/pubspec.yaml
+++ b/packages/firebase_dynamic_links/example/pubspec.yaml
@@ -12,6 +12,7 @@ dependencies:
   url_launcher: ^5.1.6
 
 dev_dependencies:
+  pedantic: ^1.8.0
   e2e: ^0.2.1
   flutter_driver:
     sdk: flutter

--- a/packages/firebase_dynamic_links/pubspec.yaml
+++ b/packages/firebase_dynamic_links/pubspec.yaml
@@ -1,7 +1,7 @@
 name: firebase_dynamic_links
 description: Flutter plugin for Google Dynamic Links for Firebase, an app solution for creating
   and handling links across multiple platforms.
-version: 0.5.0+9
+version: 0.5.0+10
 homepage: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/firebase_dynamic_links
 
 dependencies:
@@ -9,6 +9,7 @@ dependencies:
     sdk: flutter
 
 dev_dependencies:
+  pedantic: ^1.8.0
   e2e: ^0.2.1
   flutter_driver:
     sdk: flutter

--- a/packages/firebase_in_app_messaging/CHANGELOG.md
+++ b/packages/firebase_in_app_messaging/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.1+2
+
+* Make the pedantic dev_dependency explicit.
+
 ## 0.1.1+1
 
 * Remove the deprecated `author:` field from pubspec.yaml

--- a/packages/firebase_in_app_messaging/example/pubspec.yaml
+++ b/packages/firebase_in_app_messaging/example/pubspec.yaml
@@ -11,6 +11,7 @@ dependencies:
   cupertino_icons: ^0.1.2
 
 dev_dependencies:
+  pedantic: ^1.8.0
   e2e: ^0.2.1
   flutter_test:
     sdk: flutter

--- a/packages/firebase_in_app_messaging/pubspec.yaml
+++ b/packages/firebase_in_app_messaging/pubspec.yaml
@@ -1,6 +1,6 @@
 name: firebase_in_app_messaging
 description: Flutter plugin for Firebase In-App Messaging.
-version: 0.1.1+1
+version: 0.1.1+2
 homepage: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/firebase_in_app_messaging
 
 environment:
@@ -13,6 +13,7 @@ dependencies:
     sdk: flutter
 
 dev_dependencies:
+  pedantic: ^1.8.0
   e2e: ^0.2.1
   flutter_test:
     sdk: flutter

--- a/packages/firebase_messaging/CHANGELOG.md
+++ b/packages/firebase_messaging/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 6.0.11
+
+* Make the pedantic dev_dependency explicit.
+
 ## 6.0.10
 
 * Update README to explain how to correctly implement Android background message handling with the new v2 embedding. 

--- a/packages/firebase_messaging/example/pubspec.yaml
+++ b/packages/firebase_messaging/example/pubspec.yaml
@@ -10,6 +10,7 @@ dependencies:
   firebase_core: ^0.4.0
 
 dev_dependencies:
+  pedantic: ^1.8.0
   flutter_test:
     sdk: flutter
   e2e: ^0.2.1

--- a/packages/firebase_messaging/pubspec.yaml
+++ b/packages/firebase_messaging/pubspec.yaml
@@ -2,7 +2,7 @@ name: firebase_messaging
 description: Flutter plugin for Firebase Cloud Messaging, a cross-platform
   messaging solution that lets you reliably deliver messages on Android and iOS.
 homepage: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/firebase_messaging
-version: 6.0.10
+version: 6.0.11
 
 flutter:
   plugin:
@@ -20,6 +20,7 @@ dependencies:
     sdk: flutter
 
 dev_dependencies:
+  pedantic: ^1.8.0
   test: ^1.3.0
   mockito: ^3.0.0
   flutter_test:

--- a/packages/firebase_ml_vision/CHANGELOG.md
+++ b/packages/firebase_ml_vision/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.9.3+6
+
+* Make the pedantic dev_dependency explicit.
+
 ## 0.9.3+5
 
 * Remove the deprecated `author:` field from pubspec.yaml

--- a/packages/firebase_ml_vision/example/pubspec.yaml
+++ b/packages/firebase_ml_vision/example/pubspec.yaml
@@ -14,6 +14,7 @@ dependencies:
   camera: ^0.5.6+1
 
 dev_dependencies:
+  pedantic: ^1.8.0
   e2e: ^0.2.1
   flutter_test:
     sdk: flutter

--- a/packages/firebase_ml_vision/pubspec.yaml
+++ b/packages/firebase_ml_vision/pubspec.yaml
@@ -1,13 +1,14 @@
 name: firebase_ml_vision
 description: Flutter plugin for Firebase machine learning vision services.
 homepage: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/firebase_ml_vision
-version: 0.9.3+5
+version: 0.9.3+6
 
 dependencies:
   flutter:
     sdk: flutter
 
 dev_dependencies:
+  pedantic: ^1.8.0
   e2e: ^0.2.1
   image_picker: ^0.5.0
   flutter_test:

--- a/packages/firebase_performance/CHANGELOG.md
+++ b/packages/firebase_performance/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.1+6
+
+* Make the pedantic dev_dependency explicit.
+
 ## 0.3.1+5
 
 * Remove the deprecated `author:` field from pubspec.yaml

--- a/packages/firebase_performance/example/pubspec.yaml
+++ b/packages/firebase_performance/example/pubspec.yaml
@@ -11,6 +11,7 @@ dependencies:
   firebase_core: ^0.4.0
 
 dev_dependencies:
+  pedantic: ^1.8.0
   e2e: ^0.2.1
   flutter_test:
     sdk: flutter

--- a/packages/firebase_performance/pubspec.yaml
+++ b/packages/firebase_performance/pubspec.yaml
@@ -3,13 +3,14 @@ description: Flutter plugin for Google Performance Monitoring for Firebase, an a
   measurement solution that monitors traces and HTTP/S network requests on Android and
   iOS.
 homepage: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/firebase_performance
-version: 0.3.1+5
+version: 0.3.1+6
 
 dependencies:
   flutter:
     sdk: flutter
 
 dev_dependencies:
+  pedantic: ^1.8.0
   e2e: ^0.2.1
   http: ^0.12.0
   flutter_test:

--- a/packages/firebase_remote_config/CHANGELOG.md
+++ b/packages/firebase_remote_config/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.0+2
+
+* Make the pedantic dev_dependency explicit.
+
 ## 0.3.0+1
 
 * Remove the deprecated `author:` field from pubspec.yaml

--- a/packages/firebase_remote_config/example/pubspec.yaml
+++ b/packages/firebase_remote_config/example/pubspec.yaml
@@ -13,6 +13,7 @@ dependencies:
   firebase_core: ^0.4.1
 
 dev_dependencies:
+  pedantic: ^1.8.0
   flutter_test:
     sdk: flutter
   flutter_driver:

--- a/packages/firebase_remote_config/pubspec.yaml
+++ b/packages/firebase_remote_config/pubspec.yaml
@@ -2,13 +2,14 @@ name: firebase_remote_config
 description: Flutter plugin for Firebase Remote Config. Update your application look and feel and behaviour without
   re-releasing.
 homepage: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/firebase_remote_config
-version: 0.3.0+1
+version: 0.3.0+2
 
 dependencies:
   flutter:
     sdk: flutter
 
 dev_dependencies:
+  pedantic: ^1.8.0
   flutter_test:
     sdk: flutter
   firebase_core: ^0.4.0

--- a/packages/firebase_storage/CHANGELOG.md
+++ b/packages/firebase_storage/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.1.2
+
+* Make the pedantic dev_dependency explicit.
+
 ## 3.1.1
 
 * Removed unnecessary debug print statements ("i am working").

--- a/packages/firebase_storage/example/pubspec.yaml
+++ b/packages/firebase_storage/example/pubspec.yaml
@@ -12,6 +12,7 @@ dependencies:
   http: ^0.12.0
 
 dev_dependencies:
+  pedantic: ^1.8.0
   flutter_test:
     sdk: flutter
   flutter_driver:

--- a/packages/firebase_storage/pubspec.yaml
+++ b/packages/firebase_storage/pubspec.yaml
@@ -2,7 +2,7 @@ name: firebase_storage
 description: Flutter plugin for Firebase Cloud Storage, a powerful, simple, and
   cost-effective object storage service for Android and iOS.
 homepage: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/firebase_storage
-version: 3.1.1
+version: 3.1.2
 
 flutter:
   plugin:
@@ -19,6 +19,7 @@ dependencies:
   firebase_core: ^0.4.0
 
 dev_dependencies:
+  pedantic: ^1.8.0
   http: ^0.12.0
   flutter_test:
     sdk: flutter

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,0 @@
-# This only exists so that we can include pedantic in the top level
-# analysis_options.yaml. Each plugin should be published from its own
-# subdirectory underneath packages/.
-name: flutterfire_plugins
-dev_dependencies:
-  pedantic: 1.8.0
-publish_to: none


### PR DESCRIPTION
## Description

Adds pedantic dependencies for all Firebase plugins' `analysis_options`.

## Related Issues

Copy of https://github.com/flutter/plugins/pull/2543

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] If the pull request affects only one plugin, the PR title starts with the name of the plugin in brackets (e.g. [cloud_firestore])
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [ ] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
