### PR TITLE
[firebase_core] Update to use new platform interface

### DIFF
--- a/packages/firebase_core/firebase_core/CHANGELOG.md
+++ b/packages/firebase_core/firebase_core/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.4.4+2
+
+* Update dependency on firebase_core_platform_interface to 1.0.4.
+
 ## 0.4.4+1
 
 * Make the pedantic dev_dependency explicit.

--- a/packages/firebase_core/firebase_core/pubspec.yaml
+++ b/packages/firebase_core/firebase_core/pubspec.yaml
@@ -2,7 +2,7 @@ name: firebase_core
 description: Flutter plugin for Firebase Core, enabling connecting to multiple
   Firebase apps.
 homepage: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/firebase_core/firebase_core
-version: 0.4.4+1
+version: 0.4.4+2
 
 flutter:
   plugin:

--- a/packages/firebase_core/firebase_core/pubspec.yaml
+++ b/packages/firebase_core/firebase_core/pubspec.yaml
@@ -18,7 +18,7 @@ flutter:
         default_package: firebase_core_web
 
 dependencies:
-  firebase_core_platform_interface: ^1.0.0
+  firebase_core_platform_interface: ^1.0.4
   flutter:
     sdk: flutter
   meta: "^1.0.5"
@@ -37,6 +37,7 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
   mockito: ^4.1.1
+  plugin_platform_interface: ^1.0.2
 
 environment:
   sdk: ">=2.0.0-dev.28.0 <3.0.0"

--- a/packages/firebase_core/firebase_core/test/firebase_core_test.dart
+++ b/packages/firebase_core/firebase_core/test/firebase_core_test.dart
@@ -6,6 +6,7 @@ import 'package:firebase_core/firebase_core.dart';
 import 'package:firebase_core_platform_interface/firebase_core_platform_interface.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/mockito.dart';
+import 'package:plugin_platform_interface/plugin_platform_interface.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -31,7 +32,6 @@ void main() {
 
     setUp(() async {
       mock = MockFirebaseCore();
-      when(mock.isMock).thenReturn(true);
       FirebaseCorePlatform.instance = mock;
 
       final PlatformFirebaseApp app = PlatformFirebaseApp(
@@ -102,4 +102,6 @@ void main() {
   });
 }
 
-class MockFirebaseCore extends Mock implements FirebaseCorePlatform {}
+class MockFirebaseCore extends Mock
+    with MockPlatformInterfaceMixin
+    implements FirebaseCorePlatform {}


### PR DESCRIPTION
## Description

Updates `firebase_core` to use version `1.0.4` of the platform interface, which also requires modifying the tests.

## Related Issues

Partially addresses https://github.com/FirebaseExtended/flutterfire/issues/2064

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] If the pull request affects only one plugin, the PR title starts with the name of the plugin in brackets (e.g. [cloud_firestore])
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
