### PR TITLE
[firebase_auth_platform_interface] Use plugin_platform_interface

### DIFF
--- a/packages/firebase_auth/firebase_auth_platform_interface/CHANGELOG.md
+++ b/packages/firebase_auth/firebase_auth_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.1.7
+
+* Use package:plugin_platform_interface
+
 ## 1.1.6
 
 * Make the pedantic dev_dependency explicit.

--- a/packages/firebase_auth/firebase_auth_platform_interface/pubspec.yaml
+++ b/packages/firebase_auth/firebase_auth_platform_interface/pubspec.yaml
@@ -3,12 +3,13 @@ description: A common platform interface for the firebase_auth plugin.
 homepage: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/firebase_auth/firebase_auth_platform_interface
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 1.1.6
+version: 1.1.7
 
 dependencies:
   flutter:
     sdk: flutter
   meta: ^1.0.5
+  plugin_platform_interface: ^1.0.2
 
 dev_dependencies:
   pedantic: ^1.8.0

--- a/packages/firebase_auth/firebase_auth_platform_interface/test/firebase_auth_platform_interface_test.dart
+++ b/packages/firebase_auth/firebase_auth_platform_interface/test/firebase_auth_platform_interface_test.dart
@@ -5,6 +5,7 @@
 import 'package:firebase_auth_platform_interface/firebase_auth_platform_interface.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/mockito.dart';
+import 'package:plugin_platform_interface/plugin_platform_interface.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -17,7 +18,7 @@ void main() {
     test('Cannot be implemented with `implements`', () {
       expect(() {
         FirebaseAuthPlatform.instance = ImplementsFirebaseAuthPlatform();
-      }, throwsAssertionError);
+      }, throwsNoSuchMethodError);
     });
 
     test('Can be extended', () {
@@ -25,15 +26,18 @@ void main() {
     });
 
     test('Can be mocked with `implements`', () {
-      final ImplementsFirebaseAuthPlatform mock =
-          ImplementsFirebaseAuthPlatform();
-      when(mock.isMock).thenReturn(true);
+      final MockFirebaseAuthPlatform mock = MockFirebaseAuthPlatform();
       FirebaseAuthPlatform.instance = mock;
     });
   });
 }
 
-class ImplementsFirebaseAuthPlatform extends Mock
+class ImplementsFirebaseAuthPlatform implements FirebaseAuthPlatform {
+  noSuchMethod(Invocation invocation) => super.noSuchMethod(invocation);
+}
+
+class MockFirebaseAuthPlatform extends Mock
+    with MockPlatformInterfaceMixin
     implements FirebaseAuthPlatform {}
 
 class ExtendsFirebaseAuthPlatform extends FirebaseAuthPlatform {}


### PR DESCRIPTION
## Description

Updates the `firebase_auth` platform interface to use `package:plugin_platform_interface`.

## Related Issues

Partially addresses https://github.com/FirebaseExtended/flutterfire/issues/2064 and https://github.com/FirebaseExtended/flutterfire/issues/1939

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] If the pull request affects only one plugin, the PR title starts with the name of the plugin in brackets (e.g. [cloud_firestore])
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
