### PR TITLE
[firebase_messaging] Added dynamic firebase api configuration

### DIFF
--- a/packages/firebase_messaging/CHANGELOG.md
+++ b/packages/firebase_messaging/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 6.1.11
+
+* Add the `FirebaseOptions options` parameter to the `FirebaseMessaging.configure()` call to set the firebase configuration at runtime.
+
 ## 6.0.11
 
 * Make the pedantic dev_dependency explicit.

--- a/packages/firebase_messaging/README.md
+++ b/packages/firebase_messaging/README.md
@@ -286,6 +286,58 @@ Future<Map<String, dynamic>> sendAndRetrieveMessage() async {
 }
 ```
 
+## Advanced usage
+
+### Dynamic firebase configuration
+If you need to configure firebase at runtime (instead of using `google-service.json` / `GoogleService-Info.plist`) 
+you can pass an options object to the configure call:
+```dart
+import 'dart:io' show Platform;
+final firebase = FirebaseMessaging();
+
+var options = Platform.isIOS
+    ? FirebaseOptions( // iOS options
+              clientId: "...",
+              apiKey: "...",
+              gcmSenderId: "...",
+              bundleId: "...",
+              projectId: "...",
+              storageBucket: "...",
+              googleAppId: "...",
+              databaseUrl: "...",
+    )
+    : FirebaseOptions( // Android options
+                clientId: "...",
+                apiKey: "...",
+                gcmSenderId: "...",
+                projectId: "...",
+                storageBucket: "...",
+                googleAppId: "...",
+                databaseUrl: "...",
+      );
+
+firebase.configure(
+    options: options,
+);
+```
+
+### On Android:
+You need to disable the `FirebaseInitProvider`.
+To do this, put this into your `AndroidManifest.xml` inside the `<application>` tag:
+```xml
+<provider
+    android:name="com.google.firebase.provider.FirebaseInitProvider"
+    android:authorities="${applicationId}.firebaseinitprovider"
+    tools:node="remove" />
+```
+
+To hide the error message `Missing google_app_id. Firebase Analytics disabled.` put the following lines into your `res/strings.xml` of your app:
+```xml
+<!-- Fake ID to hide the Firebase Analytics Error Message -->
+<string name="google_app_id">1:0000000000000:android:0000000000000000</string> 
+```
+
+
 ## Issues and feedback
 
 Please file Flutterfire specific issues, bugs, or feature requests in our [issue tracker](https://github.com/FirebaseExtended/flutterfire/issues/new).

--- a/packages/firebase_messaging/android/src/main/java/io/flutter/plugins/firebasemessaging/FirebaseMessagingPlugin.java
+++ b/packages/firebase_messaging/android/src/main/java/io/flutter/plugins/firebasemessaging/FirebaseMessagingPlugin.java
@@ -54,7 +54,6 @@ public class FirebaseMessagingPlugin extends BroadcastReceiver
 
   private void onAttachedToEngine(Context context, BinaryMessenger binaryMessenger) {
     this.applicationContext = context;
-    FirebaseApp.initializeApp(applicationContext);
     channel = new MethodChannel(binaryMessenger, "plugins.flutter.io/firebase_messaging");
     final MethodChannel backgroundCallbackChannel =
         new MethodChannel(binaryMessenger, "plugins.flutter.io/firebase_messaging_background");
@@ -182,6 +181,34 @@ public class FirebaseMessagingPlugin extends BroadcastReceiver
       FlutterFirebaseMessagingService.onInitialized();
       result.success(true);
     } else if ("configure".equals(call.method)) {
+      if(call.arguments instanceof Map)
+      {
+        @SuppressWarnings("unchecked")
+        Map<String, String> arguments = ((Map<String, String>) call.arguments);
+
+        String apiKey, googleAppId;
+        if ((apiKey = arguments.get("apiKey")) == null) {
+          result.error("apiKey", "apiKey must not be empty!", null);
+          return;
+        }
+        if ((googleAppId = arguments.get("googleAppId")) == null) {
+          result.error("googleAppId", "googleAppId must not be empty!", null);
+          return;
+        }
+
+        FirebaseOptions options = new FirebaseOptions.Builder()
+                .setApiKey(apiKey)
+                .setGcmSenderId(arguments.get("gcmSenderId"))
+                .setProjectId(arguments.get("projectId"))
+                .setStorageBucket(arguments.get("storageBucket"))
+                .setApplicationId(googleAppId)
+                .setDatabaseUrl(arguments.get("databaseUrl"))
+                .setGaTrackingId(arguments.get("gaTrackingId"))
+                .build();
+         FirebaseApp.initializeApp(applicationContext, options);
+      } else {
+         FirebaseApp.initializeApp(applicationContext);
+      }
       FirebaseInstanceId.getInstance()
           .getInstanceId()
           .addOnCompleteListener(

--- a/packages/firebase_messaging/ios/Classes/FLTFirebaseMessagingPlugin.m
+++ b/packages/firebase_messaging/ios/Classes/FLTFirebaseMessagingPlugin.m
@@ -51,12 +51,6 @@ static NSObject<FlutterPluginRegistrar> *_registrar;
   if (self) {
     _channel = channel;
     _resumingFromBackground = NO;
-    if (![FIRApp appNamed:@"__FIRAPP_DEFAULT"]) {
-      NSLog(@"Configuring the default Firebase app...");
-      [FIRApp configure];
-      NSLog(@"Configured the default Firebase app %@.", [FIRApp defaultApp].name);
-    }
-    [FIRMessaging messaging].delegate = self;
   }
   return self;
 }
@@ -137,6 +131,58 @@ static NSObject<FlutterPluginRegistrar> *_registrar;
       result([NSNumber numberWithBool:YES]);
     }
   } else if ([@"configure" isEqualToString:method]) {
+    if (![FIRApp appNamed:@"__FIRAPP_DEFAULT"]) {
+        NSLog(@"Configuring the default Firebase app...");
+        
+        if(call.arguments != nil && [call.arguments isKindOfClass:[NSDictionary class]]) {
+            NSDictionary *arguments = call.arguments;
+            NSString
+            *googleAppId,
+            *gcmSenderId,
+            *clientId,
+            *apiKey,
+            *bundleId,
+            *projectId,
+            *storageBucket,
+            *databaseUrl;
+            
+            if((googleAppId = [arguments objectForKey:@"googleAppId"]) == nil) {
+                result([FlutterError errorWithCode:@"googleAppId" message:@"googleAppId must not be empty" details:nil]);
+                return;
+            }
+            if((gcmSenderId = [arguments objectForKey:@"gcmSenderId"]) == nil) {
+                result([FlutterError errorWithCode:@"gcmSenderId" message:@"gcmSenderId must not be empty" details:nil]);
+                return;
+            }
+            
+            FIROptions *options = [[FIROptions alloc] initWithGoogleAppID:googleAppId GCMSenderID:gcmSenderId];
+            
+            if((clientId = [arguments objectForKey:@"clientId"]) == nil) {
+                [options setClientID:clientId];
+            }
+            if((apiKey = [arguments objectForKey:@"apiKey"]) != nil) {
+                [options setAPIKey:apiKey];
+            }
+            if((bundleId = [arguments objectForKey:@"bundleId"]) != nil) {
+                [options setBundleID:bundleId];
+            }
+            if((projectId = [arguments objectForKey:@"projectId"]) != nil) {
+                [options setProjectID:projectId];
+            }
+            if((storageBucket = [arguments objectForKey:@"storageBucket"]) != nil) {
+                [options setStorageBucket:storageBucket];
+            }
+            if((databaseUrl = [arguments objectForKey:@"databaseUrl"]) != nil) {
+                [options setDatabaseURL:databaseUrl];
+            }
+            [FIRApp configureWithOptions:options];
+        } else {
+            [FIRApp configure];
+        }
+        [FIRMessaging messaging].delegate = self;
+        NSLog(@"Configured the default Firebase app %@.", [FIRApp defaultApp].name);
+    }
+
     [FIRMessaging messaging].shouldEstablishDirectChannel = true;
     [[UIApplication sharedApplication] registerForRemoteNotifications];
     if (_launchNotification != nil) {

--- a/packages/firebase_messaging/lib/firebase_messaging.dart
+++ b/packages/firebase_messaging/lib/firebase_messaging.dart
@@ -73,6 +73,7 @@ class FirebaseMessaging {
   MessageHandler _onBackgroundMessage;
   MessageHandler _onLaunch;
   MessageHandler _onResume;
+  FirebaseOptions _options;
 
   /// On iOS, prompts the user for notification permissions the first time
   /// it is called.
@@ -106,12 +107,14 @@ class FirebaseMessaging {
     MessageHandler onBackgroundMessage,
     MessageHandler onLaunch,
     MessageHandler onResume,
+    FirebaseOptions options,
   }) {
     _onMessage = onMessage;
     _onLaunch = onLaunch;
     _onResume = onResume;
+    _options = options;
     _channel.setMethodCallHandler(_handleMethod);
-    _channel.invokeMethod<void>('configure');
+    _channel.invokeMethod<void>('configure', _options?.asMap());
     if (onBackgroundMessage != null) {
       _onBackgroundMessage = onBackgroundMessage;
       final CallbackHandle backgroundSetupHandle =
@@ -235,4 +238,41 @@ class IosNotificationSettings {
 
   @override
   String toString() => 'PushNotificationSettings ${toMap()}';
+}
+
+class FirebaseOptions {
+  final String clientId;
+  final String apiKey;
+  final String gcmSenderId;
+  final String bundleId;
+  final String projectId;
+  final String storageBucket;
+  final String googleAppId;
+  final String databaseUrl;
+
+  /// Creates a new [FirebaseOptions] object
+  FirebaseOptions({
+    this.clientId,
+    this.apiKey,
+    this.gcmSenderId,
+    this.bundleId,
+    this.projectId,
+    this.storageBucket,
+    this.googleAppId,
+    this.databaseUrl,
+  });
+
+  /// Converts the options to a map for passing it through the platform channel
+  Map<String, String> asMap() {
+    return {
+      "clientId": clientId,
+      "apiKey": apiKey,
+      "gcmSenderId": gcmSenderId,
+      "bundleId": bundleId,
+      "projectId": projectId,
+      "storageBucket": storageBucket,
+      "googleAppId": googleAppId,
+      "databaseUrl": databaseUrl,
+    };
+  }
 }

--- a/packages/firebase_messaging/pubspec.yaml
+++ b/packages/firebase_messaging/pubspec.yaml
@@ -2,7 +2,7 @@ name: firebase_messaging
 description: Flutter plugin for Firebase Cloud Messaging, a cross-platform
   messaging solution that lets you reliably deliver messages on Android and iOS.
 homepage: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/firebase_messaging
-version: 6.0.11
+version: 6.1.0
 
 flutter:
   plugin:

--- a/packages/firebase_messaging/test/firebase_messaging_test.dart
+++ b/packages/firebase_messaging/test/firebase_messaging_test.dart
@@ -68,6 +68,22 @@ void main() {
     verify(mockChannel.invokeMethod<void>('configure'));
   });
 
+  test('configure with options', () {
+    var firebaseOptions = FirebaseOptions(
+        clientId: "1",
+        apiKey: "2",
+        gcmSenderId: "3",
+        bundleId: "4",
+        projectId: "5",
+        storageBucket: "6",
+        googleAppId: "7",
+        databaseUrl: "8",
+    );
+    firebaseMessaging.configure(options: firebaseOptions);
+    verify(mockChannel.setMethodCallHandler(any));
+    verify(mockChannel.invokeMethod<void>('configure', firebaseOptions.asMap()));
+  });
+
   test('incoming token', () async {
     firebaseMessaging.configure();
     final dynamic handler =


### PR DESCRIPTION
## Description

This PR extends the `firebase_messaging` plugin to provide the Firebase configuration at runtime instead of using the `google-service.json` / `GoogleService-Info.plist`

Detailed changes:
`FirebaseMessagingPlugin.java`:
- Moved `FirebaseApp.initializeApp` inside the `onMethodCall` method in the "configure" branch
- Checking if `call.arguments` is provided and it is an instance of `Map`.
  - If true create a FirebaseOptions object from the map and use it.
  - Otherwise initialize Firebase as before

`FLTFirebaseMessagingPlugin.m`:
- Moved `[FIRApp configure]` etc. inside the `handleMethodCall` method in the "configure" branch.
- Checking if `call.arguments` is provided and it is an instance of `NSDictionary`.
  - If true create a `FIROptions` object and init it with the googleAppId and gcmSenderId and pass it to `[FIRApp configureWithOptions:options]` to configure Firebase
  - Otherwise initialize Firebase as before

`firebase_messaging.dart`:
- Added the `FirebaseOptions` class, which represents the configuration
- Invoke the "configure" channel method with the options (if they are not null)

`firebase_messaging_test.dart`:
- Added a test for the new method

`README.md`:
- Added the "Advanced usage" section

## Related Issues

- [Init firebase at runtime / without google-services.json #2031](#2031).

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] If the pull request affects only one plugin, the PR title starts with the name of the plugin in brackets (e.g. [cloud_firestore])
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
