### PR TITLE
[cloud_firestore] Strip Document Reference firestore equality to solve equality & map key bug #2081

### DIFF
--- a/packages/cloud_firestore/cloud_firestore/CHANGELOG.md
+++ b/packages/cloud_firestore/cloud_firestore/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.13.4+1
+
+* Fix equality comparison for `DocumentReference` instances to only use the `path` instance variable.
+
 ## 0.13.4
 
 * Support equality comparison on `FieldValue` instances.

--- a/packages/cloud_firestore/cloud_firestore/lib/src/document_reference.dart
+++ b/packages/cloud_firestore/cloud_firestore/lib/src/document_reference.dart
@@ -22,7 +22,7 @@ class DocumentReference {
 
   @override
   bool operator ==(dynamic o) =>
-      o is DocumentReference && o.firestore == firestore && o.path == path;
+      o is DocumentReference && o.path == path;
 
   @override
   int get hashCode => hashList(_delegate.path.split("/"));

--- a/packages/cloud_firestore/cloud_firestore/lib/src/document_reference.dart
+++ b/packages/cloud_firestore/cloud_firestore/lib/src/document_reference.dart
@@ -21,8 +21,7 @@ class DocumentReference {
   }
 
   @override
-  bool operator ==(dynamic o) =>
-      o is DocumentReference && o.path == path;
+  bool operator ==(dynamic o) => o is DocumentReference && o.path == path;
 
   @override
   int get hashCode => hashList(_delegate.path.split("/"));

--- a/packages/cloud_firestore/cloud_firestore/pubspec.yaml
+++ b/packages/cloud_firestore/cloud_firestore/pubspec.yaml
@@ -3,7 +3,7 @@ description:
   Flutter plugin for Cloud Firestore, a cloud-hosted, noSQL database with
   live synchronization and offline support on Android and iOS.
 homepage: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/cloud_firestore/cloud_firestore
-version: 0.13.4+1
+version: 0.13.4+2
 
 flutter:
   plugin:

--- a/packages/cloud_firestore/cloud_firestore/pubspec.yaml
+++ b/packages/cloud_firestore/cloud_firestore/pubspec.yaml
@@ -3,7 +3,7 @@ description:
   Flutter plugin for Cloud Firestore, a cloud-hosted, noSQL database with
   live synchronization and offline support on Android and iOS.
 homepage: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/cloud_firestore/cloud_firestore
-version: 0.13.5
+version: 0.13.4+1
 
 flutter:
   plugin:

--- a/packages/cloud_firestore/cloud_firestore/pubspec.yaml
+++ b/packages/cloud_firestore/cloud_firestore/pubspec.yaml
@@ -3,7 +3,7 @@ description:
   Flutter plugin for Cloud Firestore, a cloud-hosted, noSQL database with
   live synchronization and offline support on Android and iOS.
 homepage: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/cloud_firestore/cloud_firestore
-version: 0.13.4
+version: 0.13.5
 
 flutter:
   plugin:


### PR DESCRIPTION
## Description
Due to #2081, I've decided to create a simple proposal - a patch fix for the error. It simply removes the firestore equality check to let DocumentReference checking be done solely on the path.

The expected behavior is for DocumentReference to be a valid key in a map. However, due to #2081, simply using DocumentReference as a key in a map is not possible.

First, let me confirm that equality between keys is needed for a map in Dart.

Creating a dummy class as such below:
```dart
class KeyTester {
  final String data;

  KeyTester(this.data);

  // Always returns the same hashcode
  @override
  int get hashCode => 10000;

  // Always returns not equal to any other object
  @override
  bool operator ==(dynamic o) => false;
}
```

And running the code below:
```dart
// Instantiate an instance `KeyTester` keyA
KeyTester key = KeyTester("KeyA");

// Create a map with key type KeyTester
Map<KeyTester, String> map = {
  key: 'Key',
};

// Even though I use the same instance of `KeyTester`, `.ey`, `map` still returns null. And it doesn't know if it contains that key. Even though, by the third check, it's obvious that they are the same key/

print("Map Data @ Key: ${map[key]}");
// Map Data @ Key: null

print("Map Key Exists: ${map.containsKey(key)}");
// Map Key Exists: false
  
print("Key Equality: ${key.data == map.keys.toList()[0].data}");
// Key Equality: true
```

As you can see from the output above, even with the same `hashCode`, Dart checks to see if the keys are equal or not. 

Extending this to a test using Firestore `DocumentReference`s, the actual behavior is as follows:

```dart
DocumentReference refA = Firestore.instance.document("foo/bar");
DocumentReference refB = Firestore.instance.document("foo/bar");

Map<DocumentReference, String> anotherMap = {
  refA: 'RefA',
};

print("refA: ${refA.path}");
// refA: foo/bar

print("refB: ${refB.path}");
// refB: foo/bar

print("Another Map Key Equality: ${refA.path == refB.path}");
// Another Map Key Equality: true

print("Another Map Data @ Key: ${anotherMap[refA]}");
// Another Map Data @ Key: RefA

print("Another Map Data @ Key: ${anotherMap[refB]}");
// Another Map Data @ Key: null

print("${refA == refB}");
// false

print("${refA.hashCode == refB.hashCode}");
// true
```

Running the same code above with the changes proposed yields the following results, the expected results:

``` dart
print("Another Map Data @ Key: ${anotherMap[refA]}");
// Another Map Data @ Key: RefA

print("Another Map Data @ Key: ${anotherMap[refB]}");
// Another Map Data @ Key: RefA

print("${refA == refB}");
// false

print("${refA.hashCode == refB.hashCode}");
// false
```

## Checklist
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] If the pull request affects only one plugin, the PR title starts with the name of the plugin in brackets (e.g. [cloud_firestore])
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.