### PR TITLE
[firebase_crashlytics] Remove WorkspaceSettings.xcsettings

### DIFF
--- a/packages/firebase_crashlytics/CHANGELOG.md
+++ b/packages/firebase_crashlytics/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.3+2
+
+* Remove WorkspaceSettings.xcsettings file in the Mac example app.
+
 ## 0.1.3+1
 
 * Make the pedantic dev_dependency explicit.

--- a/packages/firebase_crashlytics/CHANGELOG.md
+++ b/packages/firebase_crashlytics/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 0.1.3+2
 
-* Remove WorkspaceSettings.xcsettings file in the Mac example app.
+* Fix Cirrus build by removing WorkspaceSettings.xcsettings file in the iOS example app.
 
 ## 0.1.3+1
 

--- a/packages/firebase_crashlytics/example/ios/Runner.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
+++ b/packages/firebase_crashlytics/example/ios/Runner.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
@@ -1,8 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-<plist version="1.0">
-<dict>
-	<key>BuildSystemType</key>
-	<string>Original</string>
-</dict>
-</plist>

--- a/packages/firebase_crashlytics/pubspec.yaml
+++ b/packages/firebase_crashlytics/pubspec.yaml
@@ -2,7 +2,7 @@ name: firebase_crashlytics
 description:
   Flutter plugin for Firebase Crashlytics. It reports uncaught errors to the
   Firebase console.
-version: 0.1.3+1
+version: 0.1.3+2
 homepage: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/firebase_crashlytics
 
 environment:


### PR DESCRIPTION
## Description

Removes a file that shouldn't be checked in. 

## Related Issues

https://github.com/flutter/plugins/pull/2592 - I believe this fixed the build on Cirrus for flutter/plugins, so hopefully it will do that here too.
https://github.com/FirebaseExtended/flutterfire/pull/2099 - PR waiting for this fix to land on green