### PR TITLE
[all] Remove remaining UserAgent.h script from podspecs

### DIFF
--- a/packages/firebase_analytics/firebase_analytics/.gitignore
+++ b/packages/firebase_analytics/firebase_analytics/.gitignore
@@ -1,1 +1,0 @@
-ios/Classes/UserAgent.h

--- a/packages/firebase_analytics/firebase_analytics/CHANGELOG.md
+++ b/packages/firebase_analytics/firebase_analytics/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 5.0.12+1
+
+* Fix for missing UserAgent.h compilation failures.
+
 ## 5.0.12
 
 * Make the pedantic dev_dependency explicit.

--- a/packages/firebase_analytics/firebase_analytics/CHANGELOG.md
+++ b/packages/firebase_analytics/firebase_analytics/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 5.0.12+1
+## 5.0.13
 
 * Fix for missing UserAgent.h compilation failures.
 

--- a/packages/firebase_analytics/firebase_analytics/ios/Classes/FLTFirebaseAnalyticsPlugin.m
+++ b/packages/firebase_analytics/firebase_analytics/ios/Classes/FLTFirebaseAnalyticsPlugin.m
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 #import "FLTFirebaseAnalyticsPlugin.h"
-#import "UserAgent.h"
 
 #import "Firebase/Firebase.h"
 

--- a/packages/firebase_analytics/firebase_analytics/ios/firebase_analytics.podspec
+++ b/packages/firebase_analytics/firebase_analytics/ios/firebase_analytics.podspec
@@ -25,9 +25,5 @@ Firebase Analytics plugin for Flutter.
   s.dependency 'Firebase/Analytics', '~> 6.0'
   s.static_framework = true
 
-  s.prepare_command = <<-CMD
-      echo // Generated file, do not edit > Classes/UserAgent.h
-      echo "#define LIBRARY_VERSION @\\"#{libraryVersion}\\"" >> Classes/UserAgent.h
-      echo "#define LIBRARY_NAME @\\"flutter-fire-analytics\\"" >> Classes/UserAgent.h
-    CMD
+  s.pod_target_xcconfig = { 'GCC_PREPROCESSOR_DEFINITIONS' => "LIBRARY_VERSION=\\@\\\"#{libraryVersion}\\\" LIBRARY_NAME=\\@\\\"flutter-fire-analytics\\\"" }
 end

--- a/packages/firebase_analytics/firebase_analytics/pubspec.yaml
+++ b/packages/firebase_analytics/firebase_analytics/pubspec.yaml
@@ -2,7 +2,7 @@ name: firebase_analytics
 description: Flutter plugin for Google Analytics for Firebase, an app measurement
   solution that provides insight on app usage and user engagement on Android and iOS.
 homepage: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/firebase_analytics/firebase_analytics
-version: 5.0.12
+version: 5.0.12+1
 
 flutter:
   plugin:

--- a/packages/firebase_analytics/firebase_analytics/pubspec.yaml
+++ b/packages/firebase_analytics/firebase_analytics/pubspec.yaml
@@ -2,7 +2,7 @@ name: firebase_analytics
 description: Flutter plugin for Google Analytics for Firebase, an app measurement
   solution that provides insight on app usage and user engagement on Android and iOS.
 homepage: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/firebase_analytics/firebase_analytics
-version: 5.0.12+1
+version: 5.0.13
 
 flutter:
   plugin:

--- a/packages/firebase_database/.gitignore
+++ b/packages/firebase_database/.gitignore
@@ -1,1 +1,0 @@
-ios/Classes/UserAgent.h

--- a/packages/firebase_database/CHANGELOG.md
+++ b/packages/firebase_database/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.1.3+1
+
+* Fix for missing UserAgent.h compilation failures.
+
 ## 3.1.3
 
 * Replace deprecated `getFlutterEngine` call on Android.

--- a/packages/firebase_database/CHANGELOG.md
+++ b/packages/firebase_database/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 3.1.3+1
+## 3.1.4
 
 * Fix for missing UserAgent.h compilation failures.
 

--- a/packages/firebase_database/ios/Classes/FLTFirebaseDatabasePlugin.m
+++ b/packages/firebase_database/ios/Classes/FLTFirebaseDatabasePlugin.m
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 #import "FLTFirebaseDatabasePlugin.h"
-#import "UserAgent.h"
 
 #import <Firebase/Firebase.h>
 

--- a/packages/firebase_database/ios/firebase_database.podspec
+++ b/packages/firebase_database/ios/firebase_database.podspec
@@ -24,9 +24,5 @@ Firebase Database plugin for Flutter.
   s.dependency 'Firebase/Database'
   s.static_framework = true
 
-   s.prepare_command = <<-CMD
-      echo // Generated file, do not edit > Classes/UserAgent.h
-      echo "#define LIBRARY_VERSION @\\"#{libraryVersion}\\"" >> Classes/UserAgent.h
-      echo "#define LIBRARY_NAME @\\"flutter-fire-rtdb\\"" >> Classes/UserAgent.h
-    CMD
+  s.pod_target_xcconfig = { 'GCC_PREPROCESSOR_DEFINITIONS' => "LIBRARY_VERSION=\\@\\\"#{libraryVersion}\\\" LIBRARY_NAME=\\@\\\"flutter-fire-rtdb\\\"" }
 end

--- a/packages/firebase_database/pubspec.yaml
+++ b/packages/firebase_database/pubspec.yaml
@@ -2,7 +2,7 @@ name: firebase_database
 description: Flutter plugin for Firebase Database, a cloud-hosted NoSQL database
   with realtime data syncing across Android and iOS clients, and offline access.
 homepage: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/firebase_database
-version: 3.1.3
+version: 3.1.3+1
 
 flutter:
   plugin:

--- a/packages/firebase_database/pubspec.yaml
+++ b/packages/firebase_database/pubspec.yaml
@@ -2,7 +2,7 @@ name: firebase_database
 description: Flutter plugin for Firebase Database, a cloud-hosted NoSQL database
   with realtime data syncing across Android and iOS clients, and offline access.
 homepage: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/firebase_database
-version: 3.1.3+1
+version: 3.1.4
 
 flutter:
   plugin:

--- a/packages/firebase_dynamic_links/.gitignore
+++ b/packages/firebase_dynamic_links/.gitignore
@@ -1,1 +1,0 @@
-ios/Classes/UserAgent.h

--- a/packages/firebase_dynamic_links/CHANGELOG.md
+++ b/packages/firebase_dynamic_links/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.5.0+12
+
+* Fix for missing UserAgent.h compilation failures.
+
 ## 0.5.0+11
 
 * Replace deprecated `getFlutterEngine` call on Android.

--- a/packages/firebase_dynamic_links/ios/Classes/FLTFirebaseDynamicLinksPlugin.m
+++ b/packages/firebase_dynamic_links/ios/Classes/FLTFirebaseDynamicLinksPlugin.m
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 #import "FLTFirebaseDynamicLinksPlugin.h"
-#import "UserAgent.h"
 
 #import "Firebase/Firebase.h"
 

--- a/packages/firebase_dynamic_links/ios/firebase_dynamic_links.podspec
+++ b/packages/firebase_dynamic_links/ios/firebase_dynamic_links.podspec
@@ -25,9 +25,5 @@ Flutter plugin for Google Dynamic Links for Firebase, an app solution for creati
   s.ios.deployment_target = '8.0'
   s.static_framework = true
 
-  s.prepare_command = <<-CMD
-      echo // Generated file, do not edit > Classes/UserAgent.h
-      echo "#define LIBRARY_VERSION @\\"#{libraryVersion}\\"" >> Classes/UserAgent.h
-      echo "#define LIBRARY_NAME @\\"flutter-fire-dl\\"" >> Classes/UserAgent.h
-    CMD
+  s.pod_target_xcconfig = { 'GCC_PREPROCESSOR_DEFINITIONS' => "LIBRARY_VERSION=\\@\\\"#{libraryVersion}\\\" LIBRARY_NAME=\\@\\\"flutter-fire-dl\\\"" }
 end

--- a/packages/firebase_dynamic_links/pubspec.yaml
+++ b/packages/firebase_dynamic_links/pubspec.yaml
@@ -1,7 +1,7 @@
 name: firebase_dynamic_links
 description: Flutter plugin for Google Dynamic Links for Firebase, an app solution for creating
   and handling links across multiple platforms.
-version: 0.5.0+11
+version: 0.5.0+12
 homepage: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/firebase_dynamic_links
 
 dependencies:

--- a/packages/firebase_in_app_messaging/CHANGELOG.md
+++ b/packages/firebase_in_app_messaging/CHANGELOG.md
@@ -1,7 +1,3 @@
-## 0.1.1+4
-
-* Fix for missing UserAgent.h compilation failures.
-
 ## 0.1.1+3
 
 * Replace deprecated `getFlutterEngine` call on Android.

--- a/packages/firebase_in_app_messaging/CHANGELOG.md
+++ b/packages/firebase_in_app_messaging/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.1+4
+
+* Fix for missing UserAgent.h compilation failures.
+
 ## 0.1.1+3
 
 * Replace deprecated `getFlutterEngine` call on Android.

--- a/packages/firebase_messaging/.gitignore
+++ b/packages/firebase_messaging/.gitignore
@@ -1,1 +1,0 @@
-ios/Classes/UserAgent.h

--- a/packages/firebase_messaging/CHANGELOG.md
+++ b/packages/firebase_messaging/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 6.0.13+1
+
+* Fix for missing UserAgent.h compilation failures.
+
 ## 6.0.13
 
 * Implement `UNUserNotificationCenterDelegate` methods to allow plugin to work when method swizzling is disabled.

--- a/packages/firebase_messaging/CHANGELOG.md
+++ b/packages/firebase_messaging/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 6.0.13+1
+## 6.0.14
 
 * Fix for missing UserAgent.h compilation failures.
 

--- a/packages/firebase_messaging/ios/Classes/FLTFirebaseMessagingPlugin.m
+++ b/packages/firebase_messaging/ios/Classes/FLTFirebaseMessagingPlugin.m
@@ -5,7 +5,6 @@
 #import <UserNotifications/UserNotifications.h>
 
 #import "FLTFirebaseMessagingPlugin.h"
-#import "UserAgent.h"
 
 #import "Firebase/Firebase.h"
 

--- a/packages/firebase_messaging/ios/firebase_messaging.podspec
+++ b/packages/firebase_messaging/ios/firebase_messaging.podspec
@@ -25,9 +25,5 @@ Firebase Cloud Messaging plugin for Flutter.
   s.static_framework = true
   s.ios.deployment_target = '8.0'
 
-  s.prepare_command = <<-CMD
-      echo // Generated file, do not edit > Classes/UserAgent.h
-      echo "#define LIBRARY_VERSION @\\"#{libraryVersion}\\"" >> Classes/UserAgent.h
-      echo "#define LIBRARY_NAME @\\"flutter-fire-fcm\\"" >> Classes/UserAgent.h
-    CMD
+  s.pod_target_xcconfig = { 'GCC_PREPROCESSOR_DEFINITIONS' => "LIBRARY_VERSION=\\@\\\"#{libraryVersion}\\\" LIBRARY_NAME=\\@\\\"flutter-fire-fcm\\\"" }
 end

--- a/packages/firebase_messaging/pubspec.yaml
+++ b/packages/firebase_messaging/pubspec.yaml
@@ -2,7 +2,7 @@ name: firebase_messaging
 description: Flutter plugin for Firebase Cloud Messaging, a cross-platform
   messaging solution that lets you reliably deliver messages on Android and iOS.
 homepage: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/firebase_messaging
-version: 6.0.13
+version: 6.0.13+1
 
 flutter:
   plugin:

--- a/packages/firebase_messaging/pubspec.yaml
+++ b/packages/firebase_messaging/pubspec.yaml
@@ -2,7 +2,7 @@ name: firebase_messaging
 description: Flutter plugin for Firebase Cloud Messaging, a cross-platform
   messaging solution that lets you reliably deliver messages on Android and iOS.
 homepage: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/firebase_messaging
-version: 6.0.13+1
+version: 6.0.14
 
 flutter:
   plugin:

--- a/packages/firebase_ml_vision/.gitignore
+++ b/packages/firebase_ml_vision/.gitignore
@@ -1,1 +1,0 @@
-ios/Classes/UserAgent.h

--- a/packages/firebase_ml_vision/CHANGELOG.md
+++ b/packages/firebase_ml_vision/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.9.3+9
+
+* Fix for missing UserAgent.h compilation failures.
+
 ## 0.9.3+8
 
 * Replace deprecated `getFlutterEngine` call on Android.

--- a/packages/firebase_ml_vision/ios/Classes/FLTFirebaseMlVisionPlugin.m
+++ b/packages/firebase_ml_vision/ios/Classes/FLTFirebaseMlVisionPlugin.m
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 #import "FLTFirebaseMlVisionPlugin.h"
-#import "UserAgent.h"
 
 static FlutterError *getFlutterError(NSError *error) {
   return [FlutterError errorWithCode:[NSString stringWithFormat:@"Error %d", (int)error.code]

--- a/packages/firebase_ml_vision/ios/firebase_ml_vision.podspec
+++ b/packages/firebase_ml_vision/ios/firebase_ml_vision.podspec
@@ -26,9 +26,5 @@ An SDK that brings Google's machine learning expertise to Android and iOS apps i
   s.ios.deployment_target = '9.0'
   s.static_framework = true
 
-  s.prepare_command = <<-CMD
-      echo // Generated file, do not edit > Classes/UserAgent.h
-      echo "#define LIBRARY_VERSION @\\"#{libraryVersion}\\"" >> Classes/UserAgent.h
-      echo "#define LIBRARY_NAME @\\"flutter-fire-ml-vis\\"" >> Classes/UserAgent.h
-    CMD
+  s.pod_target_xcconfig = { 'GCC_PREPROCESSOR_DEFINITIONS' => "LIBRARY_VERSION=\\@\\\"#{libraryVersion}\\\" LIBRARY_NAME=\\@\\\"flutter-fire-ml-vis\\\"" }
 end

--- a/packages/firebase_ml_vision/pubspec.yaml
+++ b/packages/firebase_ml_vision/pubspec.yaml
@@ -1,7 +1,7 @@
 name: firebase_ml_vision
 description: Flutter plugin for Firebase machine learning vision services.
 homepage: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/firebase_ml_vision
-version: 0.9.3+8
+version: 0.9.3+9
 
 dependencies:
   flutter:

--- a/packages/firebase_performance/.gitignore
+++ b/packages/firebase_performance/.gitignore
@@ -1,1 +1,0 @@
-ios/Classes/UserAgent.h

--- a/packages/firebase_performance/CHANGELOG.md
+++ b/packages/firebase_performance/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.1+8
+
+* Fix for missing UserAgent.h compilation failures.
+
 ## 0.3.1+7
 
 * Replace deprecated `getFlutterEngine` call on Android.

--- a/packages/firebase_performance/ios/Classes/FLTFirebasePerformancePlugin.m
+++ b/packages/firebase_performance/ios/Classes/FLTFirebasePerformancePlugin.m
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 #import "FLTFirebasePerformancePlugin+Internal.h"
-#import "UserAgent.h"
 
 @implementation FLTFirebasePerformancePlugin
 static NSMutableDictionary<NSNumber *, id<MethodCallHandler>> *methodHandlers;

--- a/packages/firebase_performance/ios/firebase_performance.podspec
+++ b/packages/firebase_performance/ios/firebase_performance.podspec
@@ -25,9 +25,5 @@ Firebase Performance plugin for Flutter.
   s.ios.deployment_target = '8.0'
   s.static_framework = true
 
-  s.prepare_command = <<-CMD
-      echo // Generated file, do not edit > Classes/UserAgent.h
-      echo "#define LIBRARY_VERSION @\\"#{libraryVersion}\\"" >> Classes/UserAgent.h
-      echo "#define LIBRARY_NAME @\\"flutter-fire-perf\\"" >> Classes/UserAgent.h
-    CMD
+  s.pod_target_xcconfig = { 'GCC_PREPROCESSOR_DEFINITIONS' => "LIBRARY_VERSION=\\@\\\"#{libraryVersion}\\\" LIBRARY_NAME=\\@\\\"flutter-fire-perf\\\"" }
 end

--- a/packages/firebase_performance/pubspec.yaml
+++ b/packages/firebase_performance/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for Google Performance Monitoring for Firebase, an a
   measurement solution that monitors traces and HTTP/S network requests on Android and
   iOS.
 homepage: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/firebase_performance
-version: 0.3.1+7
+version: 0.3.1+8
 
 dependencies:
   flutter:

--- a/packages/firebase_remote_config/.gitignore
+++ b/packages/firebase_remote_config/.gitignore
@@ -1,1 +1,0 @@
-ios/Classes/UserAgent.h

--- a/packages/firebase_remote_config/CHANGELOG.md
+++ b/packages/firebase_remote_config/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.0+4
+
+* Fix for missing UserAgent.h compilation failures.
+
 ## 0.3.0+3
 
 * Replace deprecated `getFlutterEngine` call on Android.

--- a/packages/firebase_remote_config/ios/Classes/FirebaseRemoteConfigPlugin.m
+++ b/packages/firebase_remote_config/ios/Classes/FirebaseRemoteConfigPlugin.m
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 #import "FirebaseRemoteConfigPlugin.h"
-#import "UserAgent.h"
 
 #import <Firebase/Firebase.h>
 

--- a/packages/firebase_remote_config/ios/firebase_remote_config.podspec
+++ b/packages/firebase_remote_config/ios/firebase_remote_config.podspec
@@ -24,10 +24,6 @@ Firebase Remote Config plugin for Flutter.
   s.dependency 'Firebase/RemoteConfig'
   s.static_framework = true
 
-  s.prepare_command = <<-CMD
-      echo // Generated file, do not edit > Classes/UserAgent.h
-      echo "#define LIBRARY_VERSION @\\"#{libraryVersion}\\"" >> Classes/UserAgent.h
-      echo "#define LIBRARY_NAME @\\"flutter-fire-rc\\"" >> Classes/UserAgent.h
-    CMD
+  s.pod_target_xcconfig = { 'GCC_PREPROCESSOR_DEFINITIONS' => "LIBRARY_VERSION=\\@\\\"#{libraryVersion}\\\" LIBRARY_NAME=\\@\\\"flutter-fire-rc\\\"" }
 end
 

--- a/packages/firebase_remote_config/pubspec.yaml
+++ b/packages/firebase_remote_config/pubspec.yaml
@@ -2,7 +2,7 @@ name: firebase_remote_config
 description: Flutter plugin for Firebase Remote Config. Update your application look and feel and behaviour without
   re-releasing.
 homepage: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/firebase_remote_config
-version: 0.3.0+3
+version: 0.3.0+4
 
 dependencies:
   flutter:

--- a/packages/firebase_storage/.gitignore
+++ b/packages/firebase_storage/.gitignore
@@ -1,1 +1,0 @@
-ios/Classes/UserAgent.h

--- a/packages/firebase_storage/CHANGELOG.md
+++ b/packages/firebase_storage/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.1.3+1
+
+* Fix for missing UserAgent.h compilation failures.
+
 ## 3.1.3
 
 * Replace deprecated `getFlutterEngine` call on Android.

--- a/packages/firebase_storage/CHANGELOG.md
+++ b/packages/firebase_storage/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 3.1.3+1
+## 3.1.4
 
 * Fix for missing UserAgent.h compilation failures.
 

--- a/packages/firebase_storage/ios/Classes/FLTFirebaseStoragePlugin.m
+++ b/packages/firebase_storage/ios/Classes/FLTFirebaseStoragePlugin.m
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 #import "FLTFirebaseStoragePlugin.h"
-#import "UserAgent.h"
 
 #import <Firebase/Firebase.h>
 

--- a/packages/firebase_storage/ios/firebase_storage.podspec
+++ b/packages/firebase_storage/ios/firebase_storage.podspec
@@ -24,9 +24,5 @@ Firebase Storage plugin for Flutter.
   s.dependency 'Firebase/Storage'
   s.static_framework = true
 
-  s.prepare_command = <<-CMD
-      echo // Generated file, do not edit > Classes/UserAgent.h
-      echo "#define LIBRARY_VERSION @\\"#{libraryVersion}\\"" >> Classes/UserAgent.h
-      echo "#define LIBRARY_NAME @\\"flutter-fire-gcs\\"" >> Classes/UserAgent.h
-    CMD
+  s.pod_target_xcconfig = { 'GCC_PREPROCESSOR_DEFINITIONS' => "LIBRARY_VERSION=\\@\\\"#{libraryVersion}\\\" LIBRARY_NAME=\\@\\\"flutter-fire-gcs\\\"" }
 end

--- a/packages/firebase_storage/pubspec.yaml
+++ b/packages/firebase_storage/pubspec.yaml
@@ -2,7 +2,7 @@ name: firebase_storage
 description: Flutter plugin for Firebase Cloud Storage, a powerful, simple, and
   cost-effective object storage service for Android and iOS.
 homepage: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/firebase_storage
-version: 3.1.3+1
+version: 3.1.4
 
 flutter:
   plugin:

--- a/packages/firebase_storage/pubspec.yaml
+++ b/packages/firebase_storage/pubspec.yaml
@@ -2,7 +2,7 @@ name: firebase_storage
 description: Flutter plugin for Firebase Cloud Storage, a powerful, simple, and
   cost-effective object storage service for Android and iOS.
 homepage: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/firebase_storage
-version: 3.1.3
+version: 3.1.3+1
 
 flutter:
   plugin:


### PR DESCRIPTION
## Description

Follow up to https://github.com/FirebaseExtended/flutterfire/pull/2169 removing all creation of UserAgent.h files

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] If the pull request affects only one plugin, the PR title starts with the name of the plugin in brackets (e.g. [cloud_firestore])
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.
