### PR TITLE
[cloud_firestore] Fix stream error report on iOS

### DIFF
--- a/packages/cloud_firestore/cloud_firestore/CHANGELOG.md
+++ b/packages/cloud_firestore/cloud_firestore/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.13.8
+
+- Fix stream error report on iOS.
+
 ## 0.13.7
 
 * Clean up snapshot listeners when Android Activity is destroyed.

--- a/packages/cloud_firestore/cloud_firestore/darwin/Classes/FLTCloudFirestorePlugin.m
+++ b/packages/cloud_firestore/cloud_firestore/darwin/Classes/FLTCloudFirestorePlugin.m
@@ -640,7 +640,8 @@ const UInt8 DOCUMENT_ID = 139;
                                              listener:^(FIRQuerySnapshot *_Nullable snapshot,
                                                         NSError *_Nullable error) {
                                                if (snapshot == nil) {
-                                                 result(getFlutterError(error));
+                                                 // TODO: send error
+                                                 NSLog(@"%@", error);
                                                  return;
                                                }
                                                NSMutableDictionary *arguments =
@@ -660,7 +661,8 @@ const UInt8 DOCUMENT_ID = 139;
                                              listener:^(FIRDocumentSnapshot *snapshot,
                                                         NSError *_Nullable error) {
                                                if (snapshot == nil) {
-                                                 result(getFlutterError(error));
+                                                 // TODO: send error
+                                                 NSLog(@"%@", error);
                                                  return;
                                                }
                                                [weakSelf.channel

--- a/packages/cloud_firestore/cloud_firestore/pubspec.yaml
+++ b/packages/cloud_firestore/cloud_firestore/pubspec.yaml
@@ -3,7 +3,7 @@ description:
   Flutter plugin for Cloud Firestore, a cloud-hosted, noSQL database with
   live synchronization and offline support on Android and iOS.
 homepage: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/cloud_firestore/cloud_firestore
-version: 0.13.7
+version: 0.13.8
 
 flutter:
   plugin:


### PR DESCRIPTION
## Description

Fixes #185.

On iOS, there were no reports about stream error.
For `"Query#addSnapshotListener"` and `"DocumentReference#addSnapshotListener"`, error should be sent by calling `[weakSelf.channel invokeMethod:]`, not `result()`.
Calling `result()` doesn't make sense for this case.

On Android, it also doesn't send error, but `System.out.println(e)` is called instead:

- https://github.com/FirebaseExtended/flutterfire/blob/bdb95fcacf7cf077d162d2f267eee54a8b0be3bc/packages/cloud_firestore/cloud_firestore/android/src/main/java/io/flutter/plugins/firebase/cloudfirestore/CloudFirestorePlugin.java#L407-L408
- https://github.com/FirebaseExtended/flutterfire/blob/bdb95fcacf7cf077d162d2f267eee54a8b0be3bc/packages/cloud_firestore/cloud_firestore/android/src/main/java/io/flutter/plugins/firebase/cloudfirestore/CloudFirestorePlugin.java#L438-L439

iOS's behavior should follow this.

And, It is very useful to know what error was occurred and how to fix it from the error log.
Typical error for this is index error like this, so printing the error is enough in most cases.

> W/Firestore(23867): (21.3.0) [Firestore]: Listen for Query(tests where foo == bar order by -foo2, -__name__) failed: Status{code=FAILED_PRECONDITION, description=The query requires an index. You can create it here: https://console.firebase.google.com/v1/r/project/xxxxxxxx/firestore/indexes?create_composite=xxxxxxxxxxxxxxxxx, cause=null}

Of course, it is better to send error to dart side, so `// TODO: send error` is reasonable.

## Related Issues

#185, as mentioned above. 

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] If the pull request affects only one plugin, the PR title starts with the name of the plugin in brackets (e.g. [cloud_firestore])
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
  - It is hard to write test about this, and exiting Android implementation have no tests about this.
- [x] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

I cannot determin whether this is breaking change or not, but I think "no" because calling `result()` didn't make sense and `NSLog` was just added.

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
