### PR TITLE
[firebase_analytics] add instance getter

### DIFF
--- a/packages/firebase_analytics/firebase_analytics/lib/firebase_analytics.dart
+++ b/packages/firebase_analytics/firebase_analytics/lib/firebase_analytics.dart
@@ -13,6 +13,9 @@ const MethodChannel firebaseChannel =
 
 /// Firebase Analytics API.
 class FirebaseAnalytics {
+  FirebaseAnalytics._();
+  static final instance = FirebaseAnalytics._();
+    
   final MethodChannel _channel = firebaseChannel;
 
   /// Namespace for analytics API available on Android only.


### PR DESCRIPTION
The purpose for this change is to make it clear to the consumer of `firebase_analytics` that they don't need to maintain control over the `FirebaseAnalytics` class instance. That they can rely instead on a built in singleton instance that matches the pattern of all other `flutterfire` packages.
