### PR TITLE
fix(database): fix #81 - setPersistenceCacheSizeBytes call on Android

### DIFF
--- a/packages/firebase_database/CHANGELOG.md
+++ b/packages/firebase_database/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 3.1.4+1
+
+* Fix (#81) Android setPersistenceCacheSizeBytes crash when Long value was provided.
+
 ## 3.1.4
 
 * Fix for missing UserAgent.h compilation failures.

--- a/packages/firebase_database/CHANGELOG.md
+++ b/packages/firebase_database/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 3.1.4+1
+## 3.1.5
 
 * Fix (#81) Android setPersistenceCacheSizeBytes crash when Long value was provided.
 

--- a/packages/firebase_database/android/src/main/java/io/flutter/plugins/firebase/database/MethodCallHandlerImpl.java
+++ b/packages/firebase_database/android/src/main/java/io/flutter/plugins/firebase/database/MethodCallHandlerImpl.java
@@ -272,9 +272,17 @@ class MethodCallHandlerImpl implements MethodChannel.MethodCallHandler {
 
       case "FirebaseDatabase#setPersistenceCacheSizeBytes":
         {
-          Long cacheSize = call.argument("cacheSize");
+          Object value = call.argument("cacheSize");
+          Long cacheSizeBytes = 10485760L; // 10mb default
+
+          if (value instanceof Long) {
+            cacheSizeBytes = (Long) value;
+          } else if (value instanceof Integer) {
+            cacheSizeBytes = Long.valueOf((Integer) value);
+          }
+
           try {
-            database.setPersistenceCacheSizeBytes(cacheSize);
+            database.setPersistenceCacheSizeBytes(cacheSizeBytes);
             result.success(true);
           } catch (DatabaseException e) {
             // Database is already in use, e.g. after hot reload/restart.

--- a/packages/firebase_database/example/test_driver/firebase_database_e2e.dart
+++ b/packages/firebase_database/example/test_driver/firebase_database_e2e.dart
@@ -21,11 +21,13 @@ void main() {
       expect(transactionResult.dataSnapshot.value > value, true);
     });
 
-    testWidgets('setPersistenceCacheSizeBytes Integer', (WidgetTester tester) async {
+    testWidgets('setPersistenceCacheSizeBytes Integer',
+        (WidgetTester tester) async {
       await database.setPersistenceCacheSizeBytes(2147483647);
     });
 
-    testWidgets('setPersistenceCacheSizeBytes Long', (WidgetTester tester) async {
+    testWidgets('setPersistenceCacheSizeBytes Long',
+        (WidgetTester tester) async {
       await database.setPersistenceCacheSizeBytes(2147483648);
     });
   });

--- a/packages/firebase_database/example/test_driver/firebase_database_e2e.dart
+++ b/packages/firebase_database/example/test_driver/firebase_database_e2e.dart
@@ -20,5 +20,13 @@ void main() {
       expect(transactionResult.committed, true);
       expect(transactionResult.dataSnapshot.value > value, true);
     });
+
+    testWidgets('setPersistenceCacheSizeBytes Integer', (WidgetTester tester) async {
+      await database.setPersistenceCacheSizeBytes(2147483647);
+    });
+
+    testWidgets('setPersistenceCacheSizeBytes Long', (WidgetTester tester) async {
+      await database.setPersistenceCacheSizeBytes(2147483648);
+    });
   });
 }

--- a/packages/firebase_database/pubspec.yaml
+++ b/packages/firebase_database/pubspec.yaml
@@ -2,7 +2,7 @@ name: firebase_database
 description: Flutter plugin for Firebase Database, a cloud-hosted NoSQL database
   with realtime data syncing across Android and iOS clients, and offline access.
 homepage: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/firebase_database
-version: 3.1.4+1
+version: 3.1.5
 
 flutter:
   plugin:

--- a/packages/firebase_database/pubspec.yaml
+++ b/packages/firebase_database/pubspec.yaml
@@ -2,7 +2,7 @@ name: firebase_database
 description: Flutter plugin for Firebase Database, a cloud-hosted NoSQL database
   with realtime data syncing across Android and iOS clients, and offline access.
 homepage: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/firebase_database
-version: 3.1.4
+version: 3.1.4+1
 
 flutter:
   plugin:


### PR DESCRIPTION
## Description

Dart `int` value is passed to Android as a Long or Integer depending on the size of the value.

## Related Issues

Fixes #81

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] If the pull request affects only one plugin, the PR title starts with the name of the plugin in brackets (e.g. [cloud_firestore])
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

