### PR TITLE
[firebase_analytics] add optional StackTrace in onError callback

### DIFF
--- a/packages/firebase_analytics/firebase_analytics/CHANGELOG.md
+++ b/packages/firebase_analytics/firebase_analytics/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 5.0.14
+
+* Add optional StackTrace argument in `FirebaseAnalyticsObserver.onError` callback 
+
 ## 5.0.13
 
 * Fix for missing UserAgent.h compilation failures.

--- a/packages/firebase_analytics/firebase_analytics/test/observer_test.dart
+++ b/packages/firebase_analytics/firebase_analytics/test/observer_test.dart
@@ -163,7 +163,8 @@ void main() {
 
       final PlatformException thrownException = PlatformException(code: 'b');
       final StackTrace thrownStackTrace = StackTrace.current;
-      Future<void> throwPlatformException() => Future.error(thrownException, thrownStackTrace);
+      Future<void> throwPlatformException() =>
+          Future.error(thrownException, thrownStackTrace);
 
       when(analytics.setCurrentScreen(screenName: anyNamed('screenName')))
           .thenAnswer((Invocation invocation) => throwPlatformException());


### PR DESCRIPTION
## Description

Optionally include `StackTrace` in `onError` callback args.

## Related Issues

closes  #1927

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] If the pull request affects only one plugin, the PR title starts with the name of the plugin in brackets (e.g. [cloud_firestore])
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
