### PR TITLE
Use the catalina xcode 11.3.1 osx_instance on CI

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -78,7 +78,7 @@ task:
   only_if: $CIRRUS_TAG == ''
   use_compute_credits: $CIRRUS_USER_COLLABORATOR == 'true'
   osx_instance:
-    image: mojave-xcode-11.2.1-flutter
+    image: catalina-xcode-11.3.1-flutter
   setup_script:
     - pod repo update
   upgrade_script:
@@ -116,7 +116,7 @@ task:
   only_if: $CIRRUS_TAG == ''
   use_compute_credits: $CIRRUS_USER_COLLABORATOR == 'true'
   osx_instance:
-    image: mojave-xcode-11.3-flutter
+    image: catalina-xcode-11.3.1-flutter
   setup_script:
     - pod repo update
     - flutter config --enable-macos-desktop


### PR DESCRIPTION
This same change as: https://github.com/flutter/plugins/pull/2710.

It should fix the iOS simulator creation failures on CI.

https://github.com/FirebaseExtended/flutterfire/issues/2499