### PR TITLE
fix(cloud_functions): ci failures

### DIFF
--- a/packages/cloud_functions/cloud_functions/CHANGELOG.md
+++ b/packages/cloud_functions/cloud_functions/CHANGELOG.md
@@ -1,7 +1,7 @@
 ## 0.5.0
 
-* Fix example app build failure.
-* Change environment SDK requirement from `>=2.0.0-dev.28.0` to `>=2.0.0`
+* Fix example app build failure on CI (missing AndroidX Gradle properties).
+* Change environment SDK requirement from `>=2.0.0-dev.28.0` to `>=2.0.0` to fix 'publishable' CI stage.
 
 ## 0.4.2+3
 

--- a/packages/cloud_functions/cloud_functions/CHANGELOG.md
+++ b/packages/cloud_functions/cloud_functions/CHANGELOG.md
@@ -1,6 +1,7 @@
-## 0.4.2+4
+## 0.5.0
 
 * Fix example app build failure.
+* Change environment SDK requirement from `>=2.0.0-dev.28.0` to `>=2.0.0`
 
 ## 0.4.2+3
 

--- a/packages/cloud_functions/cloud_functions/CHANGELOG.md
+++ b/packages/cloud_functions/cloud_functions/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.4.2+4
+
+* Fix example app build failure.
+
 ## 0.4.2+3
 
 * Fix for missing UserAgent.h compilation failures.

--- a/packages/cloud_functions/cloud_functions/example/android/gradle.properties
+++ b/packages/cloud_functions/cloud_functions/example/android/gradle.properties
@@ -1,1 +1,4 @@
 org.gradle.jvmargs=-Xmx1536M
+android.useAndroidX=true
+android.enableJetifier=true
+android.enableR8=true

--- a/packages/cloud_functions/cloud_functions/pubspec.yaml
+++ b/packages/cloud_functions/cloud_functions/pubspec.yaml
@@ -21,8 +21,8 @@ dependencies:
   flutter:
     sdk: flutter
   firebase_core: ^0.4.4
-  cloud_functions_platform_interface: ^1.0.0
-  cloud_functions_web: ^1.0.2
+  cloud_functions_platform_interface: ^1.1.0
+  cloud_functions_web: ^1.1.0
 
 dev_dependencies:
   pedantic: ^1.8.0

--- a/packages/cloud_functions/cloud_functions/pubspec.yaml
+++ b/packages/cloud_functions/cloud_functions/pubspec.yaml
@@ -1,6 +1,6 @@
 name: cloud_functions
 description: Flutter plugin for Cloud Functions.
-version: 0.4.2+4
+version: 0.5.0
 homepage: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/cloud_functions/cloud_functions
 
 flutter:
@@ -33,5 +33,5 @@ dev_dependencies:
   test: any
 
 environment:
-  sdk: '>=2.0.0-dev.28.0 <3.0.0'
+  sdk: '>=2.0.0 <3.0.0'
   flutter: '>=1.10.0 <2.0.0'

--- a/packages/cloud_functions/cloud_functions/pubspec.yaml
+++ b/packages/cloud_functions/cloud_functions/pubspec.yaml
@@ -1,6 +1,6 @@
 name: cloud_functions
 description: Flutter plugin for Cloud Functions.
-version: 0.4.2+3
+version: 0.4.2+4
 homepage: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/cloud_functions/cloud_functions
 
 flutter:

--- a/packages/cloud_functions/cloud_functions_platform_interface/CHANGELOG.md
+++ b/packages/cloud_functions/cloud_functions_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.1.0
+
+* Change environment SDK requirement from `>=2.0.0-dev.28.0` to `>=2.0.0` to fix 'publishable' CI stage.
+
 ## 1.0.1
 
 * Make the pedantic dev_dependency explicit.

--- a/packages/cloud_functions/cloud_functions_platform_interface/pubspec.yaml
+++ b/packages/cloud_functions/cloud_functions_platform_interface/pubspec.yaml
@@ -3,7 +3,7 @@ description: A common platform interface for the cloud_functions plugin.
 homepage: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/cloud_functions/cloud_functions_platform_interface
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 1.0.1
+version: 1.1.0
 
 dependencies:
   flutter:
@@ -19,5 +19,5 @@ dev_dependencies:
   mockito: ^4.1.1
 
 environment:
-  sdk: ">=2.0.0-dev.28.0 <3.0.0"
+  sdk: ">=2.0.0 <3.0.0"
   flutter: ">=1.9.1+hotfix.5 <2.0.0"

--- a/packages/cloud_functions/cloud_functions_web/CHANGELOG.md
+++ b/packages/cloud_functions/cloud_functions_web/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.1.0
+
+* Change environment SDK requirement from `>=2.0.0-dev.28.0` to `>=2.0.0` to fix 'publishable' CI stage.
+
 ## 1.0.4
 
 * Make the pedantic dev_dependency explicit.

--- a/packages/cloud_functions/cloud_functions_web/pubspec.yaml
+++ b/packages/cloud_functions/cloud_functions_web/pubspec.yaml
@@ -1,7 +1,7 @@
 name: cloud_functions_web
 description: The web implementation of cloud_functions
 homepage: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/cloud_functions/cloud_functions_web
-version: 1.0.4
+version: 1.1.0
 
 flutter:
   plugin:
@@ -11,7 +11,7 @@ flutter:
         fileName: cloud_functions_web.dart
 
 dependencies:
-  cloud_functions_platform_interface: ^1.0.0
+  cloud_functions_platform_interface: ^1.1.0
   flutter:
     sdk: flutter
   flutter_web_plugins:
@@ -30,6 +30,6 @@ dev_dependencies:
   js: ^0.6.0
 
 environment:
-  sdk: ">=2.0.0-dev.28.0 <3.0.0"
+  sdk: ">=2.0.0 <3.0.0"
   flutter: ">=1.12.13+hotfix.4 <2.0.0"
 


### PR DESCRIPTION
## Description

Fix for CI failures highlighted in #2499.

 - Added missing `gradle.properties` AndroidX properties to `cloud_functions` example repository
 - Updated environment SDK version range to fix `Packages with an SDK constraint on a pre-release of the Dart SDK should themselves be published as a pre-release version. If this package needs Dart version 2.0.0-dev.28.0, consider publishing the package as a pre-release instead.` CI publishable issue.

### Before

![image](https://user-images.githubusercontent.com/5347038/81424578-155b4100-914e-11ea-9b1b-ec53a89a72e3.png)

![image](https://user-images.githubusercontent.com/5347038/81690526-50fa5180-9453-11ea-95d3-a968c12f3f70.png)


### After

![image](https://user-images.githubusercontent.com/5347038/81424612-2310c680-914e-11ea-9600-6af0cd5ef3ee.png)

![image](https://user-images.githubusercontent.com/5347038/81690583-653e4e80-9453-11ea-97bb-b81c105d99ea.png)


## Related Issues

 - #2499  - "CI is red"

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] If the pull request affects only one plugin, the PR title starts with the name of the plugin in brackets (e.g. [cloud_firestore])
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [ ] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
