### PR TITLE
[cloud_firestore] Fix DocumentReference comparison bug.

### DIFF
--- a/packages/cloud_firestore/cloud_firestore/lib/src/firestore.dart
+++ b/packages/cloud_firestore/cloud_firestore/lib/src/firestore.dart
@@ -25,8 +25,11 @@ class Firestore {
             ? platform.FirestorePlatform.instanceFor(app: app)
             : platform.FirestorePlatform.instance;
 
+  // Cache single instance
+  static Firestore _instance;
+
   /// Gets the instance of Firestore for the default Firebase app.
-  static Firestore get instance => Firestore();
+  static Firestore get instance => _instance ??= Firestore();
 
   /// The [FirebaseApp] instance to which this [Firestore] belongs.
   ///
@@ -98,4 +101,14 @@ class Firestore {
           host: host,
           sslEnabled: sslEnabled,
           cacheSizeBytes: cacheSizeBytes);
+
+  @override
+  int get hashCode => _delegate.app.name.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is Firestore &&
+          runtimeType == other.runtimeType &&
+          _delegate.app == other._delegate.app;
 }


### PR DESCRIPTION
## Description
I was just caught out by this.
```
void main() {
  final first = Firestore.instance.collection('a').document('b');
  final second = Firestore.instance.collection('a').document('b');
  print(first == second); // prints false
}
```
You expect two `DocumentReferences` to be equal. https://github.com/FirebaseExtended/flutterfire/blob/master/packages/cloud_firestore/cloud_firestore/lib/src/document_reference.dart#L25 shows this to be the case if the firestore instance is the same and the instance getter above does not return a singleton instead it creates a new instance each time.

This fix corrects this by firstly treating the `Firestore.instance` field as a singleton, and second adding a equality method that now compares the underlying app. Which now means even if you have multiple instances of the same Firestore class they will be considered equal.

## Tests

* `cloud_firestore` package does not contain tests.

## Checklist
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] If the pull request affects only one plugin, the PR title starts with the name of the plugin in brackets (e.g. [cloud_firestore])
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [ ] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.
