### PR TITLE
[cloud_functions] Throws CloudFunctionsException in right cases

### DIFF
--- a/packages/cloud_functions/cloud_functions/CHANGELOG.md
+++ b/packages/cloud_functions/cloud_functions/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.5.1
+
+* Fix for throwing `PlatformException` and `CloudFunctionsException`.
+
 ## 0.5.0
 
 * Fix example app build failure on CI (missing AndroidX Gradle properties).

--- a/packages/cloud_functions/cloud_functions/lib/src/https_callable.dart
+++ b/packages/cloud_functions/cloud_functions/lib/src/https_callable.dart
@@ -27,9 +27,9 @@ class HttpsCallable {
   /// automatically includes a Firebase Instance ID token to identify the app
   /// instance. If a user is logged in with Firebase Auth, an auth ID token for
   /// the user is also automatically included.
-  Future<HttpsCallableResult> call([dynamic parameters]) {
+  Future<HttpsCallableResult> call([dynamic parameters]) async {
     try {
-      return CloudFunctionsPlatform.instance
+      return await CloudFunctionsPlatform.instance
           .callCloudFunction(
             appName: _cloudFunctions._app.name,
             region: _cloudFunctions._region,

--- a/packages/cloud_functions/cloud_functions/pubspec.yaml
+++ b/packages/cloud_functions/cloud_functions/pubspec.yaml
@@ -1,6 +1,6 @@
 name: cloud_functions
 description: Flutter plugin for Cloud Functions.
-version: 0.5.0
+version: 0.5.1
 homepage: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/cloud_functions/cloud_functions
 
 flutter:

--- a/packages/cloud_functions/cloud_functions/test/cloud_functions_test.dart
+++ b/packages/cloud_functions/cloud_functions/test/cloud_functions_test.dart
@@ -84,5 +84,40 @@ void main() {
         ],
       );
     });
+
+    group('exception', () {
+      test('$CloudFunctionsException', () {
+        MethodChannelCloudFunctions.channel
+            .setMockMethodCallHandler((MethodCall methodCall) async {
+          throw PlatformException(
+              code: 'functionsError',
+              message: 'Cloud function failed with exception.',
+              details: {
+                'code': 'INTERNAL',
+                'details': null,
+                'message': 'Error: foo bar...'
+              });
+        });
+
+        expect(() async {
+          await CloudFunctions.instance
+              .getHttpsCallable(functionName: 'function-causes-error')
+              .call();
+        }, throwsA(isA<CloudFunctionsException>()));
+      });
+
+      test('Exception', () {
+        MethodChannelCloudFunctions.channel
+            .setMockMethodCallHandler((MethodCall methodCall) async {
+          throw PlatformException(code: 'something wrong');
+        });
+
+        expect(() async {
+          await CloudFunctions.instance
+              .getHttpsCallable(functionName: 'function-causes-error')
+              .call();
+        }, throwsA(isA<Exception>()));
+      });
+    });
   });
 }


### PR DESCRIPTION
## Description

cloud_functions throws `PlatformException` when the error caused by Http Callable functions.
In some cases, it should throw `CloudFunctionsExceprion` instead of `PlatformException`.

There is no async-await keyword in spite of using try-catch (it should use `then(onError:)` argument instead of try-catch if don't use async-await).

## Related Issues

https://github.com/FirebaseExtended/flutterfire/issues/2069

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] If the pull request affects only one plugin, the PR title starts with the name of the plugin in brackets (e.g. [cloud_firestore])
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing. <- There are some already failing tests on my local computer (Channel stable, v1.17.0, on Mac OS X 10.15.4 19E287, locale ja-JP) but on CI, it passed
<details>
<summary>Result of test on current master</summary>
$ pub global run flutter_plugin_tools test --plugins cloud_functions        
RUNNING cloud_functions/cloud_functions tests...
Running "flutter pub get" in cloud_functions...                     1.2s
00:00 +0: loading /Users/kikuchy/tmp/flutterfire/packages/cloud_functions/cloud_functions/test/cloud_functions_test.dart                                                                 00:01 +0: loading /Users/kikuchy/tmp/flutterfire/packages/cloud_functions/cloud_functions/test/cloud_functions_test.dart                                                                 00:02 +0: loading /Users/kikuchy/tmp/flutterfire/packages/cloud_functions/cloud_functions/test/cloud_functions_test.dart                                                                 00:02 +0: CloudFunctions call                                                                                                                                                            00:02 +1: CloudFunctions call                                                                                                                                                            00:02 +1: All tests passed!                                                                                                                                                                            
Invalidating asset graph due package config update!
ERROR - 2020-05-14 22:28:41.343377
GET /packages/ui/assets/Roboto-Regular.ttf
Error thrown by handler.
Invalid argument (packageUri): No package named "ui": Instance of '_Uri'
package:package_config/src/packages_impl.dart 49:7               PackagesBase.resolve
package:flutter_tools/src/test/flutter_web_platform.dart 224:36  FlutterWebPlatform._packageFilesHandler
===== asynchronous gap ===========================
package:shelf/shelf_io.dart 63:34                                serveRequests.<fn>.<fn>
===== asynchronous gap ===========================
package:shelf/src/io_server.dart 53:5                            IOServer.mount
package:flutter_tools/src/test/flutter_web_platform.dart 79:13   new FlutterWebPlatform._
package:flutter_tools/src/test/flutter_web_platform.dart 95:31   FlutterWebPlatform.start
dart:async                                                       _completeOnAsyncReturn
package:http_multi_server/http_multi_server.dart                 HttpMultiServer._loopback
===== asynchronous gap ===========================
dart:async                                                       _asyncThenWrapperHelper
package:flutter_tools/src/test/runner.dart 132:37                _FlutterTestRunnerImpl.runTests.<fn>
dart:async                                                       new Future.sync
package:async/src/async_memoizer.dart 43:45                      AsyncMemoizer.runOnce
package:test_core/src/runner/loader.dart 230:28                  Loader.loadFile.<fn>
package:test_core/src/runner/load_suite.dart 98:31               new LoadSuite.<fn>.<fn>
package:test_core/src/runner/load_suite.dart 108:8               new LoadSuite.<fn>
package:test_api/src/backend/invoker.dart 400:30                 Invoker._onRun.<fn>.<fn>.<fn>.<fn>
===== asynchronous gap ===========================
dart:async                                                       new Future
package:test_api/src/backend/invoker.dart 399:21                 Invoker._onRun.<fn>.<fn>.<fn>
dart:async                                                       runZoned
package:test_api/src/backend/invoker.dart 387:9                  Invoker._onRun.<fn>.<fn>
dart:async                                                       runZoned
package:test_api/src/backend/invoker.dart 148:7                  Invoker.guard
package:test_api/src/backend/invoker.dart 436:15                 Invoker._guardIfGuarded
package:test_api/src/backend/invoker.dart 386:7                  Invoker._onRun.<fn>
package:stack_trace                                              Chain.capture
package:test_api/src/backend/invoker.dart 385:11                 Invoker._onRun
package:test_api/src/backend/live_test_controller.dart 197:11    LiveTestController._run
package:test_api/src/backend/live_test_controller.dart 50:37     _LiveTest.run

RUNNING cloud_functions/cloud_functions/example tests...
00:00 +0: loading /Users/kikuchy/tmp/flutterfire/packages/cloud_functions/cloud_functions/example/test/cloud_functions_test.dart                                                         00:01 +0: loading /Users/kikuchy/tmp/flutterfire/packages/cloud_functions/cloud_functions/example/test/cloud_functions_test.dart                                                         00:02 +0: loading /Users/kikuchy/tmp/flutterfire/packages/cloud_functions/cloud_functions/example/test/cloud_functions_test.dart                                                         00:02 +0: CloudFunctions example widget test                                                                                                                                             00:03 +0: CloudFunctions example widget test                                                                                                                                             00:03 +1: CloudFunctions example widget test                                                                                                                                             00:03 +1: All tests passed!                                                                                                                                                                            
RUNNING cloud_functions/cloud_functions_platform_interface tests...
00:00 +0: loading /Users/kikuchy/tmp/flutterfire/packages/cloud_functions/cloud_functions_platform_interface/test/cloud_functions_platform_interface_test.dart                           00:01 +0: loading /Users/kikuchy/tmp/flutterfire/packages/cloud_functions/cloud_functions_platform_interface/test/cloud_functions_platform_interface_test.dart                           00:02 +0: loading /Users/kikuchy/tmp/flutterfire/packages/cloud_functions/cloud_functions_platform_interface/test/cloud_functions_platform_interface_test.dart                           00:02 +0: loading /Users/kikuchy/tmp/flutterfire/packages/cloud_functions/cloud_functions_platform_interface/test/method_channel_cloud_functions_test.dart                               00:02 +0: ... CloudFunctionsPlatform() MethodChannelCloudFunctions is the default instance                                                                                               00:02 +1: loading /Users/kikuchy/tmp/flutterfire/packages/cloud_functions/cloud_functions_platform_interface/test/method_channel_cloud_functions_test.dart                               00:02 +1: /Users/kikuchy/tmp/flutterfire/packages/cloud_functions/cloud_functions_platform_interface/test/cloud_functions_platform_interface_test.dart: ... Cannot be implemented with `i00:02 +2: loading /Users/kikuchy/tmp/flutterfire/packages/cloud_functions/cloud_functions_platform_interface/test/method_channel_cloud_functions_test.dart                               00:02 +2: /Users/kikuchy/tmp/flutterfire/packages/cloud_functions/cloud_functions_platform_interface/test/cloud_functions_platform_interface_test.dart: CloudFunctionsPlatform() Can be e00:02 +3: /Users/kikuchy/tmp/flutterfire/packages/cloud_functions/cloud_functions_platform_interface/test/method_channel_cloud_functions_test.dart: CloudFunctionsPlatform call          00:02 +4: /Users/kikuchy/tmp/flutterfire/packages/cloud_functions/cloud_functions_platform_interface/test/method_channel_cloud_functions_test.dart: CloudFunctionsPlatform call          00:02 +4 -1: /Users/kikuchy/tmp/flutterfire/packages/cloud_functions/cloud_functions_platform_interface/test/method_channel_cloud_functions_test.dart: CloudFunctionsPlatform call [E]                 
  Expected: [
              <has method name: 'CloudFunctions#call' with arguments: {
              'app': '[DEFAULT]',
              'region': null,
              'origin': null,
              'functionName': 'baz',
              'timeoutMicroseconds': null,
              'parameters': null
            }>,
              <has method name: 'CloudFunctions#call' with arguments: {
              'app': '1337',
              'region': 'space',
              'origin': null,
              'functionName': 'qux',
              'timeoutMicroseconds': 25920000000000,
              'parameters': {'quux': 'quuz'}
            }>,
              <has method name: 'CloudFunctions#call' with arguments: {
              'app': '[DEFAULT]',
              'region': null,
              'origin': 'http://localhost:5001',
              'functionName': 'bez',
              'timeoutMicroseconds': null,
              'parameters': null
            }>
            ]
    Actual: [
              MethodCall:MethodCall(CloudFunctions#call, {app: __FIRAPP_DEFAULT, region: null, origin: null, timeoutMicroseconds: null, functionName: baz, parameters: null}),
              MethodCall:MethodCall(CloudFunctions#call, {app: 1337, region: space, origin: null, timeoutMicroseconds: 25920000000000, functionName: qux, parameters: {quux: quuz}}),
              MethodCall:MethodCall(CloudFunctions#call, {app: __FIRAPP_DEFAULT, region: null, origin: http://localhost:5001, timeoutMicroseconds: null, functionName: bez, parameters: null})
            ]
     Which: does not match has method name: 'CloudFunctions#call' with arguments: {
              'app': '[DEFAULT]',
              'region': null,
              'origin': null,
              'functionName': 'baz',
              'timeoutMicroseconds': null,
              'parameters': null
            } at location [0]
  
  package:test_api                                   expect
  package:flutter_test/src/widget_tester.dart 348:3  expect
  method_channel_cloud_functions_test.dart 52:7      main.<fn>.<fn>
  
00:02 +4 -1: Some tests failed.                                                                                                                                                                        
RUNNING cloud_functions/cloud_functions_web tests...
00:00 +0: loading /Users/kikuchy/tmp/flutterfire/packages/cloud_functions/cloud_functions_web/test/cloud_functions_web_test.dart                                                         00:01 +0: loading /Users/kikuchy/tmp/flutterfire/packages/cloud_functions/cloud_functions_web/test/cloud_functions_web_test.dart                                                         00:02 +0: loading /Users/kikuchy/tmp/flutterfire/packages/cloud_functions/cloud_functions_web/test/cloud_functions_web_test.dart                                                         00:02 +0: CloudFunctionsWeb setUp wires up mock objects properly                                                                                                                         00:02 +1: CloudFunctionsWeb setUp wires up mock objects properly                                                                                                                         00:02 +1: CloudFunctionsWeb callCloudFunction calls down to Firebase API                                                                                                                 00:02 +2: CloudFunctionsWeb callCloudFunction calls down to Firebase API                                                                                                                 00:02 +2: All tests passed!                                                                                                                                                                            
ERROR - 2020-05-14 22:29:08.240528
GET /packages/ui/assets/Roboto-Regular.ttf
Error thrown by handler.
Invalid argument (packageUri): No package named "ui": Instance of '_Uri'
package:package_config/src/packages_impl.dart 49:7               PackagesBase.resolve
package:flutter_tools/src/test/flutter_web_platform.dart 224:36  FlutterWebPlatform._packageFilesHandler
===== asynchronous gap ===========================
package:shelf/shelf_io.dart 63:34                                serveRequests.<fn>.<fn>
===== asynchronous gap ===========================
package:shelf/src/io_server.dart 53:5                            IOServer.mount
package:flutter_tools/src/test/flutter_web_platform.dart 79:13   new FlutterWebPlatform._
package:flutter_tools/src/test/flutter_web_platform.dart 95:31   FlutterWebPlatform.start
dart:async                                                       _completeOnAsyncReturn
package:http_multi_server/http_multi_server.dart                 HttpMultiServer._loopback
===== asynchronous gap ===========================
dart:async                                                       _asyncThenWrapperHelper
package:flutter_tools/src/test/runner.dart 132:37                _FlutterTestRunnerImpl.runTests.<fn>
dart:async                                                       new Future.sync
package:async/src/async_memoizer.dart 43:45                      AsyncMemoizer.runOnce
package:test_core/src/runner/loader.dart 230:28                  Loader.loadFile.<fn>
package:test_core/src/runner/load_suite.dart 98:31               new LoadSuite.<fn>.<fn>
package:test_core/src/runner/load_suite.dart 108:8               new LoadSuite.<fn>
package:test_api/src/backend/invoker.dart 400:30                 Invoker._onRun.<fn>.<fn>.<fn>.<fn>
===== asynchronous gap ===========================
dart:async                                                       new Future
package:test_api/src/backend/invoker.dart 399:21                 Invoker._onRun.<fn>.<fn>.<fn>
dart:async                                                       runZoned
package:test_api/src/backend/invoker.dart 387:9                  Invoker._onRun.<fn>.<fn>
dart:async                                                       runZoned
package:test_api/src/backend/invoker.dart 148:7                  Invoker.guard
package:test_api/src/backend/invoker.dart 436:15                 Invoker._guardIfGuarded
package:test_api/src/backend/invoker.dart 386:7                  Invoker._onRun.<fn>
package:stack_trace                                              Chain.capture
package:test_api/src/backend/invoker.dart 385:11                 Invoker._onRun
package:test_api/src/backend/live_test_controller.dart 197:11    LiveTestController._run
package:test_api/src/backend/live_test_controller.dart 50:37     _LiveTest.run




Tests for the following packages are failing (see above):
 * cloud_functions/cloud_functions_platform_interface
</details>

- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
