### PR TITLE
feat(firebase_auth_web): add support for `confirmPasswordReset`

### DIFF
--- a/packages/firebase_auth/firebase_auth_web/CHANGELOG.md
+++ b/packages/firebase_auth/firebase_auth_web/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.2+3
+
+* Implement `confirmPasswordReset`.
+
 ## 0.1.2+2
 
 * Make the pedantic dev_dependency explicit.

--- a/packages/firebase_auth/firebase_auth_web/lib/firebase_auth_web.dart
+++ b/packages/firebase_auth/firebase_auth_web/lib/firebase_auth_web.dart
@@ -357,4 +357,10 @@ class FirebaseAuthWeb extends FirebaseAuthPlatform {
     // See https://github.com/flutter/flutter/issues/46021
     throw UnimplementedError('verifyPhoneNumber');
   }
+
+  Future<void> confirmPasswordReset(
+      String app, String oobCode, String newPassword) async {
+    final firebase.Auth auth = _getAuth(app);
+    await auth.confirmPasswordReset(oobCode, newPassword);
+  }
 }

--- a/packages/firebase_auth/firebase_auth_web/pubspec.yaml
+++ b/packages/firebase_auth/firebase_auth_web/pubspec.yaml
@@ -1,7 +1,7 @@
 name: firebase_auth_web
 description: The web implementation of firebase_auth
 homepage: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/firebase_auth/firebase_auth_web
-version: 0.1.2+2
+version: 0.1.2+3
 
 flutter:
   plugin:


### PR DESCRIPTION
## Description

This adds the `confirmPasswordReset` implementation to `firebase_auth_web`. Currently missing.

## Related Issues

* None I could see.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] If the pull request affects only one plugin, the PR title starts with the name of the plugin in brackets (e.g. [cloud_firestore])
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

/cc @hterkelsen
/cc @bparrishMines 