### PR TITLE
[firebase_dynamic_links] make sure the initial link resolves

### DIFF
--- a/packages/firebase_dynamic_links/CHANGELOG.md
+++ b/packages/firebase_dynamic_links/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.5.0+13
+
+- Fix for possible race condition in `getInitialLink` (iOS only).
+
 ## 0.5.0+12
 
 * Fix for missing UserAgent.h compilation failures.

--- a/packages/firebase_dynamic_links/ios/Classes/FLTFirebaseDynamicLinksPlugin.m
+++ b/packages/firebase_dynamic_links/ios/Classes/FLTFirebaseDynamicLinksPlugin.m
@@ -43,7 +43,7 @@ static NSMutableDictionary *getDictionaryFromFlutterError(FlutterError *error) {
 @interface FLTFirebaseDynamicLinksPlugin ()
 @property(nonatomic, retain) FlutterMethodChannel *channel;
 @property(nonatomic, retain) FIRDynamicLink *initialLink;
-@property(nonatomic, assign) BOOL resolvingInitialLink;
+@property(nonatomic, assign) BOOL isResolvingInitialLink;
 @property(nonatomic, retain) FlutterError *flutterError;
 @property(nonatomic) BOOL initiated;
 @end
@@ -68,7 +68,7 @@ static NSMutableDictionary *getDictionaryFromFlutterError(FlutterError *error) {
   self = [super init];
   if (self) {
     _initiated = NO;
-    _resolvingInitialLink = NO;
+    _isResolvingInitialLink = NO;
     _channel = channel;
     if (![FIRApp appNamed:@"__FIRAPP_DEFAULT"]) {
       NSLog(@"Configuring the default Firebase app...");
@@ -112,7 +112,7 @@ static NSMutableDictionary *getDictionaryFromFlutterError(FlutterError *error) {
 }
 
 - (void)continueGetInitialLinkWithResult:(FlutterResult)result {
-    if (_resolvingInitialLink == YES) {
+    if (_isResolvingInitialLink == YES) {
         dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(0.5 * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
             [self continueGetInitialLinkWithResult:result];
         });
@@ -169,7 +169,7 @@ static NSMutableDictionary *getDictionaryFromFlutterError(FlutterError *error) {
 }
 
 - (BOOL)onInitialLink:(NSUserActivity *)userActivity {
-  self.resolvingInitialLink = YES;
+  self.isResolvingInitialLink = YES;
   BOOL handled = [[FIRDynamicLinks dynamicLinks]
       handleUniversalLink:userActivity.webpageURL
                completion:^(FIRDynamicLink *_Nullable dynamicLink, NSError *_Nullable error) {
@@ -177,7 +177,7 @@ static NSMutableDictionary *getDictionaryFromFlutterError(FlutterError *error) {
                    self.flutterError = getFlutterError(error);
                  }
                  self.initialLink = dynamicLink;
-                 self.resolvingInitialLink = NO;
+                 self.isResolvingInitialLink = NO;
                }];
   return handled;
 }

--- a/packages/firebase_dynamic_links/pubspec.yaml
+++ b/packages/firebase_dynamic_links/pubspec.yaml
@@ -1,7 +1,7 @@
 name: firebase_dynamic_links
 description: Flutter plugin for Google Dynamic Links for Firebase, an app solution for creating
   and handling links across multiple platforms.
-version: 0.5.0+12
+version: 0.5.0+13
 homepage: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/firebase_dynamic_links
 
 dependencies:


### PR DESCRIPTION
## Description

We found that sometimes the initial link might not resolve correctly. This is because of a possible race condition:

1. iOS calls
```
- (BOOL)application:(UIApplication *)application
    continueUserActivity:(NSUserActivity *)userActivity
      restorationHandler:(void (^)(NSArray *))restorationHandler
```
and link resolving starts by calling `onInitialLink`.

2. `handleMethodCall` is called with `@"FirebaseDynamicLinks#getInitialLink"` while the initial link still gets resolved
3. Because `_initialLink` is still `nil` that gets send via the channel.

To resolve this issue, this PR

1. sets the new `BOOL isResolvingInitialLink` to `YES` while resolving.
2. checks if `isResolvingInitialLink` is `YES` when `@"FirebaseDynamicLinks#getInitialLink"` gets called and waits until it is `NO`.

Not sure if this solution is too simplistic, but at least it worked for our case.

## Related Issues

https://github.com/FirebaseExtended/flutterfire/issues/1624
https://github.com/FirebaseExtended/flutterfire/issues/100

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] If the pull request affects only one plugin, the PR title starts with the name of the plugin in brackets (e.g. [cloud_firestore])
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

