### PR TITLE
[firebase_admob] Bump dart version requirement

### DIFF
--- a/packages/firebase_admob/CHANGELOG.md
+++ b/packages/firebase_admob/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.9.3+4
+
+* Bump Dart version requirement.
+
 ## 0.9.3+3
 
 * Provide a default `MobileAdTargetingInfo` for `RewardedVideoAd.load()`. `RewardedVideoAd.load()`

--- a/packages/firebase_admob/pubspec.yaml
+++ b/packages/firebase_admob/pubspec.yaml
@@ -31,4 +31,4 @@ dev_dependencies:
 
 environment:
   sdk: ">=2.7.0 <3.0.0"
-  flutter: ">=1.10.0 <2.0.0"
+  flutter: ">=1.12.13+hotfix.5"

--- a/packages/firebase_admob/pubspec.yaml
+++ b/packages/firebase_admob/pubspec.yaml
@@ -2,7 +2,7 @@ name: firebase_admob
 description: Flutter plugin for Firebase AdMob, supporting
   banner, interstitial (full-screen), and rewarded video ads
 homepage: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/firebase_admob
-version: 0.9.3+3
+version: 0.9.3+4
 
 flutter:
   plugin:
@@ -30,5 +30,5 @@ dev_dependencies:
     sdk: flutter
 
 environment:
-  sdk: ">=2.0.0-dev.28.0 <3.0.0"
+  sdk: ">=2.7.0 <3.0.0"
   flutter: ">=1.10.0 <2.0.0"


### PR DESCRIPTION
A recent pub publish check requires a non release Dart SDK, bumping the requirement so we don't get the warning.

This change is a no-op as the minimally required Flutter version for v2 embedding is (1.12.13+hotfix.5) and it already requires Dart 2.7.0.
