### PR TITLE
[firebase_admob] Banner ad in CustomScrollView example

### DIFF
--- a/packages/firebase_admob/CHANGELOG.md
+++ b/packages/firebase_admob/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.9.3.+4
+
+* Added banner ad in custom scroll view example.
+
 ## 0.9.3+3
 
 * Provide a default `MobileAdTargetingInfo` for `RewardedVideoAd.load()`. `RewardedVideoAd.load()`

--- a/packages/firebase_admob/example/lib/main.dart
+++ b/packages/firebase_admob/example/lib/main.dart
@@ -8,7 +8,6 @@ import 'dart:io';
 
 import 'package:flutter/material.dart';
 import 'package:firebase_admob/firebase_admob.dart';
-
 import 'src/banner_scroll.dart';
 
 // You can also test with your own ad unit IDs by registering your device as a

--- a/packages/firebase_admob/example/lib/main.dart
+++ b/packages/firebase_admob/example/lib/main.dart
@@ -9,6 +9,8 @@ import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:firebase_admob/firebase_admob.dart';
 
+import 'src/banner_scroll.dart';
+
 // You can also test with your own ad unit IDs by registering your device as a
 // test device. Check the logs for your device's ID value.
 const String testDevice = 'YOUR_DEVICE_ID';
@@ -118,6 +120,12 @@ class _MyAppState extends State<MyApp> {
                         ..show(horizontalCenterOffset: -50, anchorOffset: 100);
                     }),
                 RaisedButton(
+                    child: const Text('SHOW BANNER IN SCROLL VIEW'),
+                    onPressed: () {
+                      Navigator.push(context,
+                          MaterialPageRoute(builder: (context) => BannerScroll()));
+                    }),
+                RaisedButton(
                     child: const Text('REMOVE BANNER'),
                     onPressed: () {
                       _bannerAd?.dispose();
@@ -185,6 +193,7 @@ class _MyAppState extends State<MyApp> {
   }
 }
 
-void main() {
-  runApp(MyApp());
-}
+void main() => runApp(MaterialApp(
+  title: 'Example',
+  home: MyApp(),
+));

--- a/packages/firebase_admob/example/lib/src/banner.dart
+++ b/packages/firebase_admob/example/lib/src/banner.dart
@@ -1,0 +1,78 @@
+import 'package:flutter/material.dart';
+import 'package:firebase_admob/firebase_admob.dart';
+import 'package:webview_flutter/webview_flutter.dart';
+
+final String article =
+    'https://medium.com/flutter/announcing-flutter-1-17-4182d8af7f8e';
+
+void main() => runApp(AdBanner());
+
+class AdBanner extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      home: BannerAdPage(),
+    );
+  }
+}
+
+class BannerAdPage extends StatefulWidget {
+  @override
+  _BannerAdPageState createState() => _BannerAdPageState();
+}
+
+class _BannerAdPageState extends State<BannerAdPage>
+    with AutomaticKeepAliveClientMixin {
+  @override
+  bool get wantKeepAlive => true;
+
+  BannerAd myBanner;
+
+  BannerAd buildBannerAd() {
+    return BannerAd(
+        adUnitId: BannerAd.testAdUnitId,
+        size: AdSize.banner,
+        listener: (MobileAdEvent event) {
+          if (event == MobileAdEvent.loaded) {
+            myBanner..show();
+          }
+        });
+  }
+
+  BannerAd buildLargeBannerAd() {
+    return BannerAd(
+        adUnitId: BannerAd.testAdUnitId,
+        size: AdSize.largeBanner,
+        listener: (MobileAdEvent event) {
+          if (event == MobileAdEvent.loaded) {
+            myBanner
+              ..show(
+                  anchorType: AnchorType.top,
+                  anchorOffset: MediaQuery.of(context).size.height * 0.50);
+          }
+        });
+  }
+
+  @override
+  void initState() {
+    super.initState();
+    FirebaseAdMob.instance.initialize(appId: FirebaseAdMob.testAppId);
+    myBanner = buildLargeBannerAd()..load();
+  }
+
+  @override
+  void dispose() {
+    myBanner.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(),
+      body: Center(
+        child: WebView(initialUrl: article),
+      ),
+    );
+  }
+}

--- a/packages/firebase_admob/example/lib/src/banner_scroll.dart
+++ b/packages/firebase_admob/example/lib/src/banner_scroll.dart
@@ -1,0 +1,60 @@
+import 'package:flutter/material.dart';
+import '../src/banner.dart';
+
+void main() => runApp(BannerScroll());
+
+class BannerScroll extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      debugShowCheckedModeBanner: false,
+      title: 'banner ad in scroll view',
+      theme: ThemeData(
+        primarySwatch: Colors.blue,
+      ),
+      home: BannerScrollView(),
+    );
+  }
+}
+
+class BannerScrollView extends StatefulWidget {
+  @override
+  _MyHomePageState createState() => _MyHomePageState();
+}
+
+class _MyHomePageState extends State<BannerScrollView> {
+  @override
+  void initState() {
+    super.initState();
+  }
+
+  @override
+  void dispose() {
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      body: CustomScrollView(
+        slivers: <Widget>[
+          SliverAppBar(
+              floating: true,
+              pinned: true,
+              snap: true,
+              actions: <Widget>[
+                IconButton(
+                  icon: const Icon(Icons.add_circle),
+                  tooltip: 'button',
+                  onPressed: () { },
+                ),
+              ]
+          ),
+          SliverFillRemaining(
+            child: AdBanner(),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/packages/firebase_admob/example/pubspec.yaml
+++ b/packages/firebase_admob/example/pubspec.yaml
@@ -7,6 +7,8 @@ dependencies:
   firebase_admob:
     path: ../
   firebase_core: ^0.4.2+1
+  flutter_webview_plugin: ^0.3.11
+  webview_flutter: ^0.3.14+1
 
 dev_dependencies:
   pedantic: ^1.8.0

--- a/packages/firebase_admob/pubspec.yaml
+++ b/packages/firebase_admob/pubspec.yaml
@@ -2,7 +2,7 @@ name: firebase_admob
 description: Flutter plugin for Firebase AdMob, supporting
   banner, interstitial (full-screen), and rewarded video ads
 homepage: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/firebase_admob
-version: 0.9.3+3
+version: 0.9.3+4
 
 flutter:
   plugin:


### PR DESCRIPTION
## Description

Add a banner ad in a `CustomScrollView` sliver to demonstrate the behavior of such a scenario for the example app.

## Related Issues

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] If the pull request affects only one plugin, the PR title starts with the name of the plugin in brackets (e.g. [cloud_firestore])
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
