### PR TITLE
[firebase_core] Update comment over name field in Firebase App

### DIFF
--- a/packages/firebase_core/firebase_core/lib/src/firebase_app.dart
+++ b/packages/firebase_core/firebase_core/lib/src/firebase_app.dart
@@ -13,7 +13,7 @@ class FirebaseApp {
   // TODO(jackson): We could assert here that an app with this name was configured previously.
   FirebaseApp({@required this.name}) : assert(name != null);
 
-  /// The name of this app.
+  /// The name of this app. App name can only contain alphanumeric, hyphen (-), and underscore (_) characters.
   final String name;
 
   static final String defaultAppName = firebaseDefaultAppName;


### PR DESCRIPTION
#2549  Description

When configuring a Firebase App, if the name contains a ' ' (whitespace) instead of suggested separators, iOS throws a cryptic error message only visible through -v flag. Even then, the lack of context of the error makes it confusing to understand if the name causing the error was in the Info.plist or anywhere else. This additional comment would be really helpful.

## Related Issues

Although closed, this issues are related to the description above. Apparently, the only available and relevant references for such error are these two issues which didn't suggest the fix I had to address in order to fix the error iOS presented in my case.

https://github.com/FirebaseExtended/flutterfire/issues/1273
https://github.com/flutter/flutter/issues/13518

In my case, removing a whitespace (using PascalCase) in my `FirebaseApp.configure(...) `code did the trick.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] If the pull request affects only one plugin, the PR title starts with the name of the plugin in brackets (e.g. [cloud_firestore])
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [ ] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [ ] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
