### PR TITLE
[firebase_in_app_messaging] Replace dependency deprecated on InAppMessagingDisplay IOS

### DIFF
--- a/packages/firebase_in_app_messaging/CHANGELOG.md
+++ b/packages/firebase_in_app_messaging/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.2+1
+
+* replace deprecated InAppMessagingDisplay ios dependency with InAppMessaging.
+
 ## 0.1.2
 
 * Update lower bound of dart dependency to 2.0.0.

--- a/packages/firebase_in_app_messaging/ios/firebase_in_app_messaging.podspec
+++ b/packages/firebase_in_app_messaging/ios/firebase_in_app_messaging.podspec
@@ -16,7 +16,7 @@ Flutter plugin for Firebase In-App Messaging.
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Flutter'
   s.dependency 'Firebase'
-  s.dependency 'Firebase/InAppMessagingDisplay'
+  s.dependency 'Firebase/InAppMessaging'
   s.static_framework = true
 
   s.ios.deployment_target = '8.0'

--- a/packages/firebase_in_app_messaging/pubspec.yaml
+++ b/packages/firebase_in_app_messaging/pubspec.yaml
@@ -1,6 +1,6 @@
 name: firebase_in_app_messaging
 description: Flutter plugin for Firebase In-App Messaging.
-version: 0.1.2
+version: 0.1.2+1
 homepage: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/firebase_in_app_messaging
 
 environment:


### PR DESCRIPTION
## Description

InAppMessagingDisplay is deprecated as of firebase sdk 6.16.0. (https://firebase.google.com/support/release-notes/ios). Replace dependency so that IOS builds do not fail.  

## Related Issues

*Fixes #2151 issue*

## Checklist

- [xI read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] If the pull request affects only one plugin, the PR title starts with the name of the plugin in brackets (e.g. [cloud_firestore])
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

