### PR TITLE
[cloud_functions] Make HttpsCallable.call async

### DIFF
--- a/packages/cloud_functions/cloud_functions/lib/src/https_callable.dart
+++ b/packages/cloud_functions/cloud_functions/lib/src/https_callable.dart
@@ -27,18 +27,17 @@ class HttpsCallable {
   /// automatically includes a Firebase Instance ID token to identify the app
   /// instance. If a user is logged in with Firebase Auth, an auth ID token for
   /// the user is also automatically included.
-  Future<HttpsCallableResult> call([dynamic parameters]) {
+  Future<HttpsCallableResult> call([dynamic parameters]) async {
     try {
-      return CloudFunctionsPlatform.instance
-          .callCloudFunction(
-            appName: _cloudFunctions._app.name,
-            region: _cloudFunctions._region,
-            origin: _cloudFunctions._origin,
-            timeout: timeout,
-            functionName: _functionName,
-            parameters: parameters,
-          )
-          .then((response) => HttpsCallableResult._(response));
+      final response = await CloudFunctionsPlatform.instance.callCloudFunction(
+        appName: _cloudFunctions._app.name,
+        region: _cloudFunctions._region,
+        origin: _cloudFunctions._origin,
+        timeout: timeout,
+        functionName: _functionName,
+        parameters: parameters,
+      );
+      return HttpsCallableResult._(response);
     } on PlatformException catch (e) {
       if (e.code == 'functionsError') {
         final String code = e.details['code'];


### PR DESCRIPTION
## Description

Previously the `catch` blocks would never execute, because the function returned `Future<HttpsCallableResult>` synchronously. `CloudFunctionsException` couldn't be thrown.

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] If the pull request affects only one plugin, the PR title starts with the name of the plugin in brackets (e.g. [cloud_firestore])
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [ ] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
