### PR TITLE
[firebase_admob] Fix callbacks and add mute support

### DIFF
--- a/packages/firebase_admob/android/src/main/java/io/flutter/plugins/firebaseadmob/FirebaseAdMobPlugin.java
+++ b/packages/firebase_admob/android/src/main/java/io/flutter/plugins/firebaseadmob/FirebaseAdMobPlugin.java
@@ -333,6 +333,7 @@ public class FirebaseAdMobPlugin implements FlutterPlugin, ActivityAware, Method
     if (rewardedWrapper.getStatus() != RewardedVideoAdWrapper.Status.CREATED
         && rewardedWrapper.getStatus() != RewardedVideoAdWrapper.Status.FAILED) {
       result.success(Boolean.TRUE); // The ad was already loading or loaded.
+      rewardedWrapper.onRewardedVideoAdLoaded();
       return;
     }
 

--- a/packages/firebase_admob/android/src/main/java/io/flutter/plugins/firebaseadmob/FirebaseAdMobPlugin.java
+++ b/packages/firebase_admob/android/src/main/java/io/flutter/plugins/firebaseadmob/FirebaseAdMobPlugin.java
@@ -8,11 +8,17 @@ import android.app.Activity;
 import android.content.Context;
 import android.util.Log;
 import android.view.Gravity;
+
 import com.google.android.gms.ads.AdSize;
 import com.google.android.gms.ads.MobileAds;
 import com.google.android.gms.ads.formats.UnifiedNativeAd;
 import com.google.android.gms.ads.formats.UnifiedNativeAdView;
 import com.google.firebase.FirebaseApp;
+
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+
 import io.flutter.embedding.engine.FlutterEngine;
 import io.flutter.embedding.engine.plugins.FlutterPlugin;
 import io.flutter.embedding.engine.plugins.activity.ActivityAware;
@@ -24,9 +30,6 @@ import io.flutter.plugin.common.MethodChannel.MethodCallHandler;
 import io.flutter.plugin.common.MethodChannel.Result;
 import io.flutter.plugin.common.PluginRegistry;
 import io.flutter.plugin.common.PluginRegistry.Registrar;
-import java.util.HashMap;
-import java.util.Locale;
-import java.util.Map;
 
 /**
  * Flutter plugin accessing Firebase Admob API.
@@ -217,7 +220,6 @@ public class FirebaseAdMobPlugin implements FlutterPlugin, ActivityAware, Method
       return;
     }
     MobileAds.initialize(applicationContext, appId);
-    MobileAds.setAppMuted(true);
     result.success(Boolean.TRUE);
   }
 
@@ -355,6 +357,12 @@ public class FirebaseAdMobPlugin implements FlutterPlugin, ActivityAware, Method
     result.success(Boolean.TRUE);
   }
 
+  private void callSetAppMuted(MethodCall call, Result result) {
+    boolean mute = call.argument("mute");
+    MobileAds.setAppMuted(mute);
+    result.success(Boolean.TRUE);
+  }
+
   private void callShowAd(Integer id, MethodCall call, Result result) {
     MobileAd ad = MobileAd.getAdForId(id);
     if (ad == null) {
@@ -481,6 +489,8 @@ public class FirebaseAdMobPlugin implements FlutterPlugin, ActivityAware, Method
       case "loadRewardedVideoAd":
         callLoadRewardedVideoAd(call, result);
         break;
+      case "setAppMuted":
+        callSetAppMuted(call, result);
       case "loadNativeAd":
         callLoadNativeAd(id, activity, call, result);
         break;

--- a/packages/firebase_admob/android/src/main/java/io/flutter/plugins/firebaseadmob/FirebaseAdMobPlugin.java
+++ b/packages/firebase_admob/android/src/main/java/io/flutter/plugins/firebaseadmob/FirebaseAdMobPlugin.java
@@ -217,6 +217,7 @@ public class FirebaseAdMobPlugin implements FlutterPlugin, ActivityAware, Method
       return;
     }
     MobileAds.initialize(applicationContext, appId);
+    MobileAds.setAppMuted(true);
     result.success(Boolean.TRUE);
   }
 

--- a/packages/firebase_admob/android/src/main/java/io/flutter/plugins/firebaseadmob/FirebaseAdMobPlugin.java
+++ b/packages/firebase_admob/android/src/main/java/io/flutter/plugins/firebaseadmob/FirebaseAdMobPlugin.java
@@ -8,17 +8,11 @@ import android.app.Activity;
 import android.content.Context;
 import android.util.Log;
 import android.view.Gravity;
-
 import com.google.android.gms.ads.AdSize;
 import com.google.android.gms.ads.MobileAds;
 import com.google.android.gms.ads.formats.UnifiedNativeAd;
 import com.google.android.gms.ads.formats.UnifiedNativeAdView;
 import com.google.firebase.FirebaseApp;
-
-import java.util.HashMap;
-import java.util.Locale;
-import java.util.Map;
-
 import io.flutter.embedding.engine.FlutterEngine;
 import io.flutter.embedding.engine.plugins.FlutterPlugin;
 import io.flutter.embedding.engine.plugins.activity.ActivityAware;
@@ -30,6 +24,9 @@ import io.flutter.plugin.common.MethodChannel.MethodCallHandler;
 import io.flutter.plugin.common.MethodChannel.Result;
 import io.flutter.plugin.common.PluginRegistry;
 import io.flutter.plugin.common.PluginRegistry.Registrar;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
 
 /**
  * Flutter plugin accessing Firebase Admob API.

--- a/packages/firebase_admob/lib/firebase_admob.dart
+++ b/packages/firebase_admob/lib/firebase_admob.dart
@@ -497,6 +497,13 @@ class RewardedVideoAd {
       'targetingInfo': targetingInfo?.toJson(),
     });
   }
+  
+  Future<bool> setAppMuted(bool mute) {
+    return _invokeBooleanMethod("setAppMuted", <String, dynamic>{
+      'mute': mute
+    });
+  }
+  
 }
 
 /// Support for Google AdMob mobile ads.

--- a/packages/firebase_admob/lib/firebase_admob.dart
+++ b/packages/firebase_admob/lib/firebase_admob.dart
@@ -497,13 +497,10 @@ class RewardedVideoAd {
       'targetingInfo': targetingInfo?.toJson(),
     });
   }
-  
+
   Future<bool> setAppMuted(bool mute) {
-    return _invokeBooleanMethod("setAppMuted", <String, dynamic>{
-      'mute': mute
-    });
+    return _invokeBooleanMethod("setAppMuted", <String, dynamic>{'mute': mute});
   }
-  
 }
 
 /// Support for Google AdMob mobile ads.


### PR DESCRIPTION
## Description

- If we call `RewardedVideoAd.instance.load`, the `RewardedVideoAdEvent.loaded` callback is called, but only first time. When we call this load method second time, we don't get any callback. This PR fixes this issue.
- Add setAppMuted support, so we can call `RewardedVideoAd.instance.setAppMuted`

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x ] If the pull request affects only one plugin, the PR title starts with the name of the plugin in brackets (e.g. [cloud_firestore])
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [ ] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
