### PR TITLE
[firebase_auth] Resolve memory leak on Android

### DIFF
--- a/packages/firebase_auth/firebase_auth/CHANGELOG.md
+++ b/packages/firebase_auth/firebase_auth/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.16.2
+
+* Android: Remove memory leaks when plugin is destroyed with active auth state 
+  listeners.
+
 ## 0.16.1
 
 * Update lower bound of dart dependency to 2.0.0.

--- a/packages/firebase_auth/firebase_auth/android/src/main/java/io/flutter/plugins/firebaseauth/LinkedAuthStateListener.java
+++ b/packages/firebase_auth/firebase_auth/android/src/main/java/io/flutter/plugins/firebaseauth/LinkedAuthStateListener.java
@@ -1,0 +1,16 @@
+package io.flutter.plugins.firebaseauth;
+
+import com.google.firebase.auth.FirebaseAuth;
+
+public abstract class LinkedAuthStateListener implements FirebaseAuth.AuthStateListener {
+
+  final FirebaseAuth auth;
+
+  protected LinkedAuthStateListener(FirebaseAuth auth) {
+    this.auth = auth;
+  }
+
+  public FirebaseAuth getAuth() {
+    return auth;
+  }
+}

--- a/packages/firebase_auth/firebase_auth/pubspec.yaml
+++ b/packages/firebase_auth/firebase_auth/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for Firebase Auth, enabling Android and iOS
   authentication using passwords, phone numbers and identity providers
   like Google, Facebook and Twitter.
 homepage: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/firebase_auth/firebase_auth
-version: 0.16.1
+version: 0.16.2
 
 flutter:
   plugin:


### PR DESCRIPTION
## Description

Resolves a memory leak on Android when a activity moves away with the plugin still having auth state listeners open. See #261 for a similar problem.
## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] If the pull request affects only one plugin, the PR title starts with the name of the plugin in brackets (e.g. [cloud_firestore])
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
