### PR TITLE
[cloud_firestore] Clean up Android Firestore listeners

### DIFF
--- a/packages/cloud_firestore/cloud_firestore/CHANGELOG.md
+++ b/packages/cloud_firestore/cloud_firestore/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.13.7
+
+* Scope Android listener's to app's Activity.
+
 ## 0.13.6
 
 * Update lower bound of dart dependency to 2.0.0.

--- a/packages/cloud_firestore/cloud_firestore/CHANGELOG.md
+++ b/packages/cloud_firestore/cloud_firestore/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## 0.13.7
 
-* Scope Android listener's to app's Activity.
+* Clean up snapshot listeners when Android Activity is destroyed.
 
 ## 0.13.6
 

--- a/packages/cloud_firestore/cloud_firestore/android/src/main/java/io/flutter/plugins/firebase/cloudfirestore/CloudFirestorePlugin.java
+++ b/packages/cloud_firestore/cloud_firestore/android/src/main/java/io/flutter/plugins/firebase/cloudfirestore/CloudFirestorePlugin.java
@@ -1002,7 +1002,7 @@ public class CloudFirestorePlugin implements MethodCallHandler, FlutterPlugin, A
 
   private void removeSnapshotListeners() {
     for (int i = 0; i < listenerRegistrations.size(); i++) {
-      listenerRegistrations.get(i).remove();
+      listenerRegistrations.valueAt(i).remove();
     }
     listenerRegistrations.clear();
   }

--- a/packages/cloud_firestore/cloud_firestore/android/src/main/java/io/flutter/plugins/firebase/cloudfirestore/CloudFirestorePlugin.java
+++ b/packages/cloud_firestore/cloud_firestore/android/src/main/java/io/flutter/plugins/firebase/cloudfirestore/CloudFirestorePlugin.java
@@ -1000,6 +1000,7 @@ public class CloudFirestorePlugin implements MethodCallHandler, FlutterPlugin, A
     for (int i = 0; i < listenerRegistrations.size(); i++) {
       listenerRegistrations.get(i).remove();
     }
+    listenerRegistrations.clear();
   }
 }
 

--- a/packages/cloud_firestore/cloud_firestore/android/src/main/java/io/flutter/plugins/firebase/cloudfirestore/CloudFirestorePlugin.java
+++ b/packages/cloud_firestore/cloud_firestore/android/src/main/java/io/flutter/plugins/firebase/cloudfirestore/CloudFirestorePlugin.java
@@ -50,7 +50,6 @@ import io.flutter.plugin.common.PluginRegistry;
 import io.flutter.plugin.common.StandardMessageCodec;
 import io.flutter.plugin.common.StandardMethodCodec;
 import io.flutter.view.FlutterNativeView;
-
 import java.io.ByteArrayOutputStream;
 import java.nio.ByteBuffer;
 import java.nio.charset.Charset;
@@ -81,13 +80,14 @@ public class CloudFirestorePlugin implements MethodCallHandler, FlutterPlugin, A
     final CloudFirestorePlugin instance = new CloudFirestorePlugin();
     instance.activity = registrar.activity();
     instance.initInstance(registrar.messenger());
-    registrar.addViewDestroyListener(new PluginRegistry.ViewDestroyListener() {
-      @Override
-      public boolean onViewDestroy(FlutterNativeView view) {
-        instance.removeSnapshotListeners();
-        return false;
-      }
-    });
+    registrar.addViewDestroyListener(
+        new PluginRegistry.ViewDestroyListener() {
+          @Override
+          public boolean onViewDestroy(FlutterNativeView view) {
+            instance.removeSnapshotListeners();
+            return false;
+          }
+        });
   }
 
   private void initInstance(BinaryMessenger messenger) {
@@ -831,8 +831,7 @@ public class CloudFirestorePlugin implements MethodCallHandler, FlutterPlugin, A
                   : MetadataChanges.EXCLUDE;
           listenerRegistrations.put(
               handle,
-              getDocumentReference(arguments)
-                  .addSnapshotListener(metadataChanges, observer));
+              getDocumentReference(arguments).addSnapshotListener(metadataChanges, observer));
           result.success(handle);
           break;
         }

--- a/packages/cloud_firestore/cloud_firestore/android/src/main/java/io/flutter/plugins/firebase/cloudfirestore/CloudFirestorePlugin.java
+++ b/packages/cloud_firestore/cloud_firestore/android/src/main/java/io/flutter/plugins/firebase/cloudfirestore/CloudFirestorePlugin.java
@@ -84,7 +84,7 @@ public class CloudFirestorePlugin implements MethodCallHandler, FlutterPlugin, A
         new PluginRegistry.ViewDestroyListener() {
           @Override
           public boolean onViewDestroy(FlutterNativeView view) {
-            instance.removeSnapshotListeners();
+            instance.onDetachedFromEngine();
             return false;
           }
         });
@@ -485,6 +485,10 @@ public class CloudFirestorePlugin implements MethodCallHandler, FlutterPlugin, A
 
   @Override
   public void onDetachedFromEngine(@NonNull FlutterPluginBinding binding) {
+    onDetachedFromEngine();
+  }
+
+  private void onDetachedFromEngine() {
     removeSnapshotListeners();
     channel.setMethodCallHandler(null);
     channel = null;

--- a/packages/cloud_firestore/cloud_firestore/android/src/main/java/io/flutter/plugins/firebase/cloudfirestore/CloudFirestorePlugin.java
+++ b/packages/cloud_firestore/cloud_firestore/android/src/main/java/io/flutter/plugins/firebase/cloudfirestore/CloudFirestorePlugin.java
@@ -805,7 +805,7 @@ public class CloudFirestorePlugin implements MethodCallHandler, FlutterPlugin, A
                   ? MetadataChanges.INCLUDE
                   : MetadataChanges.EXCLUDE;
           listenerRegistrations.put(
-              handle, getQuery(arguments).addSnapshotListener(metadataChanges, observer));
+              handle, getQuery(arguments).addSnapshotListener(activity, metadataChanges, observer));
           result.success(handle);
           break;
         }
@@ -821,7 +821,7 @@ public class CloudFirestorePlugin implements MethodCallHandler, FlutterPlugin, A
                   : MetadataChanges.EXCLUDE;
           listenerRegistrations.put(
               handle,
-              getDocumentReference(arguments).addSnapshotListener(metadataChanges, observer));
+              getDocumentReference(arguments).addSnapshotListener(activity, metadataChanges, observer));
           result.success(handle);
           break;
         }

--- a/packages/cloud_firestore/cloud_firestore/android/src/main/java/io/flutter/plugins/firebase/cloudfirestore/CloudFirestorePlugin.java
+++ b/packages/cloud_firestore/cloud_firestore/android/src/main/java/io/flutter/plugins/firebase/cloudfirestore/CloudFirestorePlugin.java
@@ -821,7 +821,8 @@ public class CloudFirestorePlugin implements MethodCallHandler, FlutterPlugin, A
                   : MetadataChanges.EXCLUDE;
           listenerRegistrations.put(
               handle,
-              getDocumentReference(arguments).addSnapshotListener(activity, metadataChanges, observer));
+              getDocumentReference(arguments)
+                  .addSnapshotListener(activity, metadataChanges, observer));
           result.success(handle);
           break;
         }

--- a/packages/cloud_firestore/cloud_firestore/pubspec.yaml
+++ b/packages/cloud_firestore/cloud_firestore/pubspec.yaml
@@ -3,7 +3,7 @@ description:
   Flutter plugin for Cloud Firestore, a cloud-hosted, noSQL database with
   live synchronization and offline support on Android and iOS.
 homepage: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/cloud_firestore/cloud_firestore
-version: 0.13.6
+version: 0.13.7
 
 flutter:
   plugin:


### PR DESCRIPTION
## Description

TL;dr: Remove Android Firestore listeners when the host Activity is destroyed or the engine is detached.

The Cloud Firestore plugins does not currently clean up listeners after the user leaves the app on Android. This results in snapshot listeners sticking around even though associated resources like the channel is no longer available.

When a change occurs to the data, the stranded listeners try to report the updates via the channel that is no longer available. This results in a null pointer exception.

This PR uses lifecycle callbacks of both v1 and v2 embedding to remove listeners before either the app's Activity is destroyed (v1) or the Flutter engine is detached (v2).

## Related Issues

fixes #2517 
fixes #2390 

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] If the pull request affects only one plugin, the PR title starts with the name of the plugin in brackets (e.g. [cloud_firestore])
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.
