### PR TITLE
Update readme with correct link for config steps

### DIFF
--- a/packages/firebase_analytics/firebase_analytics/README.md
+++ b/packages/firebase_analytics/firebase_analytics/README.md
@@ -7,7 +7,7 @@ A Flutter plugin to use the [Google Analytics for Firebase API](https://firebase
 For Flutter plugins for other Firebase products, see [README.md](https://github.com/FirebaseExtended/flutterfire/blob/master/README.md).
 
 ## Usage
-To use this plugin, add `firebase_analytics` as a [dependency in your pubspec.yaml file](https://flutter.io/platform-plugins/). You must also configure firebase analytics for each platform project: Android and iOS (see the example folder or https://codelabs.developers.google.com/codelabs/flutter-firebase/#4 for step by step details).
+To use this plugin, add `firebase_analytics` as a [dependency in your pubspec.yaml file](https://flutter.io/platform-plugins/). You must also configure firebase analytics for each platform project: Android and iOS (see the example folder or https://codelabs.developers.google.com/codelabs/flutter-firebase/#6 for step by step details).
 
 ## Track PageRoute Transitions
 


### PR DESCRIPTION
https://codelabs.developers.google.com/codelabs/flutter-firebase/#4 contains irrelevant steps for building a UI

The right Url for platform-specific steps is https://codelabs.developers.google.com/codelabs/flutter-firebase/#6
