### PR TITLE
Update Readme to use runZonedGuarded

### DIFF
--- a/packages/firebase_crashlytics/README.md
+++ b/packages/firebase_crashlytics/README.md
@@ -99,7 +99,13 @@ you can supply `Crashlytics.instance.recordError` to the `onError` parameter:
 runZoned<Future<void>>(() async {
     // ...
   }, onError: Crashlytics.instance.recordError);
-``` 
+```
+With Flutter 1.17 which includes Dart 2.8, use runZonedGuarded instead:
+```dart
+runZonedGuarded<Future<void>>(() async {
+    // ...
+  }, onError: Crashlytics.instance.recordError);
+```
 
 ## Result
 


### PR DESCRIPTION
Recommended to use runZonedGuarded instead runZoned with Flutter 1.17

