### PR TITLE
[dynamic_links]: fix initialization process

### DIFF
--- a/packages/firebase_dynamic_links/CHANGELOG.md
+++ b/packages/firebase_dynamic_links/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.5.2
+
+* Fix for race-condition issue on iOS during initialization process
+
 ## 0.5.1
 
 * Update lower bound of dart dependency to 2.0.0.

--- a/packages/firebase_dynamic_links/README.md
+++ b/packages/firebase_dynamic_links/README.md
@@ -95,8 +95,7 @@ Receiving dynamic links on *iOS* requires a couple more steps than *Android*. If
 applinks:YOUR_SUBDOMAIN.page.link
 ```
 
-4. To receive a dynamic link, call the `getInitialLink()` method from `FirebaseDynamicLinks` which gets the link that opened the app (or null if it was not opened via a dynamic link)
-and configure listeners for link callbacks when the application is active or in background calling `onLink`.
+4. To receive a dynamic link, configure listeners for link callbacks when the application is active or in background calling `onLink` and call the `getInitialLink()` method from `FirebaseDynamicLinks` which gets the link that opened the app (or null if it was not opened via a dynamic link).
 
 ```dart
 void main() {
@@ -120,13 +119,6 @@ class MyHomeWidgetState extends State<MyHomeWidget> {
   }
 
   void initDynamicLinks() async {
-    final PendingDynamicLinkData data = await FirebaseDynamicLinks.instance.getInitialLink();
-    final Uri deepLink = data?.link;
-
-    if (deepLink != null) {
-      Navigator.pushNamed(context, deepLink.path);
-    }
-
     FirebaseDynamicLinks.instance.onLink(
       onSuccess: (PendingDynamicLinkData dynamicLink) async {
         final Uri deepLink = dynamicLink?.link;
@@ -140,6 +132,13 @@ class MyHomeWidgetState extends State<MyHomeWidget> {
         print(e.message);
       }
     );
+    
+    final PendingDynamicLinkData data = await FirebaseDynamicLinks.instance.getInitialLink();
+    final Uri deepLink = data?.link;
+
+    if (deepLink != null) {
+      Navigator.pushNamed(context, deepLink.path);
+    }
   }
   .
   .

--- a/packages/firebase_dynamic_links/example/lib/main.dart
+++ b/packages/firebase_dynamic_links/example/lib/main.dart
@@ -4,8 +4,8 @@
 
 import 'dart:async';
 
-import 'package:flutter/material.dart';
 import 'package:firebase_dynamic_links/firebase_dynamic_links.dart';
+import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:url_launcher/url_launcher.dart';
 
@@ -40,14 +40,6 @@ class _MainScreenState extends State<_MainScreen> {
   }
 
   void initDynamicLinks() async {
-    final PendingDynamicLinkData data =
-        await FirebaseDynamicLinks.instance.getInitialLink();
-    final Uri deepLink = data?.link;
-
-    if (deepLink != null) {
-      Navigator.pushNamed(context, deepLink.path);
-    }
-
     FirebaseDynamicLinks.instance.onLink(
         onSuccess: (PendingDynamicLinkData dynamicLink) async {
       final Uri deepLink = dynamicLink?.link;
@@ -59,6 +51,14 @@ class _MainScreenState extends State<_MainScreen> {
       print('onLinkError');
       print(e.message);
     });
+
+    final PendingDynamicLinkData data =
+        await FirebaseDynamicLinks.instance.getInitialLink();
+    final Uri deepLink = data?.link;
+
+    if (deepLink != null) {
+      Navigator.pushNamed(context, deepLink.path);
+    }
   }
 
   Future<void> _createDynamicLink(bool short) async {

--- a/packages/firebase_dynamic_links/pubspec.yaml
+++ b/packages/firebase_dynamic_links/pubspec.yaml
@@ -1,7 +1,7 @@
 name: firebase_dynamic_links
 description: Flutter plugin for Google Dynamic Links for Firebase, an app solution for creating
   and handling links across multiple platforms.
-version: 0.5.1
+version: 0.5.2
 homepage: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/firebase_dynamic_links
 
 dependencies:


### PR DESCRIPTION
Description:

This is my first contribution to this project so I'm sorry if I made this in improper way.

## Description

Fix race conditions related to the dynamic links initialization process.

1. During installation flow `- (BOOL)application:(UIApplication *)application openURL:(NSURL *)url sourceApplication:(NSString *)sourceApplication annotation:(id)annotation` might be called by OS after `FirebaseDynamicLinks.instance.getInitialLink()` is called. In such a case the app won't retrieve the deep-link.
2. If `FirebaseDynamicLinks.instance.getInitialLink()` is called while processing `[FIRDynamicLinks dynamicLinks]  openURL:(NSURL *)url handleUniversalLink`, the url is lost.
3. Documentation fix: `FirebaseDynamicLinks.instance.getInitialLink()` call should be called after `FirebaseDynamicLinks.instance.onLink()` so url's aren't lost between those two calls.

More info in the comments in the PR:


## Related Issues

* https://github.com/FirebaseExtended/flutterfire/issues/100
* https://github.com/FirebaseExtended/flutterfire/issues/1847
* https://github.com/FirebaseExtended/flutterfire/issues/1861

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] If the pull request affects only one plugin, the PR title starts with the name of the plugin in brackets (e.g. [cloud_firestore])
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]). - **I haven't wrote any integration tests for the iOS stuff because i'd be a little complex.**
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
