### PR TITLE
[firebase_analytics_web] Add missing iOS files

### DIFF
--- a/packages/firebase_analytics/firebase_analytics_web/CHANGELOG.md
+++ b/packages/firebase_analytics/firebase_analytics_web/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.1
+
+- Add missing iOS files to be able to endorse this plugin as the web implementation of firebase_analytics.
+
 ## 0.1.0
 
 - Initial implementation for firebase_analytics_web.

--- a/packages/firebase_analytics/firebase_analytics_web/ios/firebase_analytics_web.podspec
+++ b/packages/firebase_analytics/firebase_analytics_web/ios/firebase_analytics_web.podspec
@@ -1,0 +1,21 @@
+#
+# To learn more about a Podspec see http://guides.cocoapods.org/syntax/podspec.html
+#
+Pod::Spec.new do |s|
+    s.name             = 'firebase_analytics_web'
+    s.version          = '0.1.0'
+    s.summary          = 'No-op implementation of firebase_analytics_web web plugin to avoid build issues on iOS'
+    s.description      = <<-DESC
+  temp fake firebase_auth_web plugin
+                         DESC
+    s.homepage         = 'https://github.com/FirebaseExtended/flutterfire/tree/master/packages/firebase_analytics/firebase_analytics_web'
+    s.license          = { :file => '../LICENSE' }
+    s.author           = { 'Flutter Team' => 'flutter-dev@googlegroups.com' }
+    s.source           = { :path => '.' }
+    s.source_files = 'Classes/**/*'
+    s.public_header_files = 'Classes/**/*.h'
+    s.dependency 'Flutter'
+
+    s.ios.deployment_target = '8.0'
+  end
+

--- a/packages/firebase_analytics/firebase_analytics_web/pubspec.yaml
+++ b/packages/firebase_analytics/firebase_analytics_web/pubspec.yaml
@@ -1,7 +1,7 @@
 name: firebase_analytics_web
 description: The web implementation of firebase_analytics
 homepage: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/firebase_analytics/firebase_analytics_web
-version: 0.1.0
+version: 0.1.1
 
 flutter:
   plugin:


### PR DESCRIPTION
## Description

We [tried to endorse](https://github.com/FirebaseExtended/flutterfire/pull/2794) this plugin as the web implementation of **firebase_analytics** but the integration tests failed due to missing ios files. This PR adds those missing files.

## Related Issues

flutter/flutter#45289

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] If the pull request affects only one plugin, the PR title starts with the name of the plugin in brackets (e.g. [cloud_firestore])
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
