### PR TITLE
[remote_config] Propagate native error message on #fetch

### DIFF
--- a/packages/firebase_remote_config/CHANGELOG.md
+++ b/packages/firebase_remote_config/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.1+1
+
+* Propagate native error message on fetch method.
+
 ## 0.3.1
 
 * Update lower bound of dart dependency to 2.0.0.

--- a/packages/firebase_remote_config/lib/src/remote_config.dart
+++ b/packages/firebase_remote_config/lib/src/remote_config.dart
@@ -131,7 +131,7 @@ class RemoteConfig extends ChangeNotifier {
         final int fetchThrottleEnd = e.details['fetchThrottledEnd'];
         throw FetchThrottledException._(endTimeInMills: fetchThrottleEnd);
       } else {
-        throw Exception('Unable to fetch remote config');
+        throw Exception(e.message);
       }
     }
   }

--- a/packages/firebase_remote_config/pubspec.yaml
+++ b/packages/firebase_remote_config/pubspec.yaml
@@ -2,7 +2,7 @@ name: firebase_remote_config
 description: Flutter plugin for Firebase Remote Config. Update your application look and feel and behaviour without
   re-releasing.
 homepage: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/firebase_remote_config
-version: 0.3.1
+version: 0.3.1+1
 
 dependencies:
   flutter:


### PR DESCRIPTION
## Description
Any error thrown by `RemoteConfig.fetch` that doesn't have the code `fetchFailedThrottled` is "swallowed" because we're only returning the string "Unable to fetch remote config". This PR replaces the generic message with the message returned from the native side in order to improve debuggability (if this word exists 😅 ).

## Related Issues
I couldn't find one related to this specific problem.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] If the pull request affects only one plugin, the PR title starts with the name of the plugin in brackets (e.g. [cloud_firestore])
- [x] All existing and new tests are passing.
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
