### PR TITLE
fix(core,macos): don't use umbrella Firebase header

### DIFF
--- a/packages/firebase_core/firebase_core/ios/Classes/FLTFirebasePlugin.h
+++ b/packages/firebase_core/firebase_core/ios/Classes/FLTFirebasePlugin.h
@@ -2,7 +2,11 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#import <Firebase/Firebase.h>
+// Note: Don't use <Firebase/Firebase.h> umbrella header here - will cause a build
+//       failure on MacOS builds (Flutter MacOS uses Swift) when this file is included
+//       in other Flutter plugins like Firestore with an error of "Include of non-modular header
+//       inside framework module".
+#import <FirebaseCore/FirebaseCore.h>
 #import <Foundation/Foundation.h>
 
 #if TARGET_OS_OSX


### PR DESCRIPTION
## Description

This issue relates to the new Firebase Core as per #2582.

Fixes an issue that causes MacOS builds to fail due to Swift usage. Copy of https://github.com/invertase/flutterfire/pull/28/commits/f2147b12bfc8e46cac3a6a13ea776874d0eafb37

Example failure can be seen here: https://github.com/invertase/flutterfire/runs/832934288 with this change applied CI now passes: https://github.com/invertase/flutterfire/runs/838908028


## Related Issues

*Replace this paragraph with a list of issues related to this PR from the [issue database](https://github.com/flutter/flutter/issues). Indicate, which of these issues are resolved or fixed by this PR. Note that you'll have to prefix the issue numbers with flutter/flutter#.*

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] If the pull request affects only one plugin, the PR title starts with the name of the plugin in brackets (e.g. [cloud_firestore])
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
