### PR TITLE
chore(firebase_core): bump core versions

### DIFF
--- a/packages/firebase_core/firebase_core/CHANGELOG.md
+++ b/packages/firebase_core/firebase_core/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.0.0-1.0.pre
+## 0.5.0-dev.1
 
 * DEPRECATED: `FirebaseApp.configure` method is now deprecated in favor of the `Firebase.initializeApp` method.
 * DEPRECATED: `FirebaseApp.allApps` method is now deprecated in favor of the `Firebase.apps` property.

--- a/packages/firebase_core/firebase_core/pubspec.yaml
+++ b/packages/firebase_core/firebase_core/pubspec.yaml
@@ -2,7 +2,7 @@ name: firebase_core
 description: Flutter plugin for Firebase Core, enabling connecting to multiple
   Firebase apps.
 homepage: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/firebase_core/firebase_core
-version: 0.4.5
+version: 0.5.0-dev.1
 
 flutter:
   plugin:
@@ -18,12 +18,12 @@ flutter:
         default_package: firebase_core_web
 
 dependencies:
-  firebase_core_platform_interface: ^1.0.4
+  firebase_core_platform_interface: ^1.1.0-dev.1
   flutter:
     sdk: flutter
   quiver: ">=2.0.0 <3.0.0"
   meta: ^1.1.8
-  firebase_core_web: ^0.1.1+2
+  firebase_core_web: ^0.2.0-dev.1
 
 dev_dependencies:
   pedantic: ^1.8.0

--- a/packages/firebase_core/firebase_core/pubspec.yaml
+++ b/packages/firebase_core/firebase_core/pubspec.yaml
@@ -18,7 +18,7 @@ flutter:
         default_package: firebase_core_web
 
 dependencies:
-  firebase_core_platform_interface: ^1.1.0-dev.1
+  firebase_core_platform_interface: ^2.0.0-dev.1
   flutter:
     sdk: flutter
   quiver: ">=2.0.0 <3.0.0"

--- a/packages/firebase_core/firebase_core_platform_interface/CHANGELOG.md
+++ b/packages/firebase_core/firebase_core_platform_interface/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 2.0.0-1.0.pre
+## 1.1.0-dev.1
 
 * DEPRECATED: `FirebaseApp.configure` method is now deprecated in favor of the `Firebase.initializeApp` method.
 * DEPRECATED: `FirebaseApp.allApps` method is now deprecated in favor of the `Firebase.apps` property.

--- a/packages/firebase_core/firebase_core_platform_interface/CHANGELOG.md
+++ b/packages/firebase_core/firebase_core_platform_interface/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.1.0-dev.1
+## 2.0.0-dev.1
 
 * DEPRECATED: `FirebaseApp.configure` method is now deprecated in favor of the `Firebase.initializeApp` method.
 * DEPRECATED: `FirebaseApp.allApps` method is now deprecated in favor of the `Firebase.apps` property.

--- a/packages/firebase_core/firebase_core_platform_interface/pubspec.yaml
+++ b/packages/firebase_core/firebase_core_platform_interface/pubspec.yaml
@@ -3,7 +3,7 @@ description: A common platform interface for the firebase_core plugin.
 homepage: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/firebase_core/firebase_core_platform_interface
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 1.0.5
+version: 1.1.0-dev.1
 
 dependencies:
   flutter:

--- a/packages/firebase_core/firebase_core_platform_interface/pubspec.yaml
+++ b/packages/firebase_core/firebase_core_platform_interface/pubspec.yaml
@@ -3,7 +3,7 @@ description: A common platform interface for the firebase_core plugin.
 homepage: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/firebase_core/firebase_core_platform_interface
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 1.1.0-dev.1
+version: 2.0.0-dev.1
 
 dependencies:
   flutter:

--- a/packages/firebase_core/firebase_core_web/CHANGELOG.md
+++ b/packages/firebase_core/firebase_core_web/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 1.0.0-1.0.pre
+## 0.2.0-dev.1
 
 * DEPRECATED: `FirebaseApp.configure` method is now deprecated in favor of the `Firebase.initializeApp` method.
 * DEPRECATED: `FirebaseApp.allApps` method is now deprecated in favor of the `Firebase.apps` property.

--- a/packages/firebase_core/firebase_core_web/pubspec.yaml
+++ b/packages/firebase_core/firebase_core_web/pubspec.yaml
@@ -1,7 +1,7 @@
 name: firebase_core_web
 description: The web implementation of firebase_core
 homepage: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/firebase_core/firebase_core_web
-version: 0.1.2
+version: 0.2.0-dev.1
 
 flutter:
   plugin:
@@ -12,7 +12,7 @@ flutter:
 
 dependencies:
   firebase: ^7.3.0
-  firebase_core_platform_interface: ^1.0.4
+  firebase_core_platform_interface: ^1.1.0-dev.1
   flutter:
     sdk: flutter
   flutter_web_plugins:
@@ -24,7 +24,7 @@ dev_dependencies:
   pedantic: ^1.8.0
   flutter_test:
     sdk: flutter
-  firebase_core: ^0.4.5
+  firebase_core: ^0.5.0-dev.1
 
 environment:
   sdk: ">=2.1.0 <3.0.0"

--- a/packages/firebase_core/firebase_core_web/pubspec.yaml
+++ b/packages/firebase_core/firebase_core_web/pubspec.yaml
@@ -12,7 +12,7 @@ flutter:
 
 dependencies:
   firebase: ^7.3.0
-  firebase_core_platform_interface: ^1.1.0-dev.1
+  firebase_core_platform_interface: ^2.0.0-dev.1
   flutter:
     sdk: flutter
   flutter_web_plugins:


### PR DESCRIPTION
## Description

Version bump in preparation for publishing the updated `firebase_core` plugin. This will be a "pre release" version of the core plugin. Bumping to `v0.5.0-dev.1`. `firebase_core_web` and `firebase_core_platform_interface` are also bumped in a similar way.
