### PR TITLE
fix(cloud_firestore): remove get-write validation

### DIFF
--- a/packages/cloud_firestore/cloud_firestore_platform_interface/lib/src/method_channel/method_channel_transaction.dart
+++ b/packages/cloud_firestore/cloud_firestore_platform_interface/lib/src/method_channel/method_channel_transaction.dart
@@ -26,20 +26,11 @@ class MethodChannelTransaction extends TransactionPlatform {
         FirebaseFirestorePlatform.instanceFor(app: Firebase.app(appName));
   }
 
-  int _documentGetCount = 0;
-
   List<Map<String, dynamic>> _commands = [];
 
   /// Returns all transaction commands for the current instance.
-  ///
-  /// All get operations must be written, otherwise an [AssertionError] will be thrown
   @override
   List<Map<String, dynamic>> get commands {
-    if (_documentGetCount > 0) {
-      assert(_documentGetCount <= _commands.length,
-          "All transaction get operations must also be written.");
-    }
-
     return _commands;
   }
 
@@ -58,7 +49,6 @@ class MethodChannelTransaction extends TransactionPlatform {
       'transactionId': _transactionId,
       'reference': _firestore.doc(documentPath),
     });
-    _documentGetCount++;
 
     return DocumentSnapshotPlatform(
       _firestore,

--- a/packages/cloud_firestore/cloud_firestore_platform_interface/test/method_channel_tests/method_channel_transaction_test.dart
+++ b/packages/cloud_firestore/cloud_firestore_platform_interface/test/method_channel_tests/method_channel_transaction_test.dart
@@ -64,11 +64,6 @@ void main() {
     });
 
     group('commands', () {
-      test('should throw if get is not written', () async {
-        await transaction.get(mockDocumentReference.path);
-        expect(() => transaction.commands, throwsAssertionError);
-      });
-
       test('returns with equal checks', () async {
         await transaction.get(mockDocumentReference.path);
         transaction.set(mockDocumentReference.path, {'foo': 'bar'});


### PR DESCRIPTION
## Description

Assertion on ensuring that all reads (via `get`) on transactions are updated is no longer required.

## Related Issues

N/A

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] If the pull request affects only one plugin, the PR title starts with the name of the plugin in brackets (e.g. [cloud_firestore])
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

