### PR TITLE
fix(firestore): collection and document equality checking

### DIFF
--- a/packages/cloud_firestore/cloud_firestore/CHANGELOG.md
+++ b/packages/cloud_firestore/cloud_firestore/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 - **FIX**: Collection reference `==` operator.
 
-## [UNPUBLISHED]
+## 0.14.0-dev.1
 
 Along with the below changes, the plugin has undergone a quality of life update to better support exceptions thrown. Any Firestore specific errors now return a `FirebaseException`, allowing you to directly access the code (e.g. `permission-denied`) and message.
 

--- a/packages/cloud_firestore/cloud_firestore/CHANGELOG.md
+++ b/packages/cloud_firestore/cloud_firestore/CHANGELOG.md
@@ -1,7 +1,6 @@
 ## [UNPUBLISHED]
 
-- **FIX**: Collection reference `==` operator.
-
+- **FIX**: Added `==` operator override to `CollectionReferencePlatform`.
 ## 0.14.0-dev.1
 
 Along with the below changes, the plugin has undergone a quality of life update to better support exceptions thrown. Any Firestore specific errors now return a `FirebaseException`, allowing you to directly access the code (e.g. `permission-denied`) and message.

--- a/packages/cloud_firestore/cloud_firestore/CHANGELOG.md
+++ b/packages/cloud_firestore/cloud_firestore/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [UNPUBLISHED]
 
+- **FIX**: Collection reference `==` operator.
+
+## [UNPUBLISHED]
+
 Along with the below changes, the plugin has undergone a quality of life update to better support exceptions thrown. Any Firestore specific errors now return a `FirebaseException`, allowing you to directly access the code (e.g. `permission-denied`) and message.
 
 **`Firestore`**:

--- a/packages/cloud_firestore/cloud_firestore/CHANGELOG.md
+++ b/packages/cloud_firestore/cloud_firestore/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [UNPUBLISHED]
 
 - **FIX**: Added `==` operator override to `CollectionReferencePlatform`.
+
 ## 0.14.0-dev.1
 
 Along with the below changes, the plugin has undergone a quality of life update to better support exceptions thrown. Any Firestore specific errors now return a `FirebaseException`, allowing you to directly access the code (e.g. `permission-denied`) and message.

--- a/packages/cloud_firestore/cloud_firestore_platform_interface/lib/src/platform_interface/platform_interface_collection_reference.dart
+++ b/packages/cloud_firestore/cloud_firestore_platform_interface/lib/src/platform_interface/platform_interface_collection_reference.dart
@@ -52,8 +52,8 @@ abstract class CollectionReferencePlatform extends QueryPlatform {
   @override
   bool operator ==(dynamic o) =>
       o is CollectionReferencePlatform &&
-          o.firestore == firestore &&
-          o._pointer == _pointer;
+      o.firestore == firestore &&
+      o._pointer == _pointer;
 
   @override
   int get hashCode => _pointer.hashCode;

--- a/packages/cloud_firestore/cloud_firestore_platform_interface/lib/src/platform_interface/platform_interface_collection_reference.dart
+++ b/packages/cloud_firestore/cloud_firestore_platform_interface/lib/src/platform_interface/platform_interface_collection_reference.dart
@@ -53,10 +53,10 @@ abstract class CollectionReferencePlatform extends QueryPlatform {
   bool operator ==(dynamic o) =>
       o is CollectionReferencePlatform &&
       o.firestore == firestore &&
-      o._pointer == _pointer;
+      o.path == path;
 
   @override
-  int get hashCode => _pointer.hashCode;
+  int get hashCode => path.hashCode;
 
   @override
   String toString() => '$CollectionReferencePlatform($path)';

--- a/packages/cloud_firestore/cloud_firestore_platform_interface/lib/src/platform_interface/platform_interface_collection_reference.dart
+++ b/packages/cloud_firestore/cloud_firestore_platform_interface/lib/src/platform_interface/platform_interface_collection_reference.dart
@@ -48,4 +48,16 @@ abstract class CollectionReferencePlatform extends QueryPlatform {
   DocumentReferencePlatform doc([String path]) {
     throw UnimplementedError("doc() is not implemented");
   }
+
+  @override
+  bool operator ==(dynamic o) =>
+      o is CollectionReferencePlatform &&
+          o.firestore == firestore &&
+          o._pointer == _pointer;
+
+  @override
+  int get hashCode => _pointer.hashCode;
+
+  @override
+  String toString() => '$CollectionReferencePlatform($path)';
 }

--- a/packages/cloud_firestore/cloud_firestore_platform_interface/lib/src/platform_interface/platform_interface_document_reference.dart
+++ b/packages/cloud_firestore/cloud_firestore_platform_interface/lib/src/platform_interface/platform_interface_document_reference.dart
@@ -98,10 +98,10 @@ abstract class DocumentReferencePlatform extends PlatformInterface {
   bool operator ==(dynamic o) =>
       o is DocumentReferencePlatform &&
       o.firestore == firestore &&
-      o.path == path;
+      o._pointer == _pointer;
 
   @override
-  int get hashCode => path.hashCode;
+  int get hashCode => _pointer.hashCode;
 
   @override
   String toString() => '$DocumentReferencePlatform($path)';

--- a/packages/cloud_firestore/cloud_firestore_platform_interface/lib/src/platform_interface/platform_interface_document_reference.dart
+++ b/packages/cloud_firestore/cloud_firestore_platform_interface/lib/src/platform_interface/platform_interface_document_reference.dart
@@ -98,10 +98,10 @@ abstract class DocumentReferencePlatform extends PlatformInterface {
   bool operator ==(dynamic o) =>
       o is DocumentReferencePlatform &&
       o.firestore == firestore &&
-      o._pointer == _pointer;
+      o.path == path;
 
   @override
-  int get hashCode => _pointer.hashCode;
+  int get hashCode => path.hashCode;
 
   @override
   String toString() => '$DocumentReferencePlatform($path)';

--- a/packages/cloud_firestore/cloud_firestore_platform_interface/test/platform_interface_tests/platform_interface_collection_reference_test.dart
+++ b/packages/cloud_firestore/cloud_firestore_platform_interface/test/platform_interface_tests/platform_interface_collection_reference_test.dart
@@ -17,6 +17,15 @@ class TestCollectionReference extends CollectionReferencePlatform {
       : super(FirebaseFirestorePlatform.instance, '$_kCollectionId');
 }
 
+/// Collection reference pointing to the same collection as
+/// [TestCollectionReference].
+///
+/// However, this has a leading `/` for testing path equality.
+class ShadowTestCollectionReference extends CollectionReferencePlatform {
+  ShadowTestCollectionReference._()
+      : super(FirebaseFirestorePlatform.instance, '/$_kCollectionId');
+}
+
 class TestSubcollectionReference extends CollectionReferencePlatform {
   TestSubcollectionReference._()
       : super(FirebaseFirestorePlatform.instance,
@@ -43,10 +52,7 @@ void main() {
     });
 
     test('==', () {
-      final other = CollectionReferencePlatform(
-        FirebaseFirestorePlatform.instance,
-        '/$_kCollectionId',
-      );
+      final other = ShadowTestCollectionReference._();
       final collection = TestCollectionReference._();
       expect(other, equals(collection));
     });

--- a/packages/cloud_firestore/cloud_firestore_platform_interface/test/platform_interface_tests/platform_interface_collection_reference_test.dart
+++ b/packages/cloud_firestore/cloud_firestore_platform_interface/test/platform_interface_tests/platform_interface_collection_reference_test.dart
@@ -42,6 +42,15 @@ void main() {
       expect(collection.id, equals(_kCollectionId));
     });
 
+    test('==', () {
+      final other = CollectionReferencePlatform(
+        FirebaseFirestorePlatform.instance,
+        '/$_kCollectionId',
+      );
+      final collection = TestCollectionReference._();
+      expect(other, equals(collection));
+    });
+
     test("parent", () {
       final collection = TestSubcollectionReference._();
       final parent = collection.parent;

--- a/packages/cloud_firestore/cloud_firestore_platform_interface/test/platform_interface_tests/platform_interface_document_reference_test.dart
+++ b/packages/cloud_firestore/cloud_firestore_platform_interface/test/platform_interface_tests/platform_interface_document_reference_test.dart
@@ -22,7 +22,7 @@ class TestDocumentReference extends DocumentReferencePlatform {
 ///
 /// However, this has a leading `/` for testing path equality.
 class ShadowTestDocumentReference extends DocumentReferencePlatform {
-  TestDocumentReference._()
+  ShadowTestDocumentReference._()
       : super(FirebaseFirestorePlatform.instance,
       '/$_kCollectionId/$_kDocumentId');
 }

--- a/packages/cloud_firestore/cloud_firestore_platform_interface/test/platform_interface_tests/platform_interface_document_reference_test.dart
+++ b/packages/cloud_firestore/cloud_firestore_platform_interface/test/platform_interface_tests/platform_interface_document_reference_test.dart
@@ -24,7 +24,7 @@ class TestDocumentReference extends DocumentReferencePlatform {
 class ShadowTestDocumentReference extends DocumentReferencePlatform {
   ShadowTestDocumentReference._()
       : super(FirebaseFirestorePlatform.instance,
-      '/$_kCollectionId/$_kDocumentId');
+            '/$_kCollectionId/$_kDocumentId');
 }
 
 void main() {

--- a/packages/cloud_firestore/cloud_firestore_platform_interface/test/platform_interface_tests/platform_interface_document_reference_test.dart
+++ b/packages/cloud_firestore/cloud_firestore_platform_interface/test/platform_interface_tests/platform_interface_document_reference_test.dart
@@ -17,6 +17,16 @@ class TestDocumentReference extends DocumentReferencePlatform {
             '$_kCollectionId/$_kDocumentId');
 }
 
+/// Collection reference pointing to the same collection as
+/// [TestDocumentReference].
+///
+/// However, this has a leading `/` for testing path equality.
+class ShadowTestDocumentReference extends DocumentReferencePlatform {
+  TestDocumentReference._()
+      : super(FirebaseFirestorePlatform.instance,
+      '/$_kCollectionId/$_kDocumentId');
+}
+
 void main() {
   initializeMethodChannel();
 
@@ -38,10 +48,7 @@ void main() {
     });
 
     test('==', () {
-      final other = DocumentReferencePlatform(
-        FirebaseFirestorePlatform.instance,
-        '/$_kCollectionId/$_kDocumentId',
-      );
+      final other = ShadowTestDocumentReference._();
       final reference = TestDocumentReference._();
       expect(other, equals(reference));
     });

--- a/packages/cloud_firestore/cloud_firestore_platform_interface/test/platform_interface_tests/platform_interface_document_reference_test.dart
+++ b/packages/cloud_firestore/cloud_firestore_platform_interface/test/platform_interface_tests/platform_interface_document_reference_test.dart
@@ -37,6 +37,15 @@ void main() {
       expect(document.path, equals("$_kCollectionId/$_kDocumentId"));
     });
 
+    test('==', () {
+      final other = DocumentReferencePlatform(
+        FirebaseFirestorePlatform.instance,
+        '/$_kCollectionId/$_kDocumentId',
+      );
+      final reference = TestDocumentReference._();
+      expect(other, equals(reference));
+    });
+
     test("id", () {
       final document = TestDocumentReference._();
       expect(document.id, equals(_kDocumentId));


### PR DESCRIPTION
## Description

This expands on #2929: I think the collection reference was missing the `==` override and it also seems to make more sense to check if the pointers are equal rather than the paths, which are derived from the pointers. Essentially, this makes changing the `Pointer` behavior more easily.

Additionally, I added some tests that ensure that no regression occurs. The changelog entries that @IchordeDionysos added already reflect exactly what these changes do, so there is no need for another entry.

## Related Issues

#2929

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] If the pull request affects only one plugin, the PR title starts with the name of the plugin in brackets (e.g. [cloud_firestore])
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
