### PR TITLE
tests(cloud_firestore): add additional equality tests

### DIFF
--- a/packages/cloud_firestore/cloud_firestore/test/collection_reference_test.dart
+++ b/packages/cloud_firestore/cloud_firestore/test/collection_reference_test.dart
@@ -46,6 +46,14 @@ void main() {
       expect(ref == firestore.collection('foo'), isTrue);
       expect(ref2 == firestoreSecondary.collection('foo'), isTrue);
       expect(ref3 == ref, isFalse);
+
+      DocumentReference docRef = firestore.collection('foo').doc('bar');
+      DocumentReference docRef2 =
+          firestoreSecondary.collection('foo').doc('bar');
+
+      expect(docRef, firestore.collection('foo').doc('bar'));
+      expect(docRef2, firestoreSecondary.collection('foo').doc('bar'));
+      expect(docRef == docRef2, isFalse);
     });
 
     test('returns the correct id', () {

--- a/packages/cloud_firestore/cloud_firestore/test/document_reference_test.dart
+++ b/packages/cloud_firestore/cloud_firestore/test/document_reference_test.dart
@@ -39,6 +39,8 @@ void main() {
 
       expect(ref == firestoreSecondary.doc('foo/bar'), isFalse);
       expect(ref2 == firestoreSecondary.doc('foo/bar/baz/bert'), isFalse);
+
+      expect(ref == ref2, isFalse);
     });
 
     test("returns document() returns a $DocumentReference", () {


### PR DESCRIPTION
## Description

Adds additional tests to collection & document reference equality checks.

## Related Issues

Closes https://github.com/FirebaseExtended/flutterfire/pull/2524 (problem has been resolved via rework).
