### PR TITLE
chore(release): prerelease cloud_firestore* packages

### DIFF
--- a/packages/cloud_firestore/cloud_firestore/CHANGELOG.md
+++ b/packages/cloud_firestore/cloud_firestore/CHANGELOG.md
@@ -1,4 +1,4 @@
-## [UNPUBLISHED]
+## 0.14.0-dev.1
 
 Along with the below changes, the plugin has undergone a quality of life update to better support exceptions thrown. Any Firestore specific errors now return a `FirebaseException`, allowing you to directly access the code (e.g. `permission-denied`) and message.
 

--- a/packages/cloud_firestore/cloud_firestore/pubspec.yaml
+++ b/packages/cloud_firestore/cloud_firestore/pubspec.yaml
@@ -3,7 +3,7 @@ description:
   Flutter plugin for Cloud Firestore, a cloud-hosted, noSQL database with
   live synchronization and offline support on Android and iOS.
 homepage: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/cloud_firestore/cloud_firestore
-version: 0.13.7+1
+version: 0.14.0-dev.1
 
 flutter:
   plugin:
@@ -25,8 +25,8 @@ dependencies:
   quiver: ">=2.0.0 <3.0.0"
   firebase_core: ">=0.5.0-dev.1 <0.6.0"
   firebase_core_platform_interface: ">=2.0.0-dev.1 <2.1.0"
-  cloud_firestore_platform_interface: ^1.0.0
-  cloud_firestore_web: ^0.1.1
+  cloud_firestore_platform_interface: ">=2.0.0-dev.1 <2.1.0"
+  cloud_firestore_web: ">=0.2.0-dev.1 <0.3.0"
 
 dev_dependencies:
   pedantic: ^1.8.0

--- a/packages/cloud_firestore/cloud_firestore/pubspec.yaml
+++ b/packages/cloud_firestore/cloud_firestore/pubspec.yaml
@@ -23,8 +23,8 @@ dependencies:
     sdk: flutter
   meta: ^1.0.5
   quiver: ">=2.0.0 <3.0.0"
-  firebase_core: ^0.4.4
-  firebase_core_platform_interface: ^1.0.4
+  firebase_core: ">=0.5.0-dev.1 <0.6.0"
+  firebase_core_platform_interface: ">=2.0.0-dev.1 <2.1.0"
   cloud_firestore_platform_interface: ^1.0.0
   cloud_firestore_web: ^0.1.1
 

--- a/packages/cloud_firestore/cloud_firestore_platform_interface/CHANGELOG.md
+++ b/packages/cloud_firestore/cloud_firestore_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.0-dev.1
+
+* See `cloud_firestore` plugin changelog.
+
 ## 1.1.2
 
 * Update lower bound of dart dependency to 2.0.0.

--- a/packages/cloud_firestore/cloud_firestore_platform_interface/pubspec.yaml
+++ b/packages/cloud_firestore/cloud_firestore_platform_interface/pubspec.yaml
@@ -1,6 +1,6 @@
 name: cloud_firestore_platform_interface
 description: A common platform interface for the cloud_firestore plugin.
-version: 1.1.2
+version: 2.0.0-dev.1
 homepage: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/cloud_firestore/cloud_firestore_platform_interface
 
 dependencies:

--- a/packages/cloud_firestore/cloud_firestore_platform_interface/pubspec.yaml
+++ b/packages/cloud_firestore/cloud_firestore_platform_interface/pubspec.yaml
@@ -8,11 +8,11 @@ dependencies:
     sdk: flutter
   meta: ^1.0.5
   collection: ^1.14.3
-  firebase_core: ^0.4.5
+  firebase_core: ">=0.5.0-dev.1 <0.6.0"
   plugin_platform_interface: ^1.0.0
 
 dev_dependencies:
-  firebase_core_platform_interface: ^1.0.4
+  firebase_core_platform_interface: ">=2.0.0-dev.1 <2.1.0"
   pedantic: ^1.8.0
   flutter_test:
     sdk: flutter

--- a/packages/cloud_firestore/cloud_firestore_web/CHANGELOG.md
+++ b/packages/cloud_firestore/cloud_firestore_web/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.0-dev.1
+
+* See `cloud_firestore` plugin changelog.
+
 ## 0.1.1+2
 
 * Ensure QueryWeb correctly encodes values passed in to `[start|end][At|Before](Document?)` methods.

--- a/packages/cloud_firestore/cloud_firestore_web/pubspec.yaml
+++ b/packages/cloud_firestore/cloud_firestore_web/pubspec.yaml
@@ -18,7 +18,7 @@ dependencies:
   firebase: ^7.3.0
   http_parser: ^3.1.3
   meta: ^1.1.7
-  firebase_core: ^0.4.3+1
+  firebase_core: ">=0.5.0-dev.1 <0.6.0"
   cloud_firestore_platform_interface: ^1.1.0
   js: ^0.6.1
 
@@ -26,8 +26,8 @@ dev_dependencies:
   pedantic: ^1.8.0
   flutter_test:
     sdk: flutter
-  firebase_core_platform_interface: ^1.0.0
-  firebase_core_web: ^0.1.1
+  firebase_core_platform_interface: ">=2.0.0-dev.1 <2.1.0"
+  firebase_core_web: ">=0.2.0-dev.1 <0.3.0"
   mockito: ^4.1.1
 
 environment:

--- a/packages/cloud_firestore/cloud_firestore_web/pubspec.yaml
+++ b/packages/cloud_firestore/cloud_firestore_web/pubspec.yaml
@@ -1,7 +1,7 @@
 name: cloud_firestore_web
 description: The web implementation of cloud_firestore
 homepage: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/cloud_firestore/cloud_firestore_web
-version: 0.1.1+2
+version: 0.2.0-dev.1
 
 flutter:
   plugin:
@@ -19,7 +19,7 @@ dependencies:
   http_parser: ^3.1.3
   meta: ^1.1.7
   firebase_core: ">=0.5.0-dev.1 <0.6.0"
-  cloud_firestore_platform_interface: ^1.1.0
+  cloud_firestore_platform_interface: ">=2.0.0-dev.1 <2.1.0"
   js: ^0.6.1
 
 dev_dependencies:


### PR DESCRIPTION
## Description

In preparation for Firestore prerelease versions, update Firestore to depend on Firebase Core prerelease versions.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

