### PR TITLE
fix(firestore): add timestamp tests & fix

### DIFF
--- a/packages/cloud_firestore/cloud_firestore_platform_interface/lib/src/timestamp.dart
+++ b/packages/cloud_firestore/cloud_firestore_platform_interface/lib/src/timestamp.dart
@@ -31,14 +31,14 @@ class Timestamp implements Comparable<Timestamp> {
 
   /// Create a [Timestamp] fromMillisecondsSinceEpoch
   factory Timestamp.fromMillisecondsSinceEpoch(int milliseconds) {
-    final int seconds = (milliseconds / _kThousand).floor();
+    final int seconds = (milliseconds ~/ _kThousand).floor();
     final int nanoseconds = (milliseconds - seconds * _kThousand) * _kMillion;
     return Timestamp(seconds, nanoseconds);
   }
 
   /// Create a [Timestamp] fromMicrosecondsSinceEpoch
   factory Timestamp.fromMicrosecondsSinceEpoch(int microseconds) {
-    final int seconds = (microseconds / _kMillion).floor();
+    final int seconds = (microseconds ~/ _kMillion).floor();
     final int nanoseconds = (microseconds - seconds * _kMillion) * _kThousand;
     return Timestamp(seconds, nanoseconds);
   }
@@ -68,11 +68,11 @@ class Timestamp implements Comparable<Timestamp> {
 
   // ignore: public_member_api_docs
   int get millisecondsSinceEpoch =>
-      (seconds * _kThousand + nanoseconds / _kMillion).floor();
+      (seconds * _kThousand + nanoseconds ~/ _kMillion);
 
   // ignore: public_member_api_docs
   int get microsecondsSinceEpoch =>
-      (seconds * _kMillion + nanoseconds / _kThousand).floor();
+      (seconds * _kMillion + nanoseconds ~/ _kThousand);
 
   /// Converts [Timestamp] to [DateTime]
   DateTime toDate() {
@@ -81,9 +81,11 @@ class Timestamp implements Comparable<Timestamp> {
 
   @override
   int get hashCode => hashValues(seconds, nanoseconds);
+
   @override
   bool operator ==(dynamic o) =>
       o is Timestamp && o.seconds == seconds && o.nanoseconds == nanoseconds;
+
   @override
   int compareTo(Timestamp other) {
     if (seconds == other.seconds) {

--- a/packages/cloud_firestore/cloud_firestore_platform_interface/test/timestamp_test.dart
+++ b/packages/cloud_firestore/cloud_firestore_platform_interface/test/timestamp_test.dart
@@ -1,0 +1,38 @@
+// Copyright 2020, the Chromium project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:cloud_firestore_platform_interface/cloud_firestore_platform_interface.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+const int _kBillion = 1000000000;
+const int _kStartOfTime = -62135596800;
+const int _kEndOfTime = 253402300800;
+
+void main() {
+  group('$Timestamp', () {
+    test('equality', () {
+      expect(Timestamp(0, 0), equals(Timestamp(0, 0)));
+      expect(Timestamp(123, 456), equals(Timestamp(123, 456)));
+    });
+
+    test('validation', () {
+      expect(() => Timestamp(0, -1), throwsArgumentError);
+      expect(() => Timestamp(0, _kBillion + 1), throwsArgumentError);
+      expect(() => Timestamp(_kStartOfTime - 1, 123), throwsArgumentError);
+      expect(() => Timestamp(_kEndOfTime + 1, 123), throwsArgumentError);
+    });
+
+    test('returns properties', () {
+      Timestamp t = Timestamp(123, 456);
+      expect(t.seconds, equals(123));
+      expect(t.nanoseconds, equals(456));
+    });
+
+    // https://github.com/FirebaseExtended/flutterfire/issues/1222
+    test('does not exceed range', () {
+      Timestamp maxTimestamp = Timestamp(_kEndOfTime - 1, _kBillion - 1);
+      Timestamp.fromMicrosecondsSinceEpoch(maxTimestamp.microsecondsSinceEpoch);
+    });
+  });
+}


### PR DESCRIPTION
## Description

- Ensures out of range math values are rounded down.
- Adds Timestamp tests

## Related Issues

Fixes https://github.com/FirebaseExtended/flutterfire/issues/1222

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.
