### PR TITLE
tests(cloud_firestore): add unique query test path

### DIFF
--- a/packages/cloud_firestore/cloud_firestore/example/test_driver/query_e2e.dart
+++ b/packages/cloud_firestore/cloud_firestore/example/test_driver/query_e2e.dart
@@ -527,7 +527,7 @@ void runQueryTests() {
 
       test('endbeforeDocument() ends before a document field value', () async {
         CollectionReference collection =
-            await initializeTest('endBefore-document');
+            await initializeTest('endBefore-document-field-value');
         await Future.wait([
           collection.doc('doc1').set({
             'bar': {'value': 3}


### PR DESCRIPTION
## Description

The CI is currently failing randomly on the `endBeforeDocument` tests. The previous test shares the same collection path, so I believe this may be causing the issue.

