### PR TITLE
chore: migrate functions to use new core plugin

### DIFF
--- a/packages/cloud_functions/cloud_functions/CHANGELOG.md
+++ b/packages/cloud_functions/cloud_functions/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.6.0-dev.1
+
+* Update to v1 core plugin.
+
 ## 0.5.0
 
 * Fix example app build failure on CI (missing AndroidX Gradle properties).

--- a/packages/cloud_functions/cloud_functions/pubspec.yaml
+++ b/packages/cloud_functions/cloud_functions/pubspec.yaml
@@ -1,6 +1,6 @@
 name: cloud_functions
 description: Flutter plugin for Cloud Functions.
-version: 0.5.0
+version: 0.6.0-dev.1
 homepage: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/cloud_functions/cloud_functions
 
 flutter:
@@ -20,13 +20,13 @@ dependencies:
   meta: ^1.1.6
   flutter:
     sdk: flutter
-  firebase_core: ^0.4.4
-  cloud_functions_platform_interface: ^1.1.0
-  cloud_functions_web: ^1.1.0
+  firebase_core: ^0.5.0-dev.1
+  cloud_functions_platform_interface: ^2.0.0-dev.1
+  cloud_functions_web: ^2.0.0-dev.1
 
 dev_dependencies:
   pedantic: ^1.8.0
-  firebase_core_platform_interface: ^1.0.4
+  firebase_core_platform_interface: ^2.0.0-dev.1
   flutter_test:
     sdk: flutter
   flutter_driver:

--- a/packages/cloud_functions/cloud_functions_platform_interface/CHANGELOG.md
+++ b/packages/cloud_functions/cloud_functions_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.0-dev.1
+
+* Update to v1 core plugin.
+
 ## 1.1.0
 
 * Change environment SDK requirement from `>=2.0.0-dev.28.0` to `>=2.0.0` to fix 'publishable' CI stage.

--- a/packages/cloud_functions/cloud_functions_platform_interface/pubspec.yaml
+++ b/packages/cloud_functions/cloud_functions_platform_interface/pubspec.yaml
@@ -3,17 +3,17 @@ description: A common platform interface for the cloud_functions plugin.
 homepage: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/cloud_functions/cloud_functions_platform_interface
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 1.1.0
+version: 2.0.0-dev.1
 
 dependencies:
   flutter:
     sdk: flutter
   meta: ^1.0.5
-  firebase_core: ^0.4.0
+  firebase_core: ^0.5.0-dev.1
   plugin_platform_interface: ^1.0.1
 
 dev_dependencies:
-  firebase_core_platform_interface: ^1.0.4
+  firebase_core_platform_interface: ^2.0.0-dev.1
   pedantic: ^1.8.0
   flutter_test:
     sdk: flutter

--- a/packages/cloud_functions/cloud_functions_web/CHANGELOG.md
+++ b/packages/cloud_functions/cloud_functions_web/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.0.0-dev.1
+
+* Update to v1 core plugin.
+
 ## 1.1.0
 
 * Change environment SDK requirement from `>=2.0.0-dev.28.0` to `>=2.0.0` to fix 'publishable' CI stage.

--- a/packages/cloud_functions/cloud_functions_web/pubspec.yaml
+++ b/packages/cloud_functions/cloud_functions_web/pubspec.yaml
@@ -1,7 +1,7 @@
 name: cloud_functions_web
 description: The web implementation of cloud_functions
 homepage: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/cloud_functions/cloud_functions_web
-version: 1.1.0
+version: 2.0.0-dev.1
 
 flutter:
   plugin:
@@ -11,7 +11,7 @@ flutter:
         fileName: cloud_functions_web.dart
 
 dependencies:
-  cloud_functions_platform_interface: ^1.1.0
+  cloud_functions_platform_interface: ^2.0.0-dev.1
   flutter:
     sdk: flutter
   flutter_web_plugins:
@@ -24,8 +24,8 @@ dev_dependencies:
   pedantic: ^1.8.0
   flutter_test:
     sdk: flutter
-  firebase_core_platform_interface: ^1.0.2
-  firebase_core_web: ^0.1.1+2
+  firebase_core_platform_interface: ^2.0.0-dev.1
+  firebase_core_web: ^0.2.0-dev.1
   mockito: ^4.1.1
   js: ^0.6.0
 


### PR DESCRIPTION
# Description
Move the functions plugin to use the v1 core plugin.