### PR TITLE
fix(cloud_firestore): throw FirebaseException on web errors

### DIFF
--- a/packages/cloud_firestore/cloud_firestore/example/test_driver/document_reference_e2e.dart
+++ b/packages/cloud_firestore/cloud_firestore/example/test_driver/document_reference_e2e.dart
@@ -90,12 +90,9 @@ void runDocumentReferenceTests() {
         try {
           await stream.first;
         } catch (error) {
-          // TODO(ehesp): Web does not support handling exceptions yet.
-          if (!kIsWeb) {
-            expect(error, isA<FirebaseException>());
-            expect(
-                (error as FirebaseException).code, equals('permission-denied'));
-          }
+          expect(error, isA<FirebaseException>());
+          expect(
+              (error as FirebaseException).code, equals('permission-denied'));
           return;
         }
 
@@ -122,11 +119,9 @@ void runDocumentReferenceTests() {
         try {
           await document.delete();
         } catch (error) {
-          if (!kIsWeb) {
-            expect(error, isA<FirebaseException>());
-            expect(
-                (error as FirebaseException).code, equals('permission-denied'));
-          }
+          expect(error, isA<FirebaseException>());
+          expect(
+              (error as FirebaseException).code, equals('permission-denied'));
           return;
         }
         fail("Should have thrown a [FirebaseException]");
@@ -159,12 +154,9 @@ void runDocumentReferenceTests() {
         try {
           await document.get();
         } catch (error) {
-          // TODO(ehesp): Web does not support handling exceptions yet.
-          if (!kIsWeb) {
-            expect(error, isA<FirebaseException>());
-            expect(
-                (error as FirebaseException).code, equals('permission-denied'));
-          }
+          expect(error, isA<FirebaseException>());
+          expect(
+              (error as FirebaseException).code, equals('permission-denied'));
           return;
         }
         fail("Should have thrown a [FirebaseException]");
@@ -226,12 +218,9 @@ void runDocumentReferenceTests() {
         try {
           await document.set({'foo': 'bar'});
         } catch (error) {
-          // TODO(ehesp): Web does not support handling exceptions yet.
-          if (!kIsWeb) {
-            expect(error, isA<FirebaseException>());
-            expect(
-                (error as FirebaseException).code, equals('permission-denied'));
-          }
+          expect(error, isA<FirebaseException>());
+          expect(
+              (error as FirebaseException).code, equals('permission-denied'));
           return;
         }
         fail("Should have thrown a [FirebaseException]");
@@ -321,11 +310,8 @@ void runDocumentReferenceTests() {
           await document.update({'foo': 'bar'});
           fail("Should have thrown");
         } catch (e) {
-          // TODO(ehesp): Web does not support handling exceptions yet.
-          if (!kIsWeb) {
-            expect(e, isA<FirebaseException>());
-            expect(e.code, equals('not-found'));
-          }
+          expect(e, isA<FirebaseException>());
+          expect(e.code, equals('not-found'));
         }
       });
     });

--- a/packages/cloud_firestore/cloud_firestore/example/test_driver/query_e2e.dart
+++ b/packages/cloud_firestore/cloud_firestore/example/test_driver/query_e2e.dart
@@ -89,11 +89,9 @@ void runQueryTests() {
         try {
           await collection.get();
         } catch (error) {
-          if (!kIsWeb) {
-            expect(error, isA<FirebaseException>());
-            expect(
-                (error as FirebaseException).code, equals('permission-denied'));
-          }
+          expect(error, isA<FirebaseException>());
+          expect(
+              (error as FirebaseException).code, equals('permission-denied'));
           return;
         }
         fail("Should have thrown a [FireebaseException]");
@@ -185,11 +183,9 @@ void runQueryTests() {
         try {
           await stream.first;
         } catch (error) {
-          if (!kIsWeb) {
-            expect(error, isA<FirebaseException>());
-            expect(
-                (error as FirebaseException).code, equals('permission-denied'));
-          }
+          expect(error, isA<FirebaseException>());
+          expect(
+              (error as FirebaseException).code, equals('permission-denied'));
           return;
         }
 

--- a/packages/cloud_firestore/cloud_firestore_web/lib/cloud_firestore_web.dart
+++ b/packages/cloud_firestore/cloud_firestore_web/lib/cloud_firestore_web.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:cloud_firestore_platform_interface/cloud_firestore_platform_interface.dart';
+import 'package:cloud_firestore_web/src/utils/exception.dart';
 import 'package:firebase/firebase.dart' as firebase;
 import 'package:firebase/firestore.dart' as web;
 import 'package:firebase_core/firebase_core.dart';
@@ -59,7 +60,11 @@ class FirebaseFirestoreWeb extends FirebaseFirestorePlatform {
 
   @override
   Future<void> disableNetwork() async {
-    await _webFirestore.disableNetwork();
+    try {
+      await _webFirestore.disableNetwork();
+    } catch (e) {
+      throw throwFirebaseException(e);
+    }
   }
 
   @override
@@ -68,7 +73,11 @@ class FirebaseFirestoreWeb extends FirebaseFirestorePlatform {
 
   @override
   Future<void> enableNetwork() async {
-    await _webFirestore.enableNetwork();
+    try {
+      await _webFirestore.enableNetwork();
+    } catch (e) {
+      throw throwFirebaseException(e);
+    }
   }
 
   // @override
@@ -79,13 +88,17 @@ class FirebaseFirestoreWeb extends FirebaseFirestorePlatform {
   @override
   Future<T> runTransaction<T>(TransactionHandler transactionHandler,
       {Duration timeout = const Duration(seconds: 30)}) async {
-    dynamic result = await _webFirestore.runTransaction((transaction) async {
-      return transactionHandler(
-          TransactionWeb(this, _webFirestore, transaction));
-    }).timeout(timeout);
-    // Workaround for 'Runtime type information not available for type_variable_local'
-    // See: https://github.com/dart-lang/sdk/issues/29722
-    return result as T;
+    try {
+      dynamic result = await _webFirestore.runTransaction((transaction) async {
+        return transactionHandler(
+            TransactionWeb(this, _webFirestore, transaction));
+      }).timeout(timeout);
+      // Workaround for 'Runtime type information not available for type_variable_local'
+      // See: https://github.com/dart-lang/sdk/issues/29722
+      return result as T;
+    } catch (e) {
+      throw throwFirebaseException(e);
+    }
   }
 
   @override
@@ -114,9 +127,13 @@ class FirebaseFirestoreWeb extends FirebaseFirestorePlatform {
   /// Enable persistence of Firestore data. Web only.
   Future<void> enablePersistence() async {
     // TODO(salakar): this should accept a [PersistenceSettings] argument
-    // but it is currently unsupported on the 'firebase' dart package.
+    // but it is currently unsupported on the 'firebase-dart' package.
     // See https://firebase.google.com/docs/reference/js/firebase.firestore.PersistenceSettings
-    await _webFirestore.enablePersistence();
+    try {
+      await _webFirestore.enablePersistence();
+    } catch (e) {
+      throw throwFirebaseException(e);
+    }
   }
 
   // @override

--- a/packages/cloud_firestore/cloud_firestore_web/lib/cloud_firestore_web.dart
+++ b/packages/cloud_firestore/cloud_firestore_web/lib/cloud_firestore_web.dart
@@ -63,7 +63,7 @@ class FirebaseFirestoreWeb extends FirebaseFirestorePlatform {
     try {
       await _webFirestore.disableNetwork();
     } catch (e) {
-      throw throwFirebaseException(e);
+      throw getFirebaseException(e);
     }
   }
 
@@ -76,7 +76,7 @@ class FirebaseFirestoreWeb extends FirebaseFirestorePlatform {
     try {
       await _webFirestore.enableNetwork();
     } catch (e) {
-      throw throwFirebaseException(e);
+      throw getFirebaseException(e);
     }
   }
 
@@ -97,7 +97,7 @@ class FirebaseFirestoreWeb extends FirebaseFirestorePlatform {
       // See: https://github.com/dart-lang/sdk/issues/29722
       return result as T;
     } catch (e) {
-      throw throwFirebaseException(e);
+      throw getFirebaseException(e);
     }
   }
 
@@ -132,7 +132,7 @@ class FirebaseFirestoreWeb extends FirebaseFirestorePlatform {
     try {
       await _webFirestore.enablePersistence();
     } catch (e) {
-      throw throwFirebaseException(e);
+      throw getFirebaseException(e);
     }
   }
 

--- a/packages/cloud_firestore/cloud_firestore_web/lib/src/document_reference_web.dart
+++ b/packages/cloud_firestore/cloud_firestore_web/lib/src/document_reference_web.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:cloud_firestore_platform_interface/cloud_firestore_platform_interface.dart';
+import 'package:cloud_firestore_web/src/utils/exception.dart';
 import 'package:firebase/firestore.dart' as web;
 
 import 'package:cloud_firestore_web/src/utils/web_utils.dart';
@@ -26,27 +27,46 @@ class DocumentReferenceWeb extends DocumentReferencePlatform {
         super(firestore, path);
 
   @override
-  Future<void> set(Map<String, dynamic> data, [SetOptions options]) {
-    return _delegate.set(
-      CodecUtility.encodeMapData(data),
-      // TODO(ehesp): `mergeFields` missing from web implementation
-      options != null ? web.SetOptions(merge: options.merge) : null,
-    );
+  Future<void> set(Map<String, dynamic> data, [SetOptions options]) async {
+    try {
+      await _delegate.set(
+        CodecUtility.encodeMapData(data),
+        // TODO(ehesp): `mergeFields` missing from web implementation
+        options != null ? web.SetOptions(merge: options.merge) : null,
+      );
+    } catch (e) {
+      throw throwFirebaseException(e);
+    }
   }
 
   @override
-  Future<void> update(Map<String, dynamic> data) =>
-      _delegate.update(data: CodecUtility.encodeMapData(data));
+  Future<void> update(Map<String, dynamic> data) async {
+    try {
+      await _delegate.update(data: CodecUtility.encodeMapData(data));
+    } catch (e) {
+      throw throwFirebaseException(e);
+    }
+  }
 
   @override
   Future<DocumentSnapshotPlatform> get([GetOptions options]) async {
     // TODO(ehesp): web implementation not handling options
-    web.DocumentSnapshot documentSnapshot = await _delegate.get();
-    return convertWebDocumentSnapshot(this.firestore, documentSnapshot);
+    try {
+      web.DocumentSnapshot documentSnapshot = await _delegate.get();
+      return convertWebDocumentSnapshot(this.firestore, documentSnapshot);
+    } catch (e) {
+      throw throwFirebaseException(e);
+    }
   }
 
   @override
-  Future<void> delete() => _delegate.delete();
+  Future<void> delete() async {
+    try {
+      await _delegate.delete();
+    } catch (e) {
+      throw throwFirebaseException(e);
+    }
+  }
 
   @override
   Stream<DocumentSnapshotPlatform> snapshots({
@@ -56,7 +76,11 @@ class DocumentReferenceWeb extends DocumentReferencePlatform {
     if (includeMetadataChanges) {
       querySnapshots = _delegate.onMetadataChangesSnapshot;
     }
-    return querySnapshots.map((webSnapshot) =>
-        convertWebDocumentSnapshot(this.firestore, webSnapshot));
+    return querySnapshots
+        .map((webSnapshot) =>
+            convertWebDocumentSnapshot(this.firestore, webSnapshot))
+        .handleError((e) {
+      throw throwFirebaseException(e);
+    });
   }
 }

--- a/packages/cloud_firestore/cloud_firestore_web/lib/src/document_reference_web.dart
+++ b/packages/cloud_firestore/cloud_firestore_web/lib/src/document_reference_web.dart
@@ -35,7 +35,7 @@ class DocumentReferenceWeb extends DocumentReferencePlatform {
         options != null ? web.SetOptions(merge: options.merge) : null,
       );
     } catch (e) {
-      throw throwFirebaseException(e);
+      throw getFirebaseException(e);
     }
   }
 
@@ -44,7 +44,7 @@ class DocumentReferenceWeb extends DocumentReferencePlatform {
     try {
       await _delegate.update(data: CodecUtility.encodeMapData(data));
     } catch (e) {
-      throw throwFirebaseException(e);
+      throw getFirebaseException(e);
     }
   }
 
@@ -55,7 +55,7 @@ class DocumentReferenceWeb extends DocumentReferencePlatform {
       web.DocumentSnapshot documentSnapshot = await _delegate.get();
       return convertWebDocumentSnapshot(this.firestore, documentSnapshot);
     } catch (e) {
-      throw throwFirebaseException(e);
+      throw getFirebaseException(e);
     }
   }
 
@@ -64,7 +64,7 @@ class DocumentReferenceWeb extends DocumentReferencePlatform {
     try {
       await _delegate.delete();
     } catch (e) {
-      throw throwFirebaseException(e);
+      throw getFirebaseException(e);
     }
   }
 
@@ -80,7 +80,7 @@ class DocumentReferenceWeb extends DocumentReferencePlatform {
         .map((webSnapshot) =>
             convertWebDocumentSnapshot(this.firestore, webSnapshot))
         .handleError((e) {
-      throw throwFirebaseException(e);
+      throw getFirebaseException(e);
     });
   }
 }

--- a/packages/cloud_firestore/cloud_firestore_web/lib/src/query_web.dart
+++ b/packages/cloud_firestore/cloud_firestore_web/lib/src/query_web.dart
@@ -4,6 +4,7 @@
 
 import 'package:cloud_firestore_platform_interface/cloud_firestore_platform_interface.dart';
 import 'package:cloud_firestore_web/src/utils/codec_utility.dart';
+import 'package:cloud_firestore_web/src/utils/exception.dart';
 import 'package:firebase/firestore.dart' as web;
 
 import 'package:cloud_firestore_web/src/utils/web_utils.dart';
@@ -121,8 +122,12 @@ class QueryWeb extends QueryPlatform {
   @override
   Future<QuerySnapshotPlatform> get([GetOptions options]) async {
     // TODO(ehesp): web implementation not handling options
-    return convertWebQuerySnapshot(
-        firestore, await _buildWebQueryWithParameters().get());
+    try {
+      return convertWebQuerySnapshot(
+          firestore, await _buildWebQueryWithParameters().get());
+    } catch (e) {
+      throw throwFirebaseException(e);
+    }
   }
 
   @override
@@ -152,8 +157,12 @@ class QueryWeb extends QueryPlatform {
     } else {
       querySnapshots = _buildWebQueryWithParameters().onSnapshot;
     }
-    return querySnapshots.map((webQuerySnapshot) =>
-        convertWebQuerySnapshot(firestore, webQuerySnapshot));
+    return querySnapshots
+        .map((webQuerySnapshot) =>
+            convertWebQuerySnapshot(firestore, webQuerySnapshot))
+        .handleError((e) {
+      throw throwFirebaseException(e);
+    });
   }
 
   @override

--- a/packages/cloud_firestore/cloud_firestore_web/lib/src/query_web.dart
+++ b/packages/cloud_firestore/cloud_firestore_web/lib/src/query_web.dart
@@ -126,7 +126,7 @@ class QueryWeb extends QueryPlatform {
       return convertWebQuerySnapshot(
           firestore, await _buildWebQueryWithParameters().get());
     } catch (e) {
-      throw throwFirebaseException(e);
+      throw getFirebaseException(e);
     }
   }
 
@@ -161,7 +161,7 @@ class QueryWeb extends QueryPlatform {
         .map((webQuerySnapshot) =>
             convertWebQuerySnapshot(firestore, webQuerySnapshot))
         .handleError((e) {
-      throw throwFirebaseException(e);
+      throw getFirebaseException(e);
     });
   }
 

--- a/packages/cloud_firestore/cloud_firestore_web/lib/src/transaction_web.dart
+++ b/packages/cloud_firestore/cloud_firestore_web/lib/src/transaction_web.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:cloud_firestore_platform_interface/cloud_firestore_platform_interface.dart';
+import 'package:cloud_firestore_web/src/utils/exception.dart';
 import 'package:firebase/firestore.dart' as web;
 
 import 'package:cloud_firestore_web/src/utils/codec_utility.dart';
@@ -28,10 +29,14 @@ class TransactionWeb extends TransactionPlatform {
 
   @override
   Future<DocumentSnapshotPlatform> get(String documentPath) async {
-    final webDocumentSnapshot = await _webTransactionDelegate
-        .get(_webFirestoreDelegate.doc(documentPath));
+    try {
+      final webDocumentSnapshot = await _webTransactionDelegate
+          .get(_webFirestoreDelegate.doc(documentPath));
 
-    return convertWebDocumentSnapshot(this._firestore, webDocumentSnapshot);
+      return convertWebDocumentSnapshot(this._firestore, webDocumentSnapshot);
+    } catch (e) {
+      throw throwFirebaseException(e);
+    }
   }
 
   @override

--- a/packages/cloud_firestore/cloud_firestore_web/lib/src/transaction_web.dart
+++ b/packages/cloud_firestore/cloud_firestore_web/lib/src/transaction_web.dart
@@ -35,7 +35,7 @@ class TransactionWeb extends TransactionPlatform {
 
       return convertWebDocumentSnapshot(this._firestore, webDocumentSnapshot);
     } catch (e) {
-      throw throwFirebaseException(e);
+      throw getFirebaseException(e);
     }
   }
 

--- a/packages/cloud_firestore/cloud_firestore_web/lib/src/utils/exception.dart
+++ b/packages/cloud_firestore/cloud_firestore_web/lib/src/utils/exception.dart
@@ -17,7 +17,7 @@ FirebaseException getFirebaseException(Object object) {
 
   if (object is! firebase.FirebaseError) {
     return FirebaseException(
-        plugin: "cloud_firestore",
+        plugin: 'cloud_firestore',
         code: 'unknown',
         message: (object as Exception).toString());
   }

--- a/packages/cloud_firestore/cloud_firestore_web/lib/src/utils/exception.dart
+++ b/packages/cloud_firestore/cloud_firestore_web/lib/src/utils/exception.dart
@@ -1,0 +1,25 @@
+// Copyright 2020, the Chromium project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'package:firebase_core/firebase_core.dart';
+
+import 'package:firebase/firebase.dart' as firebase;
+
+/// Returns a [FirebaseException] from a thrown web error.
+FirebaseException throwFirebaseException(Object exception) {
+  if (exception is! firebase.FirebaseError) {
+    return FirebaseException(
+        plugin: "cloud_firestore",
+        code: 'unknown',
+        message: 'An unknown error occurred.');
+  }
+
+  firebase.FirebaseError firebaseError = exception as firebase.FirebaseError;
+
+  String code = firebaseError.code.replaceFirst('firestore/', '');
+  String message =
+      firebaseError.message.replaceFirst('(${firebaseError.code})', '');
+  return FirebaseException(
+      plugin: "cloud_firestore", code: code, message: message);
+}

--- a/packages/cloud_firestore/cloud_firestore_web/lib/src/utils/exception.dart
+++ b/packages/cloud_firestore/cloud_firestore_web/lib/src/utils/exception.dart
@@ -7,19 +7,26 @@ import 'package:firebase_core/firebase_core.dart';
 import 'package:firebase/firebase.dart' as firebase;
 
 /// Returns a [FirebaseException] from a thrown web error.
-FirebaseException throwFirebaseException(Object exception) {
-  if (exception is! firebase.FirebaseError) {
+FirebaseException getFirebaseException(Object object) {
+  if (object is! Exception) {
     return FirebaseException(
-        plugin: "cloud_firestore",
+        plugin: 'cloud_firestore',
         code: 'unknown',
         message: 'An unknown error occurred.');
   }
 
-  firebase.FirebaseError firebaseError = exception as firebase.FirebaseError;
+  if (object is! firebase.FirebaseError) {
+    return FirebaseException(
+        plugin: "cloud_firestore",
+        code: 'unknown',
+        message: (object as Exception).toString());
+  }
+
+  firebase.FirebaseError firebaseError = object as firebase.FirebaseError;
 
   String code = firebaseError.code.replaceFirst('firestore/', '');
   String message =
       firebaseError.message.replaceFirst('(${firebaseError.code})', '');
   return FirebaseException(
-      plugin: "cloud_firestore", code: code, message: message);
+      plugin: 'cloud_firestore', code: code, message: message);
 }

--- a/packages/cloud_firestore/cloud_firestore_web/lib/src/utils/exception.dart
+++ b/packages/cloud_firestore/cloud_firestore_web/lib/src/utils/exception.dart
@@ -8,18 +8,11 @@ import 'package:firebase/firebase.dart' as firebase;
 
 /// Returns a [FirebaseException] from a thrown web error.
 FirebaseException getFirebaseException(Object object) {
-  if (object is! Exception) {
-    return FirebaseException(
-        plugin: 'cloud_firestore',
-        code: 'unknown',
-        message: 'An unknown error occurred.');
-  }
-
   if (object is! firebase.FirebaseError) {
     return FirebaseException(
         plugin: 'cloud_firestore',
         code: 'unknown',
-        message: (object as Exception).toString());
+        message: object.toString());
   }
 
   firebase.FirebaseError firebaseError = object as firebase.FirebaseError;

--- a/packages/cloud_firestore/cloud_firestore_web/lib/src/utils/exception.dart
+++ b/packages/cloud_firestore/cloud_firestore_web/lib/src/utils/exception.dart
@@ -10,9 +10,7 @@ import 'package:firebase/firebase.dart' as firebase;
 FirebaseException getFirebaseException(Object object) {
   if (object is! firebase.FirebaseError) {
     return FirebaseException(
-        plugin: 'cloud_firestore',
-        code: 'unknown',
-        message: object.toString());
+        plugin: 'cloud_firestore', code: 'unknown', message: object.toString());
   }
 
   firebase.FirebaseError firebaseError = object as firebase.FirebaseError;

--- a/packages/cloud_firestore/cloud_firestore_web/lib/src/write_batch_web.dart
+++ b/packages/cloud_firestore/cloud_firestore_web/lib/src/write_batch_web.dart
@@ -23,7 +23,7 @@ class WriteBatchWeb extends WriteBatchPlatform {
     try {
       await _webWriteBatchDelegate.commit();
     } catch (e) {
-      throw throwFirebaseException(e);
+      throw getFirebaseException(e);
     }
   }
 

--- a/packages/cloud_firestore/cloud_firestore_web/lib/src/write_batch_web.dart
+++ b/packages/cloud_firestore/cloud_firestore_web/lib/src/write_batch_web.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:cloud_firestore_platform_interface/cloud_firestore_platform_interface.dart';
+import 'package:cloud_firestore_web/src/utils/exception.dart';
 import 'package:firebase/firestore.dart' as web;
 
 import 'package:cloud_firestore_web/src/utils/codec_utility.dart';
@@ -19,7 +20,11 @@ class WriteBatchWeb extends WriteBatchPlatform {
 
   @override
   Future<void> commit() async {
-    await _webWriteBatchDelegate.commit();
+    try {
+      await _webWriteBatchDelegate.commit();
+    } catch (e) {
+      throw throwFirebaseException(e);
+    }
   }
 
   @override


### PR DESCRIPTION
## Description

Currently, Firestore web errors throw an internal Firebase error. This change wraps all delegate calls and catches errors, ensuring a `FirebaseException` is thrown to mimic native behaviour.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] If the pull request affects only one plugin, the PR title starts with the name of the plugin in brackets (e.g. [cloud_firestore])
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [ ] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [ ] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.
