### PR TITLE
[firebase_dynamic_links]: fix plugin crash when link is null

### DIFF
--- a/packages/firebase_dynamic_links/CHANGELOG.md
+++ b/packages/firebase_dynamic_links/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.5.3
+
+* Fix for passing null/nil link between native libraries and flutter code.
+
 ## 0.5.2
 
 * Fix for race-condition issue on iOS during initialization process

--- a/packages/firebase_dynamic_links/android/src/main/java/io/flutter/plugins/firebasedynamiclinks/FirebaseDynamicLinksPlugin.java
+++ b/packages/firebase_dynamic_links/android/src/main/java/io/flutter/plugins/firebasedynamiclinks/FirebaseDynamicLinksPlugin.java
@@ -170,7 +170,8 @@ public class FirebaseDynamicLinksPlugin
   private Map<String, Object> getMapFromPendingDynamicLinkData(
       PendingDynamicLinkData pendingDynamicLinkData) {
     Map<String, Object> dynamicLink = new HashMap<>();
-    dynamicLink.put("link", pendingDynamicLinkData.getLink().toString());
+    Uri link = pendingDynamicLinkData.getLink();
+    dynamicLink.put("link", link != null ? link.toString() : null);
 
     Map<String, Object> androidData = new HashMap<>();
     androidData.put("clickTimestamp", pendingDynamicLinkData.getClickTimestamp());

--- a/packages/firebase_dynamic_links/lib/src/firebase_dynamic_links.dart
+++ b/packages/firebase_dynamic_links/lib/src/firebase_dynamic_links.dart
@@ -48,6 +48,9 @@ class FirebaseDynamicLinks {
       Map<dynamic, dynamic> linkData) {
     if (linkData == null) return null;
 
+    final link = linkData['link'];
+    if (link == null) return null;
+
     PendingDynamicLinkDataAndroid androidData;
     if (linkData['android'] != null) {
       final Map<dynamic, dynamic> data = linkData['android'];
@@ -64,7 +67,7 @@ class FirebaseDynamicLinks {
     }
 
     return PendingDynamicLinkData._(
-      Uri.parse(linkData['link']),
+      Uri.parse(link),
       androidData,
       iosData,
     );
@@ -83,10 +86,12 @@ class FirebaseDynamicLinks {
   Future<dynamic> _handleMethod(MethodCall call) async {
     switch (call.method) {
       case "onLinkSuccess":
-        final Map<dynamic, dynamic> data =
-            call.arguments.cast<dynamic, dynamic>();
-        final PendingDynamicLinkData linkData =
-            getPendingDynamicLinkDataFromMap(data);
+        PendingDynamicLinkData linkData;
+        if (call.arguments != null) {
+          final Map<dynamic, dynamic> data =
+              call.arguments.cast<dynamic, dynamic>();
+          linkData = getPendingDynamicLinkDataFromMap(data);
+        }
         return _onLinkSuccess(linkData);
       case "onLinkError":
         final Map<dynamic, dynamic> data =

--- a/packages/firebase_dynamic_links/pubspec.yaml
+++ b/packages/firebase_dynamic_links/pubspec.yaml
@@ -1,7 +1,7 @@
 name: firebase_dynamic_links
 description: Flutter plugin for Google Dynamic Links for Firebase, an app solution for creating
   and handling links across multiple platforms.
-version: 0.5.2
+version: 0.5.3
 homepage: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/firebase_dynamic_links
 
 dependencies:

--- a/packages/firebase_dynamic_links/test/firebase_dynamic_links_test.dart
+++ b/packages/firebase_dynamic_links/test/firebase_dynamic_links_test.dart
@@ -1,10 +1,10 @@
 // Copyright 2018 The Chromium Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
-
-import 'package:flutter/services.dart';
+import 'dart:async';
 
 import 'package:firebase_dynamic_links/firebase_dynamic_links.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {
@@ -50,23 +50,86 @@ void main() {
       log.clear();
     });
 
-    test('getInitialLink', () async {
-      final PendingDynamicLinkData data =
-          await FirebaseDynamicLinks.instance.getInitialLink();
+    group('getInitialLink', () {
+      test('link can be parsed', () async {
+        final PendingDynamicLinkData data =
+            await FirebaseDynamicLinks.instance.getInitialLink();
 
-      expect(data.link, Uri.parse('https://google.com'));
+        expect(data.link, Uri.parse('https://google.com'));
 
-      expect(data.android.clickTimestamp, 1234567);
-      expect(data.android.minimumVersion, 12);
+        expect(data.android.clickTimestamp, 1234567);
+        expect(data.android.minimumVersion, 12);
 
-      expect(data.ios.minimumVersion, 'Version 12');
+        expect(data.ios.minimumVersion, 'Version 12');
 
-      expect(log, <Matcher>[
-        isMethodCall(
-          'FirebaseDynamicLinks#getInitialLink',
-          arguments: null,
-        )
-      ]);
+        expect(log, <Matcher>[
+          isMethodCall(
+            'FirebaseDynamicLinks#getInitialLink',
+            arguments: null,
+          )
+        ]);
+      });
+
+      // Both iOS FIRDynamicLink.url and android PendingDynamicLinkData.getUrl()
+      // might return null link. In such a case we want to ignore the deep-link.
+      test('for null link, returns null', () async {
+        FirebaseDynamicLinks.channel
+            .setMockMethodCallHandler((MethodCall methodCall) async {
+          log.add(methodCall);
+          switch (methodCall.method) {
+            case 'FirebaseDynamicLinks#getInitialLink':
+              return <dynamic, dynamic>{
+                'link': null,
+                'android': <dynamic, dynamic>{
+                  'clickTimestamp': 1234567,
+                  'minimumVersion': 12,
+                },
+                'ios': <dynamic, dynamic>{
+                  'minimumVersion': 'Version 12',
+                },
+              };
+            default:
+              return null;
+          }
+        });
+
+        final PendingDynamicLinkData data =
+            await FirebaseDynamicLinks.instance.getInitialLink();
+
+        expect(data, isNull);
+
+        expect(log, <Matcher>[
+          isMethodCall(
+            'FirebaseDynamicLinks#getInitialLink',
+            arguments: null,
+          )
+        ]);
+      });
+
+      test('for null result, returns null', () async {
+        FirebaseDynamicLinks.channel
+            .setMockMethodCallHandler((MethodCall methodCall) async {
+          log.add(methodCall);
+          switch (methodCall.method) {
+            case 'FirebaseDynamicLinks#getInitialLink':
+              return null;
+            default:
+              return null;
+          }
+        });
+
+        final PendingDynamicLinkData data =
+            await FirebaseDynamicLinks.instance.getInitialLink();
+
+        expect(data, isNull);
+
+        expect(log, <Matcher>[
+          isMethodCall(
+            'FirebaseDynamicLinks#getInitialLink',
+            arguments: null,
+          )
+        ]);
+      });
     });
 
     test('getDynamicLink', () async {
@@ -495,6 +558,115 @@ void main() {
             },
           ),
         ]);
+      });
+    });
+
+    group('onLink', () {
+      OnLinkSuccessCallback onSuccess;
+      OnLinkErrorCallback onError;
+      final List<PendingDynamicLinkData> successLog =
+          <PendingDynamicLinkData>[];
+      final List<OnLinkErrorException> errorLog = <OnLinkErrorException>[];
+      setUp(() {
+        onSuccess = (linkData) async {
+          successLog.add(linkData);
+        };
+        onError = (error) async {
+          errorLog.add(error);
+        };
+        successLog.clear();
+        errorLog.clear();
+      });
+
+      Future<void> callMethodHandler(String method, dynamic arguments) {
+        final channel = FirebaseDynamicLinks.channel;
+        final methodCall = MethodCall(method, arguments);
+        final data = channel.codec.encodeMethodCall(methodCall);
+        final Completer<void> completer = Completer<void>();
+        channel.binaryMessenger.handlePlatformMessage(
+          channel.name,
+          data,
+          (data) {
+            completer.complete(null);
+          },
+        );
+        return completer.future;
+      }
+
+      test('onSuccess', () async {
+        FirebaseDynamicLinks.instance
+            .onLink(onSuccess: onSuccess, onError: onError);
+        await callMethodHandler('onLinkSuccess', <dynamic, dynamic>{
+          'link': 'https://google.com',
+          'android': <dynamic, dynamic>{
+            'clickTimestamp': 1234567,
+            'minimumVersion': 12,
+          },
+          'ios': <dynamic, dynamic>{
+            'minimumVersion': 'Version 12',
+          },
+        });
+
+        expect(successLog, hasLength(1));
+        expect(errorLog, hasLength(0));
+        final success = successLog[0];
+
+        expect(success.link, Uri.parse('https://google.com'));
+
+        expect(success.android.clickTimestamp, 1234567);
+        expect(success.android.minimumVersion, 12);
+
+        expect(success.ios.minimumVersion, 'Version 12');
+      });
+
+      test('onSuccess with null link', () async {
+        FirebaseDynamicLinks.instance
+            .onLink(onSuccess: onSuccess, onError: onError);
+        await callMethodHandler('onLinkSuccess', <dynamic, dynamic>{
+          'link': null,
+          'android': <dynamic, dynamic>{
+            'clickTimestamp': 1234567,
+            'minimumVersion': 12,
+          },
+          'ios': <dynamic, dynamic>{
+            'minimumVersion': 'Version 12',
+          },
+        });
+
+        expect(successLog, hasLength(1));
+        expect(errorLog, hasLength(0));
+        final success = successLog[0];
+
+        expect(success, isNull);
+      });
+
+      test('onSuccess with null', () async {
+        FirebaseDynamicLinks.instance
+            .onLink(onSuccess: onSuccess, onError: onError);
+        await callMethodHandler('onLinkSuccess', null);
+
+        expect(successLog, hasLength(1));
+        expect(errorLog, hasLength(0));
+        final success = successLog[0];
+
+        expect(success, isNull);
+      });
+
+      test('onError', () async {
+        FirebaseDynamicLinks.instance
+            .onLink(onSuccess: onSuccess, onError: onError);
+        await callMethodHandler('onLinkError', <dynamic, dynamic>{
+          'code': 'code',
+          'message': 'message',
+          'details': 'details',
+        });
+
+        expect(successLog, hasLength(0));
+        expect(errorLog, hasLength(1));
+        final failure = errorLog[0];
+        expect(failure.code, 'code');
+        expect(failure.message, 'message');
+        expect(failure.details, 'details');
       });
     });
   });


### PR DESCRIPTION
## Description

[iOS FIRDynamicLink#url](https://firebase.google.com/docs/reference/ios/firebasedynamiclinks/api/reference/Classes/FIRDynamicLink#url) and [Android PendingDynamicLinkData#getLink()](https://firebase.google.com/docs/reference/android/com/google/firebase/dynamiclinks/PendingDynamicLinkData#public-uri-getlink) may return nil/null. In sucha a case we get to the following stack trace:

```
flutter: Stack Trace:
flutter: #0      Object.noSuchMethod  (dart:core-patch/object_patch.dart:53:5)
flutter: #1      Uri.parse  (dart:core/uri.dart:794:17)
flutter: #2      FirebaseDynamicLinks.getPendingDynamicLinkDataFromMap 
package:firebase_dynamic_links/src/firebase_dynamic_links.dart:67
flutter: #3      FirebaseDynamicLinks.getInitialLink 
package:firebase_dynamic_links/src/firebase_dynamic_links.dart:37
flutter: <asynchronous suspension>
```

because 'link' in the dictionary is null.

This PR handles such a situation and return null link instead of throwing the error.

## Related Issues

No issues related

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] If the pull request affects only one plugin, the PR title starts with the name of the plugin in brackets (e.g. [cloud_firestore])
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`) - Documentation doesn't need to be changed.
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.
ls
