### PR TITLE
[cloud_firestore] Allow iOS and macOS to be imported as a module

### DIFF
--- a/packages/cloud_firestore/cloud_firestore/CHANGELOG.md
+++ b/packages/cloud_firestore/cloud_firestore/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## [UNPUBLISHED]
 
 - **FIX**: Added `==` operator override to `CollectionReferencePlatform`.
+- **FIX**: Allow iOS and macOS to be imported as a module.
 
 ## 0.14.0-dev.1
 

--- a/packages/cloud_firestore/cloud_firestore/ios/cloud_firestore.podspec
+++ b/packages/cloud_firestore/cloud_firestore/ios/cloud_firestore.podspec
@@ -38,5 +38,8 @@ Pod::Spec.new do |s|
   s.dependency 'Firebase/Firestore', "~> #{firebase_sdk_version}"
   
   s.static_framework = true
-  s.pod_target_xcconfig = { 'GCC_PREPROCESSOR_DEFINITIONS' => "LIBRARY_VERSION=\\@\\\"#{library_version}\\\" LIBRARY_NAME=\\@\\\"flutter-fire-fst\\\"" }
+  s.pod_target_xcconfig = {
+    'GCC_PREPROCESSOR_DEFINITIONS' => "LIBRARY_VERSION=\\@\\\"#{library_version}\\\" LIBRARY_NAME=\\@\\\"flutter-fire-fst\\\"",
+    'DEFINES_MODULE' => 'YES'
+  }
 end

--- a/packages/cloud_firestore/cloud_firestore/macos/cloud_firestore.podspec
+++ b/packages/cloud_firestore/cloud_firestore/macos/cloud_firestore.podspec
@@ -41,7 +41,8 @@ Pod::Spec.new do |s|
   s.dependency 'Firebase/Firestore', "~> #{firebase_sdk_version}"
 
   s.static_framework = true
-  s.pod_target_xcconfig = { 
-    'GCC_PREPROCESSOR_DEFINITIONS' => "LIBRARY_VERSION=\\@\\\"#{library_version}\\\" LIBRARY_NAME=\\@\\\"flutter-fire-fst\\\""
+  s.pod_target_xcconfig = {
+    'GCC_PREPROCESSOR_DEFINITIONS' => "LIBRARY_VERSION=\\@\\\"#{library_version}\\\" LIBRARY_NAME=\\@\\\"flutter-fire-fst\\\"",
+    'DEFINES_MODULE' => 'YES'
   }
 end


### PR DESCRIPTION
## Description

Define the module by setting `DEFINES_MODULE` in the podspec.  

> If enabled, the product will be treated as defining its own module. This enables automatic production of LLVM module map files when appropriate, and allows the product to be imported as a module.

See also [CocoaPod modular headers docs](http://blog.cocoapods.org/CocoaPods-1.5.0/).

## Related Issues

https://github.com/FirebaseExtended/flutterfire/issues/1258

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] If the pull request affects only one plugin, the PR title starts with the name of the plugin in brackets (e.g. [cloud_firestore])
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [ ] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.