### PR TITLE
[cloud_functions] Fix callable parameter type support on Android

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -47,3 +47,4 @@ Tobias Löfstrand <tobias@leafnode.se>
 Stephen Beitzel <sbeitzel@pobox.com>
 Mark Veenstra <markdark81@gmail.com>
 Ben Hagen <ben@ottomatic.io>
+Yongliang Zhan <yzhan94@gmail.com>

--- a/packages/cloud_functions/cloud_functions/CHANGELOG.md
+++ b/packages/cloud_functions/cloud_functions/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.6.0-dev.3
+
+* Fix HttpsCallable#call not working with parameters of non-Map type.
+
 ## 0.6.0-dev.2
 
 * Firebase iOS SDK versions are now locked to use the same version defined in

--- a/packages/cloud_functions/cloud_functions/android/src/main/java/io/flutter/plugins/firebase/cloudfunctions/CloudFunctionsPlugin.java
+++ b/packages/cloud_functions/cloud_functions/android/src/main/java/io/flutter/plugins/firebase/cloudfunctions/CloudFunctionsPlugin.java
@@ -35,7 +35,7 @@ public class CloudFunctionsPlugin implements MethodCallHandler {
     switch (call.method) {
       case "CloudFunctions#call":
         String functionName = call.argument("functionName");
-        Map<String, Object> parameters = call.argument("parameters");
+        Object parameters = call.argument("parameters");
         String appName = call.argument("app");
         FirebaseApp app = FirebaseApp.getInstance(appName);
         String region = call.argument("region");


### PR DESCRIPTION
## Description

Fixes HttpsCallable#call not working with a String (or any other type which is not a Map) parameter on Android

## Related Issues

#2492

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] If the pull request affects only one plugin, the PR title starts with the name of the plugin in brackets (e.g. [cloud_firestore])
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [ ] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [ ] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
