### PR TITLE
[firebase_ml_vision] Bug fix: if confidence is 1 or 0 it is decoded as int

### DIFF
--- a/packages/firebase_ml_vision/CHANGELOG.md
+++ b/packages/firebase_ml_vision/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.9.4
+## 0.9.5
 
 * Fix for error if confidence is 1 or 0.
 

--- a/packages/firebase_ml_vision/CHANGELOG.md
+++ b/packages/firebase_ml_vision/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 0.9.4
 
+* Fix for error if confidence is 1 or 0.
+
+## 0.9.4
+
 * Update lower bound of dart dependency to 2.0.0.
 
 ## 0.9.3+9

--- a/packages/firebase_ml_vision/lib/src/image_labeler.dart
+++ b/packages/firebase_ml_vision/lib/src/image_labeler.dart
@@ -127,7 +127,8 @@ class CloudImageLabelerOptions {
 /// Represents an entity label detected by [ImageLabeler] and [CloudImageLabeler].
 class ImageLabel {
   ImageLabel._(dynamic data)
-      : confidence = data['confidence'],
+      : confidence =
+            data['confidence'] == null ? null : data['confidence'].toDouble(),
         entityId = data['entityId'],
         text = data['text'];
 

--- a/packages/firebase_ml_vision/lib/src/text_recognizer.dart
+++ b/packages/firebase_ml_vision/lib/src/text_recognizer.dart
@@ -97,7 +97,8 @@ abstract class TextContainer {
                 data['height'],
               )
             : null,
-        confidence = data['confidence'],
+        confidence =
+            data['confidence'] == null ? null : data['confidence'].toDouble(),
         cornerPoints = List<Offset>.unmodifiable(
             data['points'].map<Offset>((dynamic point) => Offset(
                   point[0],

--- a/packages/firebase_ml_vision/pubspec.yaml
+++ b/packages/firebase_ml_vision/pubspec.yaml
@@ -1,7 +1,7 @@
 name: firebase_ml_vision
 description: Flutter plugin for Firebase machine learning vision services.
 homepage: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/firebase_ml_vision
-version: 0.9.4
+version: 0.9.5
 
 dependencies:
   flutter:

--- a/packages/firebase_ml_vision/test/firebase_ml_vision_test.dart
+++ b/packages/firebase_ml_vision/test/firebase_ml_vision_test.dart
@@ -795,7 +795,7 @@ void main() {
                 'languageCode': 'cd',
               }
             ],
-            'confidence': 0,
+            'confidence': 0.1,
           },
           <dynamic, dynamic>{
             'text': 'my',
@@ -808,7 +808,7 @@ void main() {
               <dynamic>[8.0, 7.0],
             ],
             'recognizedLanguages': <dynamic>[],
-            'confidence': 1,
+            'confidence': 0.2,
           },
         ];
 
@@ -886,6 +886,20 @@ void main() {
             'lines': <dynamic>[],
             'confidence': 0.6,
           },
+          <dynamic, dynamic>{
+            'text': 'hey',
+            'left': 14.0,
+            'top': 13.0,
+            'width': 16.0,
+            'height': 15.0,
+            'points': <dynamic>[
+              <dynamic>[18.0, 17.0],
+              <dynamic>[20.0, 19.0],
+            ],
+            'recognizedLanguages': <dynamic>[],
+            'lines': <dynamic>[],
+            'confidence': 1,
+          },
         ];
 
         final dynamic visionText = <dynamic, dynamic>{
@@ -900,7 +914,7 @@ void main() {
         test('processImage', () async {
           final VisionText text = await recognizer.processImage(image);
 
-          expect(text.blocks, hasLength(2));
+          expect(text.blocks, hasLength(3));
 
           TextBlock block = text.blocks[0];
           // TODO(jackson): Use const Rect when available in minimum Flutter SDK
@@ -926,6 +940,17 @@ void main() {
             Offset(20.0, 19.0),
           ]);
           expect(block.confidence, 0.6);
+
+          block = text.blocks[2];
+          // TODO(jackson): Use const Rect when available in minimum Flutter SDK
+          // ignore: prefer_const_constructors
+          expect(block.boundingBox, Rect.fromLTWH(14.0, 13.0, 16.0, 15.0));
+          expect(block.text, 'hey');
+          expect(block.cornerPoints, const <Offset>[
+            Offset(18.0, 17.0),
+            Offset(20.0, 19.0),
+          ]);
+          expect(block.confidence, 1.0);
         });
       });
 
@@ -975,7 +1000,7 @@ void main() {
           expect(element.recognizedLanguages, hasLength(2));
           expect(element.recognizedLanguages[0].languageCode, 'ab');
           expect(element.recognizedLanguages[1].languageCode, 'cd');
-          expect(element.confidence, 0.0);
+          expect(element.confidence, 0.1);
 
           element = text.blocks[0].lines[0].elements[1];
           // TODO(jackson): Use const Rect when available in minimum Flutter SDK
@@ -986,7 +1011,7 @@ void main() {
             Offset(6.0, 5.0),
             Offset(8.0, 7.0),
           ]);
-          expect(element.confidence, 1.0);
+          expect(element.confidence, 0.2);
         });
       });
 

--- a/packages/firebase_ml_vision/test/firebase_ml_vision_test.dart
+++ b/packages/firebase_ml_vision/test/firebase_ml_vision_test.dart
@@ -795,7 +795,7 @@ void main() {
                 'languageCode': 'cd',
               }
             ],
-            'confidence': 0.1,
+            'confidence': 0,
           },
           <dynamic, dynamic>{
             'text': 'my',
@@ -808,7 +808,7 @@ void main() {
               <dynamic>[8.0, 7.0],
             ],
             'recognizedLanguages': <dynamic>[],
-            'confidence': 0.2,
+            'confidence': 1,
           },
         ];
 
@@ -975,7 +975,7 @@ void main() {
           expect(element.recognizedLanguages, hasLength(2));
           expect(element.recognizedLanguages[0].languageCode, 'ab');
           expect(element.recognizedLanguages[1].languageCode, 'cd');
-          expect(element.confidence, 0.1);
+          expect(element.confidence, 0.0);
 
           element = text.blocks[0].lines[0].elements[1];
           // TODO(jackson): Use const Rect when available in minimum Flutter SDK
@@ -986,7 +986,7 @@ void main() {
             Offset(6.0, 5.0),
             Offset(8.0, 7.0),
           ]);
-          expect(element.confidence, 0.2);
+          expect(element.confidence, 1.0);
         });
       });
 

--- a/packages/firebase_ml_vision/test/image_labeler_test.dart
+++ b/packages/firebase_ml_vision/test/image_labeler_test.dart
@@ -33,7 +33,7 @@ void main() {
       test('processImage', () async {
         final List<dynamic> labelData = <dynamic>[
           <dynamic, dynamic>{
-            'confidence': 1,
+            'confidence': 0.6,
             'entityId': 'hello',
             'text': 'friend',
           },
@@ -41,6 +41,11 @@ void main() {
             'confidence': 0.8,
             'entityId': 'hi',
             'text': 'brother',
+          },
+          <dynamic, dynamic>{
+            'confidence': 1,
+            'entityId': 'hey',
+            'text': 'sister',
           },
         ];
 
@@ -73,13 +78,17 @@ void main() {
           ),
         ]);
 
-        expect(labels[0].confidence, 1.0);
+        expect(labels[0].confidence, 0.6);
         expect(labels[0].entityId, 'hello');
         expect(labels[0].text, 'friend');
 
         expect(labels[1].confidence, 0.8);
         expect(labels[1].entityId, 'hi');
         expect(labels[1].text, 'brother');
+
+        expect(labels[2].confidence, 1.0);
+        expect(labels[2].entityId, 'hey');
+        expect(labels[2].text, 'sister');
       });
 
       test('processImage no blocks', () async {
@@ -127,6 +136,11 @@ void main() {
             'entityId': '/m/1',
             'text': 'apple',
           },
+          <dynamic, dynamic>{
+            'confidence': 1,
+            'entityId': '/m/2',
+            'text': 'orange',
+          },
         ];
 
         returnValue = labelData;
@@ -165,6 +179,10 @@ void main() {
         expect(labels[1].confidence, 0.8);
         expect(labels[1].entityId, '/m/1');
         expect(labels[1].text, 'apple');
+
+        expect(labels[2].confidence, 1.0);
+        expect(labels[2].entityId, '/m/2');
+        expect(labels[2].text, 'orange');
       });
     });
   });

--- a/packages/firebase_ml_vision/test/image_labeler_test.dart
+++ b/packages/firebase_ml_vision/test/image_labeler_test.dart
@@ -33,7 +33,7 @@ void main() {
       test('processImage', () async {
         final List<dynamic> labelData = <dynamic>[
           <dynamic, dynamic>{
-            'confidence': 0.6,
+            'confidence': 1,
             'entityId': 'hello',
             'text': 'friend',
           },
@@ -73,7 +73,7 @@ void main() {
           ),
         ]);
 
-        expect(labels[0].confidence, 0.6);
+        expect(labels[0].confidence, 1.0);
         expect(labels[0].entityId, 'hello');
         expect(labels[0].text, 'friend');
 


### PR DESCRIPTION
## Description

When `confidence` (used by `ImageLabel` and `TextContainer`) is 1 or 0 and the value is passed over the channel, on the Dart side it is decoded as `int`, which leads to the following error:
```
Unhandled Exception: type 'int' is not a subtype of type 'double'
```

This fix forces the value to be interpreted as `double`.

## Related Issues

*Replace this paragraph with a list of issues related to this PR from the [issue database](https://github.com/flutter/flutter/issues). Indicate, which of these issues are resolved or fixed by this PR. Note that you'll have to prefix the issue numbers with flutter/flutter#.*

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] If the pull request affects only one plugin, the PR title starts with the name of the plugin in brackets (e.g. [cloud_firestore])
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
