### PR TITLE
[Firebase_auth] Text says register instead of sign in auth example

### DIFF
--- a/packages/firebase_auth/firebase_auth/example/lib/signin_page.dart
+++ b/packages/firebase_auth/firebase_auth/example/lib/signin_page.dart
@@ -12,7 +12,7 @@ final FirebaseAuth _auth = FirebaseAuth.instance;
 final GoogleSignIn _googleSignIn = GoogleSignIn();
 
 class SignInPage extends StatefulWidget {
-  final String title = 'Registration';
+  final String title = 'Sign In';
   @override
   State<StatefulWidget> createState() => SignInPageState();
 }


### PR DESCRIPTION
Should say sign in here for more clarity
