### PR TITLE
[firebase_auth] Update example in Auth to use new core

### DIFF
--- a/packages/firebase_auth/firebase_auth/CHANGELOG.md
+++ b/packages/firebase_auth/firebase_auth/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.17.0-dev.2
+
+* Update plugin and example to use the same core.
+
 ## 0.17.0-dev.1
 
 * Depend on `firebase_core` pre-release versions.

--- a/packages/firebase_auth/firebase_auth/example/pubspec.yaml
+++ b/packages/firebase_auth/firebase_auth/example/pubspec.yaml
@@ -8,7 +8,7 @@ dependencies:
   firebase_auth:
     path: ../
   google_sign_in: ^4.0.0
-  firebase_core: ^0.4.4
+  firebase_core: ^0.5.0-dev.2
   firebase_dynamic_links: ^0.5.1
   uuid: ^2.0.2
 

--- a/packages/firebase_auth/firebase_auth/pubspec.yaml
+++ b/packages/firebase_auth/firebase_auth/pubspec.yaml
@@ -3,7 +3,7 @@ description: Flutter plugin for Firebase Auth, enabling Android and iOS
   authentication using passwords, phone numbers and identity providers
   like Google, Facebook and Twitter.
 homepage: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/firebase_auth/firebase_auth
-version: 0.17.0-dev.1
+version: 0.17.0-dev.2
 
 flutter:
   plugin:

--- a/packages/firebase_auth/firebase_auth/pubspec.yaml
+++ b/packages/firebase_auth/firebase_auth/pubspec.yaml
@@ -20,7 +20,7 @@ flutter:
 
 dependencies:
   meta: ^1.0.4
-  firebase_core: ^0.5.0-dev.1
+  firebase_core: ^0.5.0-dev.2
   firebase_auth_platform_interface: ^1.1.7
   # The design on https://flutter.dev/go/federated-plugins was to leave
   # this constraint as "any". We cannot do it right now as it fails pub publish


### PR DESCRIPTION
## Description

Use new core (dev version) in Auth example since auth plugin already depends on new core.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] If the pull request affects only one plugin, the PR title starts with the name of the plugin in brackets (e.g. [cloud_firestore])
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.