### PR TITLE
[firebase_ml_vision] Options for Cloud TextRecognizer

### DIFF
--- a/packages/firebase_ml_custom/example/lib/main.dart
+++ b/packages/firebase_ml_custom/example/lib/main.dart
@@ -26,6 +26,7 @@ class MyApp extends StatefulWidget {
 }
 
 class _MyAppState extends State<MyApp> {
+  final ImagePicker _picker = ImagePicker();
   File _image;
   List<Map<dynamic, dynamic>> _labels;
   //When the model is ready, _loaded changes to trigger the screen state change.
@@ -34,8 +35,7 @@ class _MyAppState extends State<MyApp> {
   /// Triggers selection of an image and the consequent inference.
   Future<void> getImageLabels() async {
     try {
-      final pickedFile =
-          await ImagePicker.pickImage(source: ImageSource.gallery);
+      final pickedFile = await _picker.getImage(source: ImageSource.gallery);
       final image = File(pickedFile.path);
       if (image == null) {
         return;

--- a/packages/firebase_ml_custom/example/pubspec.yaml
+++ b/packages/firebase_ml_custom/example/pubspec.yaml
@@ -17,7 +17,7 @@ dependencies:
   firebase_core: ^0.4.0
   cupertino_icons: ^0.1.3
 
-  image_picker: ^0.5.0
+  image_picker: ^0.6.0
   tflite: 1.1.1
 
 dev_dependencies:

--- a/packages/firebase_ml_vision/CHANGELOG.md
+++ b/packages/firebase_ml_vision/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.9.6+1
+
+* Add options for cloud text recognition.
+
 ## 0.9.6
 
 * Add recognition of text in document images through `DocumentTextRecognizer`. See `README.md` for more information.

--- a/packages/firebase_ml_vision/CHANGELOG.md
+++ b/packages/firebase_ml_vision/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 * Add recognition of text in document images through `DocumentTextRecognizer`. See `README.md` for more information.
 
+## 0.9.5+1
+
+* Add options for cloud text recognition.
+
 ## 0.9.5
 
 * Fix for error if confidence is 1 or 0.

--- a/packages/firebase_ml_vision/README.md
+++ b/packages/firebase_ml_vision/README.md
@@ -89,7 +89,7 @@ final TextRecognizer cloudTextRecognizer = FirebaseVision.instance.cloudTextReco
 final DocumentTextRecognizer cloudDocumentTextRecognizer = FirebaseVision.instance.cloudDocumentTextRecognizer();
 ```
 
-You can also configure all detectors, except on-device `TextRecognizer`, with desired options.
+You can also configure all detectors, except on-device `TextRecognizer` and `DocumentTextRecognizer`, with desired options.
 
 ```dart
 final ImageLabeler labeler = FirebaseVision.instance.imageLabler(

--- a/packages/firebase_ml_vision/README.md
+++ b/packages/firebase_ml_vision/README.md
@@ -89,7 +89,7 @@ final TextRecognizer cloudTextRecognizer = FirebaseVision.instance.cloudTextReco
 final DocumentTextRecognizer cloudDocumentTextRecognizer = FirebaseVision.instance.cloudDocumentTextRecognizer();
 ```
 
-You can also configure all detectors, except `TextRecognizer` and `DocumentTextRecognizer`, with desired options.
+You can also configure all detectors, except on-device `TextRecognizer`, with desired options.
 
 ```dart
 final ImageLabeler labeler = FirebaseVision.instance.imageLabler(

--- a/packages/firebase_ml_vision/android/src/main/java/io/flutter/plugins/firebasemlvision/TextRecognizer.java
+++ b/packages/firebase_ml_vision/android/src/main/java/io/flutter/plugins/firebasemlvision/TextRecognizer.java
@@ -11,6 +11,7 @@ import com.google.android.gms.tasks.OnFailureListener;
 import com.google.android.gms.tasks.OnSuccessListener;
 import com.google.firebase.ml.vision.FirebaseVision;
 import com.google.firebase.ml.vision.common.FirebaseVisionImage;
+import com.google.firebase.ml.vision.text.FirebaseVisionCloudTextRecognizerOptions;
 import com.google.firebase.ml.vision.text.FirebaseVisionText;
 import com.google.firebase.ml.vision.text.FirebaseVisionTextRecognizer;
 import com.google.firebase.ml.vision.text.RecognizedLanguage;
@@ -29,7 +30,16 @@ class TextRecognizer implements Detector {
     if (modelType.equals("onDevice")) {
       recognizer = vision.getOnDeviceTextRecognizer();
     } else if (modelType.equals("cloud")) {
-      recognizer = vision.getCloudTextRecognizer();
+      FirebaseVisionCloudTextRecognizerOptions.Builder optionsBuilder =
+          new FirebaseVisionCloudTextRecognizerOptions.Builder();
+      if (options.get("hintedLanguages") != null) {
+        optionsBuilder.setLanguageHints((List<String>) options.get("hintedLanguages"));
+      }
+      if (options.get("textModelType").equals("dense")) {
+        optionsBuilder.setModelType(FirebaseVisionCloudTextRecognizerOptions.DENSE_MODEL);
+      }
+      FirebaseVisionCloudTextRecognizerOptions cloudTextRecognizerOptions = optionsBuilder.build();
+      recognizer = vision.getCloudTextRecognizer(cloudTextRecognizerOptions);
     } else {
       final String message = String.format("No model for type: %s", modelType);
       throw new IllegalArgumentException(message);

--- a/packages/firebase_ml_vision/example/lib/picture_scanner.dart
+++ b/packages/firebase_ml_vision/example/lib/picture_scanner.dart
@@ -33,6 +33,7 @@ class _PictureScannerState extends State<PictureScanner> {
       FirebaseVision.instance.cloudTextRecognizer();
   final DocumentTextRecognizer _cloudDocumentRecognizer =
       FirebaseVision.instance.cloudDocumentTextRecognizer();
+  final ImagePicker _picker = ImagePicker();
 
   Future<void> _getAndScanImage() async {
     setState(() {
@@ -40,8 +41,9 @@ class _PictureScannerState extends State<PictureScanner> {
       _imageSize = null;
     });
 
-    final File imageFile =
-        await ImagePicker.pickImage(source: ImageSource.gallery);
+    final PickedFile pickedImage =
+        await _picker.getImage(source: ImageSource.gallery);
+    final File imageFile = File(pickedImage.path);
 
     if (imageFile != null) {
       _getImageSize(imageFile);

--- a/packages/firebase_ml_vision/example/pubspec.yaml
+++ b/packages/firebase_ml_vision/example/pubspec.yaml
@@ -6,7 +6,7 @@ dependencies:
   flutter:
     sdk: flutter
 
-  image_picker: ^0.5.0
+  image_picker: ^0.6.0
   cupertino_icons: ^0.1.2
   firebase_ml_vision:
     path: ../

--- a/packages/firebase_ml_vision/example/test_driver/text_recognizer.dart
+++ b/packages/firebase_ml_vision/example/test_driver/text_recognizer.dart
@@ -45,7 +45,7 @@ void textRecognizerTests() {
 
       final options = CloudTextRecognizerOptions(
           hintedLanguages: languageHints, textModelType: textModelType);
-      final TextRecognizer recognizerWithOptions =
+      final recognizerWithOptions =
           FirebaseVision.instance.cloudTextRecognizer(options);
 
       final text = await recognizerWithOptions.processImage(visionImage);

--- a/packages/firebase_ml_vision/example/test_driver/text_recognizer.dart
+++ b/packages/firebase_ml_vision/example/test_driver/text_recognizer.dart
@@ -8,15 +8,15 @@ void textRecognizerTests() {
   FirebaseVisionImage visionImage;
 
   setUp(() async {
-    final String tmpFilename = await _loadImage('assets/test_text.png');
+    final tmpFilename = await _loadImage('assets/test_text.png');
     visionImage = FirebaseVisionImage.fromFilePath(tmpFilename);
   });
 
   group('$TextRecognizer', () {
-    final TextRecognizer recognizer = FirebaseVision.instance.textRecognizer();
+    final recognizer = FirebaseVision.instance.textRecognizer();
 
     test('processImage', () async {
-      final VisionText text = await recognizer.processImage(visionImage);
+      final text = await recognizer.processImage(visionImage);
 
       expect(text.text, 'TEXT');
     });
@@ -27,11 +27,10 @@ void textRecognizerTests() {
   });
 
   group('Cloud $TextRecognizer', () {
-    final TextRecognizer recognizer =
-        FirebaseVision.instance.cloudTextRecognizer();
+    final recognizer = FirebaseVision.instance.cloudTextRecognizer();
 
     test('processImage with default options', () async {
-      final VisionText text = await recognizer.processImage(visionImage);
+      final text = await recognizer.processImage(visionImage);
 
       expect(text.text, 'TEXT\n');
     });
@@ -41,16 +40,15 @@ void textRecognizerTests() {
     });
 
     test('processImage with specified options', () async {
-      var languageHints = ['en', 'ru'];
-      var textModelType = CloudTextModelType.dense;
+      final languageHints = ['en', 'ru'];
+      final textModelType = CloudTextModelType.dense;
 
-      var options = CloudTextRecognizerOptions(
+      final options = CloudTextRecognizerOptions(
           hintedLanguages: languageHints, textModelType: textModelType);
       final TextRecognizer recognizerWithOptions =
           FirebaseVision.instance.cloudTextRecognizer(options);
 
-      final VisionText text =
-          await recognizerWithOptions.processImage(visionImage);
+      final text = await recognizerWithOptions.processImage(visionImage);
 
       expect(text.text, 'TEXT\n');
 

--- a/packages/firebase_ml_vision/example/test_driver/text_recognizer.dart
+++ b/packages/firebase_ml_vision/example/test_driver/text_recognizer.dart
@@ -5,14 +5,17 @@
 part of 'firebase_ml_vision.dart';
 
 void textRecognizerTests() {
+  FirebaseVisionImage visionImage;
+
+  setUp(() async {
+    final String tmpFilename = await _loadImage('assets/test_text.png');
+    visionImage = FirebaseVisionImage.fromFilePath(tmpFilename);
+  });
+
   group('$TextRecognizer', () {
     final TextRecognizer recognizer = FirebaseVision.instance.textRecognizer();
 
     test('processImage', () async {
-      final String tmpFilename = await _loadImage('assets/test_text.png');
-      final FirebaseVisionImage visionImage =
-          FirebaseVisionImage.fromFilePath(tmpFilename);
-
       final VisionText text = await recognizer.processImage(visionImage);
 
       expect(text.text, 'TEXT');
@@ -20,6 +23,38 @@ void textRecognizerTests() {
 
     test('close', () {
       expect(recognizer.close(), completes);
+    });
+  });
+
+  group('Cloud $TextRecognizer', () {
+    final TextRecognizer recognizer =
+        FirebaseVision.instance.cloudTextRecognizer();
+
+    test('processImage with default options', () async {
+      final VisionText text = await recognizer.processImage(visionImage);
+
+      expect(text.text, 'TEXT\n');
+    });
+
+    test('close', () {
+      expect(recognizer.close(), completes);
+    });
+
+    test('processImage with specified options', () async {
+      var languageHints = ['en', 'ru'];
+      var textModelType = CloudTextModelType.dense;
+
+      var options = CloudTextRecognizerOptions(
+          hintedLanguages: languageHints, textModelType: textModelType);
+      final TextRecognizer recognizerWithOptions =
+          FirebaseVision.instance.cloudTextRecognizer(options);
+
+      final VisionText text =
+          await recognizerWithOptions.processImage(visionImage);
+
+      expect(text.text, 'TEXT\n');
+
+      recognizer.close();
     });
   });
 }

--- a/packages/firebase_ml_vision/ios/Classes/TextRecognizer.m
+++ b/packages/firebase_ml_vision/ios/Classes/TextRecognizer.m
@@ -15,7 +15,16 @@
     if ([@"onDevice" isEqualToString:options[@"modelType"]]) {
       _recognizer = [vision onDeviceTextRecognizer];
     } else if ([@"cloud" isEqualToString:options[@"modelType"]]) {
-      _recognizer = [vision cloudTextRecognizer];
+      FIRVisionCloudTextRecognizerOptions *cloudTextRecognizerOptions =
+          [[FIRVisionCloudTextRecognizerOptions alloc] init];
+      if (options[@"hintedLanguages"] != [NSNull null]) {
+        NSArray<NSString *> *languageHints = options[@"hintedLanguages"];
+        cloudTextRecognizerOptions.languageHints = languageHints;
+      }
+      if ([@"dense" isEqualToString:options[@"textModelType"]]) {
+        cloudTextRecognizerOptions.modelType = FIRVisionCloudTextModelTypeDense;
+      }
+      _recognizer = [vision cloudTextRecognizerWithOptions:cloudTextRecognizerOptions];
     } else {
       NSString *reason =
           [NSString stringWithFormat:@"Invalid model type: %@", options[@"modelType"]];

--- a/packages/firebase_ml_vision/lib/src/firebase_vision.dart
+++ b/packages/firebase_ml_vision/lib/src/firebase_vision.dart
@@ -93,9 +93,9 @@ class FirebaseVision {
   }
 
   /// Creates a cloud instance of [TextRecognizer].
-  TextRecognizer cloudTextRecognizer([CloudTextRecognizerOptions options]) {
+  TextRecognizer cloudTextRecognizer([CloudTextRecognizerOptions cloudOptions]) {
     return TextRecognizer._(
-      options: options ?? const CloudTextRecognizerOptions(),
+      cloudOptions: cloudOptions ?? const CloudTextRecognizerOptions(),
       modelType: ModelType.cloud,
       handle: nextHandle++,
     );

--- a/packages/firebase_ml_vision/lib/src/firebase_vision.dart
+++ b/packages/firebase_ml_vision/lib/src/firebase_vision.dart
@@ -93,8 +93,9 @@ class FirebaseVision {
   }
 
   /// Creates a cloud instance of [TextRecognizer].
-  TextRecognizer cloudTextRecognizer() {
+  TextRecognizer cloudTextRecognizer([CloudTextRecognizerOptions options]) {
     return TextRecognizer._(
+      options: options ?? const CloudTextRecognizerOptions(),
       modelType: ModelType.cloud,
       handle: nextHandle++,
     );

--- a/packages/firebase_ml_vision/lib/src/firebase_vision.dart
+++ b/packages/firebase_ml_vision/lib/src/firebase_vision.dart
@@ -93,7 +93,8 @@ class FirebaseVision {
   }
 
   /// Creates a cloud instance of [TextRecognizer].
-  TextRecognizer cloudTextRecognizer([CloudTextRecognizerOptions cloudOptions]) {
+  TextRecognizer cloudTextRecognizer(
+      [CloudTextRecognizerOptions cloudOptions]) {
     return TextRecognizer._(
       cloudOptions: cloudOptions ?? const CloudTextRecognizerOptions(),
       modelType: ModelType.cloud,

--- a/packages/firebase_ml_vision/lib/src/text_recognizer.dart
+++ b/packages/firebase_ml_vision/lib/src/text_recognizer.dart
@@ -26,18 +26,18 @@ enum CloudTextModelType { sparse, dense }
 /// ```
 class TextRecognizer {
   TextRecognizer._({
-    CloudTextRecognizerOptions options,
+    CloudTextRecognizerOptions cloudOptions,
     @required this.modelType,
     @required int handle,
-  })  : _options = options,
+  })  : _cloudOptions = cloudOptions,
         _handle = handle,
         assert(modelType != null),
-        assert((modelType == ModelType.cloud && options != null) ||
-            (modelType == ModelType.onDevice && options == null));
+        assert((modelType == ModelType.cloud && cloudOptions != null) ||
+            (modelType == ModelType.onDevice && cloudOptions == null));
 
   final ModelType modelType;
 
-  final CloudTextRecognizerOptions _options;
+  final CloudTextRecognizerOptions _cloudOptions;
   final int _handle;
   bool _hasBeenOpened = false;
   bool _isClosed = false;
@@ -50,10 +50,10 @@ class TextRecognizer {
     _hasBeenOpened = true;
     Map<String, dynamic> options = {'modelType': _enumToString(modelType)};
 
-    if (_options != null) {
+    if (_cloudOptions != null) {
       options.addAll({
-        'hintedLanguages': _options.hintedLanguages,
-        'textModelType': _enumToString(_options.textModelType),
+        'hintedLanguages': _cloudOptions.hintedLanguages,
+        'textModelType': _enumToString(_cloudOptions.textModelType),
       });
     }
 

--- a/packages/firebase_ml_vision/lib/src/text_recognizer.dart
+++ b/packages/firebase_ml_vision/lib/src/text_recognizer.dart
@@ -82,7 +82,10 @@ class TextRecognizer {
   }
 }
 
-/// Options for cloud text recognizer.
+/// Options for a cloud text recognizer.
+///
+/// Hinted languages and text model type may provide better results if text
+/// language and density are known prior to inference.
 class CloudTextRecognizerOptions {
   /// Language hints for text recognition.
   ///

--- a/packages/firebase_ml_vision/lib/src/text_recognizer.dart
+++ b/packages/firebase_ml_vision/lib/src/text_recognizer.dart
@@ -25,6 +25,10 @@ enum CloudTextModelType { sparse, dense }
 ///     await textRecognizer.processImage(image);
 /// ```
 class TextRecognizer {
+  final ModelType modelType;
+  final CloudTextRecognizerOptions _cloudOptions;
+  final int _handle;
+
   TextRecognizer._({
     CloudTextRecognizerOptions cloudOptions,
     @required this.modelType,
@@ -35,10 +39,6 @@ class TextRecognizer {
         assert((modelType == ModelType.cloud && cloudOptions != null) ||
             (modelType == ModelType.onDevice && cloudOptions == null));
 
-  final ModelType modelType;
-
-  final CloudTextRecognizerOptions _cloudOptions;
-  final int _handle;
   bool _hasBeenOpened = false;
   bool _isClosed = false;
 
@@ -84,17 +84,6 @@ class TextRecognizer {
 
 /// Options for cloud text recognizer.
 class CloudTextRecognizerOptions {
-  /// Constructor for [TextRecognizerOptions].
-  ///
-  /// For Latin alphabet based languages, setting language hints is not needed.
-  ///
-  /// In cases, when the language of the text in the image is known, setting
-  /// a hint will help get better results (although it will be a significant
-  /// hindrance if the hint is wrong).
-  const CloudTextRecognizerOptions(
-      {this.hintedLanguages, this.textModelType = CloudTextModelType.sparse})
-      : assert(textModelType != null);
-
   /// Language hints for text recognition.
   ///
   /// In most cases, an empty value yields the best results since it enables
@@ -110,6 +99,17 @@ class CloudTextRecognizerOptions {
   ///
   /// Default setting is 'sparse'.
   final CloudTextModelType textModelType;
+
+  /// Constructor for [CloudTextRecognizerOptions].
+  ///
+  /// For Latin alphabet based languages, setting language hints is not needed.
+  ///
+  /// In cases, when the language of the text in the image is known, setting
+  /// a hint will help get better results (although it will be a significant
+  /// hindrance if the hint is wrong).
+  const CloudTextRecognizerOptions(
+      {this.hintedLanguages, this.textModelType = CloudTextModelType.sparse})
+      : assert(textModelType != null);
 }
 
 /// Recognized text in an image.

--- a/packages/firebase_ml_vision/pubspec.yaml
+++ b/packages/firebase_ml_vision/pubspec.yaml
@@ -1,7 +1,7 @@
 name: firebase_ml_vision
 description: Flutter plugin for Firebase machine learning vision services.
 homepage: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/firebase_ml_vision
-version: 0.9.6
+version: 0.9.6+1
 
 dependencies:
   flutter:
@@ -9,7 +9,6 @@ dependencies:
 
 dev_dependencies:
   pedantic: ^1.8.0
-  image_picker: ^0.5.0
   flutter_test:
     sdk: flutter
   firebase_core: ^0.4.5

--- a/packages/firebase_ml_vision/test/firebase_ml_vision_test.dart
+++ b/packages/firebase_ml_vision/test/firebase_ml_vision_test.dart
@@ -1278,7 +1278,7 @@ void main() {
         });
       });
 
-      test('processImage', () async {
+      test('processImage with default options', () async {
         final VisionText text = await recognizer.processImage(image);
 
         expect(text.text, 'testext');
@@ -1293,6 +1293,36 @@ void main() {
               'metadata': null,
               'options': <String, dynamic>{
                 'modelType': 'cloud',
+                'hintedLanguages': null,
+                'textModelType': 'sparse',
+              },
+            },
+          ),
+        ]);
+      });
+
+      test('processImage with non-default options', () async {
+        final CloudTextRecognizerOptions options = CloudTextRecognizerOptions(
+            hintedLanguages: ['en'], textModelType: CloudTextModelType.dense);
+
+        final TextRecognizer recognizerWithOptions =
+            FirebaseVision.instance.cloudTextRecognizer(options);
+        final VisionText text = await recognizerWithOptions.processImage(image);
+
+        expect(text.text, 'testext');
+        expect(log, <Matcher>[
+          isMethodCall(
+            'TextRecognizer#processImage',
+            arguments: <String, dynamic>{
+              'handle': 1,
+              'type': 'file',
+              'path': 'empty',
+              'bytes': null,
+              'metadata': null,
+              'options': <String, dynamic>{
+                'modelType': 'cloud',
+                'hintedLanguages': ['en'],
+                'textModelType': 'dense',
               },
             },
           ),
@@ -1315,6 +1345,88 @@ void main() {
 
         final TextBlock block = text.blocks[0];
         expect(block.boundingBox, null);
+      });
+
+      test('close', () async {
+        await recognizer.processImage(image);
+        expect(recognizer.close(), completes);
+
+        expect(log, <Matcher>[
+          isMethodCall(
+            'TextRecognizer#processImage',
+            arguments: <String, dynamic>{
+              'handle': 0,
+              'type': 'file',
+              'path': 'empty',
+              'bytes': null,
+              'metadata': null,
+              'options': <String, dynamic>{
+                'modelType': 'cloud',
+                'hintedLanguages': null,
+                'textModelType': 'sparse',
+              },
+            },
+          ),
+          isMethodCall(
+            'TextRecognizer#close',
+            arguments: <String, dynamic>{
+              'handle': 0,
+            },
+          ),
+        ]);
+      });
+
+      test('when called to close without opening returns right away', () async {
+        expect(recognizer.close(), completes);
+
+        expect(log, <Matcher>[]);
+      });
+
+      test('when given wrong input on processing an image fails', () async {
+        expect(
+            () => recognizer.processImage(null),
+            throwsA(isA<AssertionError>().having((e) => e.toString(), 'message',
+                contains("'visionImage != null': is not true"))));
+      });
+
+      test('when given wrong null options', () async {
+        expect(
+            () => recognizer.processImage(null),
+            throwsA(isA<AssertionError>().having((e) => e.toString(), 'message',
+                contains("'visionImage != null': is not true"))));
+      });
+
+      group('throws an exception when native API fails to', () {
+        final ERROR_MESSAGE = "There is some problem with a call";
+
+        test('process an image', () async {
+          FirebaseVision.channel
+              .setMockMethodCallHandler((MethodCall methodCall) async {
+            throw Exception(ERROR_MESSAGE);
+          });
+          expect(
+              recognizer.processImage(image),
+              throwsA(isA<PlatformException>().having(
+                  (e) => e.toString(), 'message', contains(ERROR_MESSAGE))));
+        });
+
+        test('close', () async {
+          FirebaseVision.channel
+              .setMockMethodCallHandler((MethodCall methodCall) async {
+            switch (methodCall.method) {
+              case 'TextRecognizer#processImage':
+                return returnValue;
+              default:
+                throw Exception(ERROR_MESSAGE);
+            }
+          });
+          await recognizer.processImage(image);
+
+          expect(
+              recognizer.close(),
+              throwsA(isA<PlatformException>().having(
+                  (e) => e.toString(), 'message', contains(ERROR_MESSAGE))));
+        });
       });
     });
   });

--- a/packages/firebase_ml_vision/test/firebase_ml_vision_test.dart
+++ b/packages/firebase_ml_vision/test/firebase_ml_vision_test.dart
@@ -1057,7 +1057,7 @@ void main() {
 
     group('Cloud $TextRecognizer', () {
       TextRecognizer recognizer;
-      final FirebaseVisionImage image = FirebaseVisionImage.fromFilePath(
+      final image = FirebaseVisionImage.fromFilePath(
         'empty',
       );
 
@@ -1279,7 +1279,7 @@ void main() {
       });
 
       test('processImage with default options', () async {
-        final VisionText text = await recognizer.processImage(image);
+        final text = await recognizer.processImage(image);
 
         expect(text.text, 'testext');
         expect(log, <Matcher>[
@@ -1302,12 +1302,12 @@ void main() {
       });
 
       test('processImage with non-default options', () async {
-        final CloudTextRecognizerOptions options = CloudTextRecognizerOptions(
+        final options = CloudTextRecognizerOptions(
             hintedLanguages: ['en'], textModelType: CloudTextModelType.dense);
 
-        final TextRecognizer recognizerWithOptions =
+        final recognizerWithOptions =
             FirebaseVision.instance.cloudTextRecognizer(options);
-        final VisionText text = await recognizerWithOptions.processImage(image);
+        final text = await recognizerWithOptions.processImage(image);
 
         expect(text.text, 'testext');
         expect(log, <Matcher>[


### PR DESCRIPTION
## Description

Added CloudTextRecognizerOptions for cloud TextRecognizer.
Options specify hinted languages and type of image text density (sparse or dense).

In most cases, an empty value for hinted languages yields the best results since it enables automatic language detection.
However, there are cases when those hints are helpful to a user, specifically when the language is known.

Choosing 'sparse' or 'dense' option will lead the recognizer to use one of two different models, which differ by handling text densities in an image.

Options EnforceCertFingerprintMatch for Android and APIKeyOverride for IOS are **not added**.

## Related Issues

[Flutterfire issue #2467](https://github.com/FirebaseExtended/flutterfire/issues/2467): Add support for FirebaseVisionCloudTextRecognizerOptions in the Text Recognition API

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] If the pull request affects only one plugin, the PR title starts with the name of the plugin in brackets (e.g. [cloud_firestore])
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
