### PR TITLE
[infra] Add direct trigger for docs workflow

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -7,6 +7,7 @@ on:
     paths:
     - "docs/**"
     - "website/**"
+  workflow_dispatch:
 
 jobs:
   build_docs:


### PR DESCRIPTION
## Description

Add direct trigger to docs workflow so publishing of documentation can be done on doc updates and as needed.
