### PR TITLE
[cloud_functions] Change http urls to https in documentation

### DIFF
--- a/packages/cloud_functions/cloud_functions/README.md
+++ b/packages/cloud_functions/cloud_functions/README.md
@@ -10,12 +10,12 @@ For Flutter plugins for other Firebase products, see [README.md](https://github.
 
 To use this plugin:
 
-1. Using the [Firebase Console](http://console.firebase.google.com/), add an Android app to your project:
+1. Using the [Firebase Console](https://console.firebase.google.com/), add an Android app to your project:
 Follow the assistant, download the generated google-services.json file and place it inside android/app. Next,
 modify the android/build.gradle file and the android/app/build.gradle file to add the Google services plugin
 as described by the Firebase assistant. Ensure that your `android/build.gradle` file contains the
 `maven.google.com` as [described here](https://firebase.google.com/docs/android/setup#add_the_sdk).
-1. Using the [Firebase Console](http://console.firebase.google.com/), add an iOS app to your project:
+1. Using the [Firebase Console](https://console.firebase.google.com/), add an iOS app to your project:
 Follow the assistant, download the generated GoogleService-Info.plist file, open ios/Runner.xcworkspace
 with Xcode, and within Xcode place the file inside ios/Runner. Don't follow the steps named
 "Add Firebase SDK" and "Add initialization code" in the Firebase assistant.


### PR DESCRIPTION
## Description

Cloud firestore in pub.dev loses 5 pub points points by having insecure links in the documentation. This PR changes the http urls to https.

<img width="807" alt="Screen Shot 2020-08-12 at 12 54 13 pm" src="https://user-images.githubusercontent.com/8036973/89969928-f2838000-dc9a-11ea-882a-94f195088e11.png">


## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x ] If the pull request affects only one plugin, the PR title starts with the name of the plugin in brackets (e.g. [cloud_firestore])
- [x ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ x] All existing and new tests are passing.
- [x ] I updated/added relevant documentation (doc comments with `///`).
- [ x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [ x] I read and followed the [Flutter Style Guide].
- [x ] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x ] I updated CHANGELOG.md to add a description of the change.
- [x ] I signed the [CLA].
- [x ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x ] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://www.dartlang.org/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
