### PR TITLE
[firebase_messaging] fix onLaunch being called again when resuming an application from Recents screen

### DIFF
--- a/packages/firebase_messaging/CHANGELOG.md
+++ b/packages/firebase_messaging/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 7.0.0-dev.2
+
+* Fix `onLaunch` being called again when resuming an application on Android from the Recents screen
+
 ## 7.0.0-dev.1
 
 * Depend on `firebase_core` pre-release versions and migrate plugin to use `firebase_core` native SDK versioning features;

--- a/packages/firebase_messaging/android/src/main/java/io/flutter/plugins/firebasemessaging/FirebaseMessagingPlugin.java
+++ b/packages/firebase_messaging/android/src/main/java/io/flutter/plugins/firebasemessaging/FirebaseMessagingPlugin.java
@@ -192,8 +192,9 @@ public class FirebaseMessagingPlugin extends BroadcastReceiver
                   channel.invokeMethod("onToken", task.getResult().getToken());
                 }
               });
-      if (mainActivity != null) {
-        sendMessageFromIntent("onLaunch", mainActivity.getIntent());
+      Intent intent = mainActivity.getIntent();
+      if (mainActivity != null && !launchedActivityFromHistory(intent)) {
+        sendMessageFromIntent("onLaunch", intent);
       }
       result.success(null);
     } else if ("subscribeToTopic".equals(call.method)) {
@@ -286,6 +287,10 @@ public class FirebaseMessagingPlugin extends BroadcastReceiver
     } else {
       result.notImplemented();
     }
+  }
+
+  private static boolean launchedActivityFromHistory(Intent intent) {
+    return intent != null && (intent.getFlags() & Intent.FLAG_ACTIVITY_LAUNCHED_FROM_HISTORY) == Intent.FLAG_ACTIVITY_LAUNCHED_FROM_HISTORY;
   }
 
   @Override

--- a/packages/firebase_messaging/pubspec.yaml
+++ b/packages/firebase_messaging/pubspec.yaml
@@ -2,7 +2,7 @@ name: firebase_messaging
 description: Flutter plugin for Firebase Cloud Messaging, a cross-platform
   messaging solution that lets you reliably deliver messages on Android and iOS.
 homepage: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/firebase_messaging
-version: 7.0.0-dev.1
+version: 7.0.0-dev.2
 
 flutter:
   plugin:


### PR DESCRIPTION

## Description

On Android, there is an issue where it is possible for the `onLaunch` callback to be invoked multiple times. One way to produce this is

- Sent a notification a device when the app is terminated
- Tap on the notification to launch the app -> `onLaunch` should be called
- Tap back until the application is in the background
- Open the Recents screen (aka recent task/app list) and go back to the app
- `onLaunch` is called again

This is happening as when the application starts up again, it will call `configure` method that will in turn process the intent. However, when processing the intent it should check to make sure that the app isn't launched via the Recents screen. This PR as this guard in to prevent the issue from happening.

**Note**: for some reason, pub is failing to resolve the dependencies (didn't happen in the past) so I cannot try to out properly but had to a similar fix for my own plugin for local notifications. This is why I haven't ticked the box that the analyzer doesn't report any problems

## Related Issues

* https://github.com/FirebaseExtended/flutterfire/issues/1887

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] If the pull request affects only one plugin, the PR title starts with the name of the plugin in brackets (e.g. [cloud_firestore])
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [] I updated/added relevant documentation (doc comments with `///`).
- [] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.