### PR TITLE
fix(cloud_firestore): allow FieldPath.documentId as query field

### DIFF
--- a/packages/cloud_firestore/cloud_firestore/lib/src/query.dart
+++ b/packages/cloud_firestore/cloud_firestore/lib/src/query.dart
@@ -216,7 +216,7 @@ class Query {
   ///
   /// After a [FieldPath.documentId] order by call, you cannot add any more [orderBy]
   /// calls.
-  /// 
+  ///
   /// Furthermore, you may not use [orderBy] on the [FieldPath.documentId] [field] when
   /// using [startAfterDocument], [startAtDocument], [endAfterDocument],
   /// or [endAtDocument] because the order by clause on the document id

--- a/packages/cloud_firestore/cloud_firestore/lib/src/query.dart
+++ b/packages/cloud_firestore/cloud_firestore/lib/src/query.dart
@@ -110,7 +110,8 @@ class Query {
 
   /// Asserts that the query [field] is either a String or a [FieldPath].
   void _assertValidFieldType(dynamic field) {
-    assert(field is String || field is FieldPath,
+    assert(
+        field is String || field is FieldPath || field == FieldPath.documentId,
         'Supported [field] types are [String] and [FieldPath].');
   }
 
@@ -215,6 +216,7 @@ class Query {
   ///
   /// After a [FieldPath.documentId] order by call, you cannot add any more [orderBy]
   /// calls.
+  /// 
   /// Furthermore, you may not use [orderBy] on the [FieldPath.documentId] [field] when
   /// using [startAfterDocument], [startAtDocument], [endAfterDocument],
   /// or [endAtDocument] because the order by clause on the document id
@@ -350,9 +352,16 @@ class Query {
 
     // Conditions can be chained from other [Query] instances
     void addCondition(dynamic field, String operator, dynamic value) {
-      FieldPath fieldPath =
-          field is String ? FieldPath.fromString(field) : field as FieldPath;
-      final List<dynamic> condition = <dynamic>[fieldPath, operator, value];
+      List<dynamic> condition;
+
+      if (field == FieldPath.documentId) {
+        condition = <dynamic>[field, operator, value];
+      } else {
+        FieldPath fieldPath =
+            field is String ? FieldPath.fromString(field) : field as FieldPath;
+        condition = <dynamic>[fieldPath, operator, value];
+      }
+
       assert(
           conditions
               .where((List<dynamic> item) => equality.equals(condition, item))
@@ -393,7 +402,7 @@ class Query {
     // Once all conditions have been set, we must now check them to ensure the
     // query is valid.
     for (dynamic condition in conditions) {
-      FieldPath field = condition[0];
+      dynamic field = condition[0]; // FieldPath or FieldPathType
       String operator = condition[1];
       dynamic value = condition[2];
 


### PR DESCRIPTION
## Description

Calling `FieldPath.documentId` returns an internal `FieldPathType`. This allows users to use this sentinel value as a query field.

## Related Issues

Fixes #3171

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] If the pull request affects only one plugin, the PR title starts with the name of the plugin in brackets (e.g. [cloud_firestore])
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
