### PR TITLE
fix(cloud_firestore): add FieldPathType check & tests

### DIFF
--- a/packages/cloud_firestore/cloud_firestore/example/test_driver/query_e2e.dart
+++ b/packages/cloud_firestore/cloud_firestore/example/test_driver/query_e2e.dart
@@ -691,9 +691,9 @@ void runQueryTests() {
       });
     });
 
-    // /**
-    //  * Limit
-    //  */
+    /**
+     * Limit
+     */
 
     group('Query.limit{toLast}()', () {
       test('limits documents', () async {
@@ -760,8 +760,37 @@ void runQueryTests() {
      * Order
      */
     group('Query.orderBy()', () {
+      test('allows ordering by documentId', () async {
+        CollectionReference collection =
+            await initializeTest('order-document-id');
+
+        await Future.wait([
+          collection.doc('doc1').set({
+            'foo': 1,
+          }),
+          collection.doc('doc2').set({
+            'foo': 1,
+          }),
+          collection.doc('doc3').set({
+            'foo': 1,
+          }),
+          collection.doc('doc4').set({
+            'bar': 1,
+          }),
+        ]);
+
+        QuerySnapshot snapshot =
+            await collection.orderBy('foo').orderBy(FieldPath.documentId).get();
+
+        expect(snapshot.docs.length, equals(3));
+        expect(snapshot.docs[0].id, equals('doc1'));
+        expect(snapshot.docs[1].id, equals('doc2'));
+        expect(snapshot.docs[2].id, equals('doc3'));
+      });
+
       test('orders async by default', () async {
         CollectionReference collection = await initializeTest('order-asc');
+
         await Future.wait([
           collection.doc('doc1').set({
             'foo': 3,
@@ -1063,6 +1092,27 @@ void runQueryTests() {
         expect(snapshot.docs[0].get(fieldPath), isTrue);
         expect(snapshot.docs[1].get(fieldPath), isTrue);
         expect(snapshot.docs[1].get('foo'), equals('bar'));
+      });
+
+      test('returns results using FieldPath.documentId', () async {
+        CollectionReference collection =
+            await initializeTest('where-field-path-document-id');
+
+        DocumentReference docRef = await collection.add({
+          'foo': 'bar',
+        });
+
+        // Add secondary document for sanity check
+        await collection.add({
+          'bar': 'baz',
+        });
+
+        QuerySnapshot snapshot = await collection
+            .where(FieldPath.documentId, isEqualTo: docRef.id)
+            .get();
+
+        expect(snapshot.docs.length, equals(1));
+        expect(snapshot.docs[0].get('foo'), equals('bar'));
       });
     });
   });

--- a/packages/cloud_firestore/cloud_firestore/lib/src/query.dart
+++ b/packages/cloud_firestore/cloud_firestore/lib/src/query.dart
@@ -235,9 +235,13 @@ class Query {
     assert(orders.where((List<dynamic> item) => field == item[0]).isEmpty,
         "OrderBy field '$field' already exists in this query");
 
-    FieldPath fieldPath = field is String ? FieldPath.fromString(field) : field;
-
-    orders.add([fieldPath, descending]);
+    if (field == FieldPath.documentId) {
+      orders.add([field, descending]);
+    } else {
+      FieldPath fieldPath =
+          field is String ? FieldPath.fromString(field) : field;
+      orders.add([fieldPath, descending]);
+    }
 
     final List<List<dynamic>> conditions =
         List<List<dynamic>>.from(parameters['where']);

--- a/packages/cloud_firestore/cloud_firestore_web/lib/src/query_web.dart
+++ b/packages/cloud_firestore/cloud_firestore_web/lib/src/query_web.dart
@@ -88,8 +88,8 @@ class QueryWeb extends QueryPlatform {
   @override
   QueryPlatform endAtDocument(List<dynamic> orders, List<dynamic> values) {
     return _copyWithParameters(<String, dynamic>{
-      'orderBy': CodecUtility.valueEncode(orders),
-      'endAt': CodecUtility.valueEncode(values),
+      'orderBy': orders,
+      'endAt': values,
       'endBefore': null,
     });
   }
@@ -97,7 +97,7 @@ class QueryWeb extends QueryPlatform {
   @override
   QueryPlatform endAt(List<dynamic> fields) {
     return _copyWithParameters(<String, dynamic>{
-      'endAt': CodecUtility.valueEncode(fields),
+      'endAt': fields,
       'endBefore': null,
     });
   }
@@ -105,9 +105,9 @@ class QueryWeb extends QueryPlatform {
   @override
   QueryPlatform endBeforeDocument(List<dynamic> orders, List<dynamic> values) {
     return _copyWithParameters(<String, dynamic>{
-      'orderBy': CodecUtility.valueEncode(orders),
+      'orderBy': orders,
       'endAt': null,
-      'endBefore': CodecUtility.valueEncode(values),
+      'endBefore': values,
     });
   }
 
@@ -115,7 +115,7 @@ class QueryWeb extends QueryPlatform {
   QueryPlatform endBefore(List<dynamic> fields) {
     return _copyWithParameters(<String, dynamic>{
       'endAt': null,
-      'endBefore': CodecUtility.valueEncode(fields),
+      'endBefore': fields,
     });
   }
 
@@ -175,7 +175,7 @@ class QueryWeb extends QueryPlatform {
     return _copyWithParameters(<String, dynamic>{
       'orderBy': orders,
       'startAt': null,
-      'startAfter': CodecUtility.valueEncode(values),
+      'startAfter': values,
     });
   }
 
@@ -183,7 +183,7 @@ class QueryWeb extends QueryPlatform {
   QueryPlatform startAfter(List<dynamic> fields) {
     return _copyWithParameters(<String, dynamic>{
       'startAt': null,
-      'startAfter': CodecUtility.valueEncode(fields),
+      'startAfter': fields,
     });
   }
 
@@ -191,7 +191,7 @@ class QueryWeb extends QueryPlatform {
   QueryPlatform startAtDocument(List<dynamic> orders, List<dynamic> values) {
     return _copyWithParameters(<String, dynamic>{
       'orderBy': orders,
-      'startAt': CodecUtility.valueEncode(values),
+      'startAt': values,
       'startAfter': null,
     });
   }
@@ -199,7 +199,7 @@ class QueryWeb extends QueryPlatform {
   @override
   QueryPlatform startAt(List<dynamic> fields) {
     return _copyWithParameters(<String, dynamic>{
-      'startAt': CodecUtility.valueEncode(fields),
+      'startAt': fields,
       'startAfter': null,
     });
   }


### PR DESCRIPTION
## Description

Currently `orderBy` assumes the field to be a FieldPath or String - this adds a check for FieldPathTypes, plus additional tests and cleanup.

## Related Issues

Fixes https://github.com/FirebaseExtended/flutterfire/issues/3210

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] If the pull request affects only one plugin, the PR title starts with the name of the plugin in brackets (e.g. [cloud_firestore])
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [ ] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [ ] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
