### PR TITLE
fix(cloud_firestore): prevent snapshot race conditions

### DIFF
--- a/packages/cloud_firestore/cloud_firestore/android/src/main/java/io/flutter/plugins/firebase/firestore/FlutterFirebaseFirestorePlugin.java
+++ b/packages/cloud_firestore/cloud_firestore/android/src/main/java/io/flutter/plugins/firebase/firestore/FlutterFirebaseFirestorePlugin.java
@@ -493,8 +493,10 @@ public class FlutterFirebaseFirestorePlugin
     switch (call.method) {
       case "Firestore#removeListener":
         int handle = Objects.requireNonNull(call.argument("handle"));
-        listenerRegistrations.get(handle).remove();
-        listenerRegistrations.remove(handle);
+        if (listenerRegistrations.get(handle) != null) {
+          listenerRegistrations.get(handle).remove();
+          listenerRegistrations.remove(handle);
+        }
         result.success(null);
         return;
       case "Firestore#disableNetwork":

--- a/packages/cloud_firestore/cloud_firestore_platform_interface/lib/src/method_channel/method_channel_query.dart
+++ b/packages/cloud_firestore/cloud_firestore_platform_interface/lib/src/method_channel/method_channel_query.dart
@@ -123,14 +123,15 @@ class MethodChannelQuery extends QueryPlatform {
   }) {
     assert(includeMetadataChanges != null);
     int handle = MethodChannelFirebaseFirestore.nextMethodChannelHandleId;
+    Completer<void> onListenComplete = Completer<void>();
 
     // It's fine to let the StreamController be garbage collected once all the
     // subscribers have cancelled; this analyzer warning is safe to ignore.
     StreamController<QuerySnapshotPlatform> controller; // ignore: close_sinks
     controller = StreamController<QuerySnapshotPlatform>.broadcast(
-      onListen: () {
+      onListen: () async {
         MethodChannelFirebaseFirestore.queryObservers[handle] = controller;
-        MethodChannelFirebaseFirestore.channel.invokeMethod<void>(
+        await MethodChannelFirebaseFirestore.channel.invokeMethod<void>(
           'Query#addSnapshotListener',
           <String, dynamic>{
             'query': this,
@@ -139,13 +140,18 @@ class MethodChannelQuery extends QueryPlatform {
             'includeMetadataChanges': includeMetadataChanges,
           },
         );
+
+        if (!onListenComplete.isCompleted) {
+          onListenComplete.complete();
+        }
       },
-      onCancel: () {
-        MethodChannelFirebaseFirestore.queryObservers.remove(handle);
-        MethodChannelFirebaseFirestore.channel.invokeMethod<void>(
+      onCancel: () async {
+        await onListenComplete.future;
+        await MethodChannelFirebaseFirestore.channel.invokeMethod<void>(
           'Firestore#removeListener',
           <String, dynamic>{'handle': handle},
         );
+        MethodChannelFirebaseFirestore.queryObservers.remove(handle);
       },
     );
     return controller.stream;


### PR DESCRIPTION
## Description

Fixes 2 race conditions:

1. When a snapshot stream unsubscribes, the Dart Stream is removed at the same time an async request to remove the native listener is sent. In some cases, an event is sent from native before the native listener has been removed, but after the Dart Stream is removed, causing an assertion error.
2. If a widget updates in a very short period of time, the `onCancel` stream handler is called pretty much straight away. Since setting up the stream handler takes longer than removing, in some edge cases it's trying to remove a listener which hasn't been created.

## Related Issues

- https://github.com/FirebaseExtended/flutterfire/issues/3222
- https://github.com/FirebaseExtended/flutterfire/issues/3237

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] If the pull request affects only one plugin, the PR title starts with the name of the plugin in brackets (e.g. [cloud_firestore])
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [ ] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [ ] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
