### PR TITLE
feat(firebase_auth): use named arguments for ActionCodeSettings

### DIFF
--- a/packages/firebase_auth/firebase_auth/example/lib/signin_page.dart
+++ b/packages/firebase_auth/firebase_auth/example/lib/signin_page.dart
@@ -226,14 +226,10 @@ class _EmailLinkSignInSectionState extends State<_EmailLinkSignInSection> {
             url:
                 'https://react-native-firebase-testing.firebaseapp.com/emailSignin',
             handleCodeInApp: true,
-            iOS: {
-              'bundleId': 'io.flutter.plugins.firebaseAuthExample',
-            },
-            android: {
-              'packageName': 'io.flutter.plugins.firebaseauthexample',
-              'androidInstallIfNotAvailable': true,
-              'androidMinimumVersion': "1",
-            },
+            iOSBundleId: 'io.flutter.plugins.firebaseAuthExample',
+            androidPackageName: 'io.flutter.plugins.firebaseauthexample',
+            androidInstallApp: true,
+            androidMinimumVersion: "1",
           ));
 
       Scaffold.of(context).showSnackBar(SnackBar(

--- a/packages/firebase_auth/firebase_auth_platform_interface/lib/src/action_code_settings.dart
+++ b/packages/firebase_auth/firebase_auth_platform_interface/lib/src/action_code_settings.dart
@@ -10,22 +10,43 @@ class ActionCodeSettings {
   // ignore: public_member_api_docs
   @protected
   ActionCodeSettings({
-    this.android,
+    @Deprecated("Deprecated in favor of using named args instead ([androidPackageName], [androidMinimumVersion], [androidInstallApp])")
+        // ignore: deprecated_member_use_from_same_package
+        this.android,
+    this.androidPackageName,
+    this.androidMinimumVersion,
+    this.androidInstallApp,
     this.dynamicLinkDomain,
     this.handleCodeInApp,
-    this.iOS,
-    @required this.url,
-  }) : assert(url != null) {
-    if (android != null) {
-      assert(android['packageName'] != null);
-    }
-    if (iOS != null) {
-      assert(iOS['bundleId'] != null);
-    }
-  }
+    @Deprecated("Deprecated in favor of using named args instead ([iOSBundleId])")
+        // ignore: deprecated_member_use_from_same_package
+        this.iOS,
+    this.iOSBundleId,
+    @required
+        this.url,
+  }) : assert(url != null);
 
-  /// Sets the Android package name.
-  final Map<String, dynamic> android;
+  @Deprecated(
+      "Deprecated in favor of using named args instead ([androidPackageName], [androidMinimumVersion], [androidInstallApp])")
+  // ignore: public_member_api_docs
+  Map<String, dynamic> android;
+
+  /// The Android package name of the application to open when the URL is pressed.
+  final String androidPackageName;
+
+  /// The minimum app version which must be installed on the device.
+  ///
+  /// This argument is only set if [androidPackageName] is also set. If the user
+  /// has the application on the device but it is a lower version number than the
+  /// one specified they will be taken to the Play Store to upgrade the application.
+  final String androidMinimumVersion;
+
+  /// Whether or not the user should be automatically prompted to install the app
+  /// via the Play Store if it is not already installed.
+  final bool androidInstallApp;
+
+  /// The iOS app to open if it is installed on the device.
+  final String iOSBundleId;
 
   /// Sets an optional Dynamic Link domain.
   final String dynamicLinkDomain;
@@ -35,30 +56,54 @@ class ActionCodeSettings {
   /// app if installed.
   final bool handleCodeInApp;
 
-  /// Sets the iOS bundle ID.
-  final Map<String, dynamic> iOS;
+  @Deprecated("Deprecated in favor of using named args instead ([iOSBundleId])")
+  // ignore: public_member_api_docs
+  Map<String, dynamic> iOS;
 
   /// Sets the link continue/state URL
   final String url;
 
   /// Returns the current instance as a [Map].
   Map<String, dynamic> asMap() {
+    // ignore: deprecated_member_use_from_same_package
+    android ??= {};
+    // ignore: deprecated_member_use_from_same_package
+    iOS ??= {};
+
+    Map<String, dynamic> androidMap;
+    Map<String, dynamic> iOSMap;
+
+    // ignore: deprecated_member_use_from_same_package
+    if (androidPackageName != null || android['packageName'] != null) {
+      androidMap = {};
+      androidMap['packageName'] =
+          // ignore: deprecated_member_use_from_same_package
+          androidPackageName ?? android['packageName'].toString();
+      androidMap['minimumVersion'] =
+          // ignore: deprecated_member_use_from_same_package
+          androidMinimumVersion ?? android['minimumVersion']?.toString();
+      androidMap['installApp'] = androidInstallApp;
+
+      // ignore: deprecated_member_use_from_same_package
+      if (androidMap['installApp'] == null && android['installApp'] is bool) {
+        // ignore: deprecated_member_use_from_same_package
+        androidMap['installApp'] = android['installApp'];
+      }
+    }
+
+    // ignore: deprecated_member_use_from_same_package
+    if (iOSBundleId != null || iOS['bundleId'] != null) {
+      iOSMap = {};
+      // ignore: deprecated_member_use_from_same_package
+      iOSMap['bundleId'] = iOSBundleId ?? iOS['bundleId'].toString();
+    }
+
     return <String, dynamic>{
       'url': url,
       'dynamicLinkDomain': dynamicLinkDomain,
       'handleCodeInApp': handleCodeInApp,
-      'android': android == null
-          ? null
-          : <String, dynamic>{
-              'installApp': android['installApp'],
-              'minimumVersion': android['minimumVersion'],
-              'packageName': android['packageName'],
-            },
-      'iOS': iOS == null
-          ? null
-          : <String, dynamic>{
-              'bundleId': iOS['bundleId'],
-            }
+      'android': androidMap,
+      'iOS': iOSMap,
     };
   }
 

--- a/packages/firebase_auth/firebase_auth_platform_interface/test/action_code_settings_test.dart
+++ b/packages/firebase_auth/firebase_auth_platform_interface/test/action_code_settings_test.dart
@@ -13,24 +13,18 @@ void main() {
   final bool kMockHandleCodeInApp = true;
   final String kMockUrl = 'https://test.url';
   final String kMockMinimumVersion = '8.0';
-  final Map<String, dynamic> kMockInstallApp = <String, dynamic>{};
-
-  final Map<String, dynamic> kMockAndroid = <String, dynamic>{
-    'packageName': kMockPackageName,
-    'installApp': kMockInstallApp,
-    'minimumVersion': kMockMinimumVersion,
-  };
-  final Map<String, dynamic> kMockIOS = <String, dynamic>{
-    'bundleId': kMockBundleId
-  };
+  final bool kMockInstallApp = true;
 
   group('$ActionCodeSettings', () {
     ActionCodeSettings actionCodeSettings = ActionCodeSettings(
-        android: kMockAndroid,
+        androidPackageName: kMockPackageName,
+        androidMinimumVersion: kMockMinimumVersion,
+        androidInstallApp: kMockInstallApp,
         dynamicLinkDomain: kMockDynamicLinkDomain,
         handleCodeInApp: kMockHandleCodeInApp,
-        iOS: kMockIOS,
+        iOSBundleId: kMockBundleId,
         url: kMockUrl);
+
     group('Constructor', () {
       test('returns an instance of [ActionCodeInfo]', () {
         expect(actionCodeSettings, isA<ActionCodeSettings>());
@@ -39,77 +33,120 @@ void main() {
             equals(kMockDynamicLinkDomain));
         expect(
             actionCodeSettings.handleCodeInApp, equals(kMockHandleCodeInApp));
-        expect(actionCodeSettings.android, equals(kMockAndroid));
-        expect(actionCodeSettings.android['packageName'],
-            equals(kMockPackageName));
-        expect(actionCodeSettings.iOS, equals(kMockIOS));
-        expect(actionCodeSettings.iOS['bundleId'], equals(kMockBundleId));
+        expect(actionCodeSettings.androidPackageName, equals(kMockPackageName));
+        expect(actionCodeSettings.androidMinimumVersion,
+            equals(kMockMinimumVersion));
+        expect(actionCodeSettings.androidInstallApp, equals(kMockInstallApp));
+        expect(actionCodeSettings.iOSBundleId, equals(kMockBundleId));
       });
       test('throws [AssertionError] when url is null', () {
         expect(() => ActionCodeSettings(url: null), throwsAssertionError);
       });
 
-      test('throws [AssertionError] when android.packageName is null', () {
-        expect(
-            () => ActionCodeSettings(
-                url: kMockUrl, android: <String, dynamic>{'packageName': null}),
-            throwsAssertionError);
+      group('asMap', () {
+        test('returns the current instance as a [Map]', () {
+          final result = actionCodeSettings.asMap();
+
+          expect(result, isA<Map<String, dynamic>>());
+
+          expect(result['url'], equals(kMockUrl));
+          expect(result['dynamicLinkDomain'], equals(kMockDynamicLinkDomain));
+          expect(result['handleCodeInApp'], equals(kMockHandleCodeInApp));
+
+          expect(result['android'], isNotNull);
+          expect(result['iOS'], isNotNull);
+
+          expect(result['android']['packageName'], equals(kMockPackageName));
+          expect(result['android']['installApp'], equals(kMockInstallApp));
+          expect(
+              result['android']['minimumVersion'], equals(kMockMinimumVersion));
+          expect(result['iOS']['bundleId'], equals(kMockBundleId));
+        });
+
+        test('handles deprecated properties', () {
+          ActionCodeSettings deprecatedSettings = ActionCodeSettings(
+              // ignore: deprecated_member_use_from_same_package
+              android: <String, dynamic>{
+                'packageName': kMockPackageName,
+                'minimumVersion': kMockMinimumVersion,
+                'installApp': true,
+              },
+              // ignore: deprecated_member_use_from_same_package
+              iOS: <String, dynamic>{
+                'bundleId': kMockBundleId,
+              },
+              dynamicLinkDomain: kMockDynamicLinkDomain,
+              handleCodeInApp: kMockHandleCodeInApp,
+              url: kMockUrl);
+
+          final result = deprecatedSettings.asMap();
+          expect(result, isA<Map<String, dynamic>>());
+
+          expect(result['url'], equals(kMockUrl));
+          expect(result['dynamicLinkDomain'], equals(kMockDynamicLinkDomain));
+          expect(result['handleCodeInApp'], equals(kMockHandleCodeInApp));
+
+          expect(result['android'], isNotNull);
+          expect(result['iOS'], isNotNull);
+
+          expect(result['android']['packageName'], equals(kMockPackageName));
+          expect(result['android']['installApp'], equals(kMockInstallApp));
+          expect(
+              result['android']['minimumVersion'], equals(kMockMinimumVersion));
+          expect(result['iOS']['bundleId'], equals(kMockBundleId));
+        });
+
+        test('handles mixed deprecated properties', () {
+          ActionCodeSettings deprecatedSettings = ActionCodeSettings(
+              // ignore: deprecated_member_use_from_same_package
+              android: <String, dynamic>{
+                'packageName': kMockPackageName,
+                'minimumVersion': kMockMinimumVersion,
+                'installApp': true,
+              },
+              androidPackageName: kMockPackageName + '!',
+              // ignore: deprecated_member_use_from_same_package
+              iOS: <String, dynamic>{
+                'bundleId': kMockBundleId,
+              },
+              iOSBundleId: kMockBundleId + '!',
+              dynamicLinkDomain: kMockDynamicLinkDomain,
+              handleCodeInApp: kMockHandleCodeInApp,
+              url: kMockUrl);
+
+          final result = deprecatedSettings.asMap();
+          expect(result, isA<Map<String, dynamic>>());
+
+          expect(result['url'], equals(kMockUrl));
+          expect(result['dynamicLinkDomain'], equals(kMockDynamicLinkDomain));
+          expect(result['handleCodeInApp'], equals(kMockHandleCodeInApp));
+
+          expect(result['android'], isNotNull);
+          expect(result['iOS'], isNotNull);
+
+          expect(
+              result['android']['packageName'], equals(kMockPackageName + '!'));
+          expect(result['android']['installApp'], equals(kMockInstallApp));
+          expect(
+              result['android']['minimumVersion'], equals(kMockMinimumVersion));
+          expect(result['iOS']['bundleId'], equals(kMockBundleId + '!'));
+        });
+
+        test('expects android/iOS Maps to be null', () {
+          ActionCodeSettings testActionCodeSettings =
+              ActionCodeSettings(url: kMockUrl);
+
+          final result = testActionCodeSettings.asMap();
+          expect(result, isA<Map<String, dynamic>>());
+          expect(result['android'], isNull);
+          expect(result['iOS'], isNull);
+        });
       });
 
-      test('throws [AssertionError] when iOS.bundleId is null', () {
-        expect(
-            () => ActionCodeSettings(
-                url: kMockUrl,
-                android: kMockAndroid,
-                iOS: <String, dynamic>{'bundleId': null}),
-            throwsAssertionError);
+      test('toString', () {
+        expect(actionCodeSettings.toString(),
+            equals('$ActionCodeSettings(${actionCodeSettings.asMap})'));
       });
-    });
-
-    group('asMap', () {
-      test('returns the current instance as a [Map]', () {
-        final result = actionCodeSettings.asMap();
-
-        expect(result, isA<Map<String, dynamic>>());
-
-        expect(result['url'], equals(kMockUrl));
-        expect(result['dynamicLinkDomain'], equals(kMockDynamicLinkDomain));
-        expect(result['handleCodeInApp'], equals(kMockHandleCodeInApp));
-        expect(result['android'], equals(kMockAndroid));
-        expect(result['android']['packageName'], equals(kMockPackageName));
-        expect(result['android']['installApp'], equals(kMockInstallApp));
-        expect(
-            result['android']['minimumVersion'], equals(kMockMinimumVersion));
-        expect(result['iOS'], equals(kMockIOS));
-        expect(result['iOS']['bundleId'], equals(kMockBundleId));
-      });
-
-      test('sets android to null', () {
-        ActionCodeSettings testActionCodeSettings =
-            ActionCodeSettings(url: kMockUrl, android: null, iOS: kMockIOS);
-
-        final result = testActionCodeSettings.asMap();
-
-        expect(result, isA<Map<String, dynamic>>());
-
-        expect(result['android'], isNull);
-      });
-
-      test('sets iOS to null', () {
-        ActionCodeSettings testActionCodeSettings =
-            ActionCodeSettings(url: kMockUrl, android: kMockAndroid, iOS: null);
-
-        final result = testActionCodeSettings.asMap();
-
-        expect(result, isA<Map<String, dynamic>>());
-
-        expect(result['iOS'], isNull);
-      });
-    });
-
-    test('toString', () {
-      expect(actionCodeSettings.toString(),
-          equals('$ActionCodeSettings(${actionCodeSettings.asMap})'));
     });
   });
 }

--- a/packages/firebase_auth/firebase_auth_platform_interface/test/method_channel_tests/method_channel_user_test.dart
+++ b/packages/firebase_auth/firebase_auth_platform_interface/test/method_channel_tests/method_channel_user_test.dart
@@ -677,11 +677,10 @@ void main() {
 
     group('verifyBeforeUpdateEmail()', () {
       final ActionCodeSettings actionCodeSettings = ActionCodeSettings(
-          url: 'test',
-          dynamicLinkDomain: null,
-          handleCodeInApp: null,
-          android: null,
-          iOS: null);
+        url: 'test',
+        dynamicLinkDomain: null,
+        handleCodeInApp: null,
+      );
       const newEmail = 'new@email.com';
       test('verifyBeforeUpdateEmail()', () async {
         await auth.currentUser

--- a/packages/firebase_auth/firebase_auth_web/lib/utils.dart
+++ b/packages/firebase_auth/firebase_auth_web/lib/utils.dart
@@ -71,18 +71,27 @@ firebase.ActionCodeSettings convertPlatformActionCodeSettings(
     return null;
   }
 
+  Map<String, dynamic> actionCodeSettingsMap = actionCodeSettings.asMap();
+  firebase.AndroidSettings android;
+  firebase.IosSettings iOS;
+
+  if (actionCodeSettingsMap['android'] != null) {
+    android = firebase.AndroidSettings(
+        packageName: actionCodeSettingsMap['android']['packageName'],
+        minimumVersion: actionCodeSettingsMap['android']['minimumVersion'],
+        installApp: actionCodeSettingsMap['android']['installApp']);
+  }
+
+  if (actionCodeSettingsMap['iOS'] != null) {
+    iOS = firebase.IosSettings(
+        bundleId: actionCodeSettingsMap['iOS']['bundleId']);
+  }
+
   return firebase.ActionCodeSettings(
       url: actionCodeSettings.url,
       handleCodeInApp: actionCodeSettings.handleCodeInApp,
-      android: actionCodeSettings.android == null
-          ? null
-          : firebase.AndroidSettings(
-              packageName: actionCodeSettings.android['packageName'],
-              minimumVersion: actionCodeSettings.android['minimumVersion'],
-              installApp: actionCodeSettings.android['installApp']),
-      iOS: actionCodeSettings.iOS == null
-          ? null
-          : firebase.IosSettings(bundleId: actionCodeSettings.iOS['bundleId']));
+      android: android,
+      iOS: iOS);
 }
 
 /// Converts a [Persistence] enum into a web string persistence value.


### PR DESCRIPTION
## Description

The current implementation of the `android` and `iOS` keys on `ActionCodeSettings` is error prone. 

This PR deprecates those dynamic maps in favour of named arguments. The logic attempts to use the new arguments and falls back to the deprecated ones.

## Related Issues

https://github.com/FirebaseExtended/flutterfire/issues/3259

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] If the pull request affects only one plugin, the PR title starts with the name of the plugin in brackets (e.g. [cloud_firestore])
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [ ] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [ ] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
