### PR TITLE
fix(firebase_auth): use correct FIRAuth instance on for listeners

### DIFF
--- a/packages/firebase_auth/firebase_auth/ios/Classes/FLTFirebaseAuthPlugin.m
+++ b/packages/firebase_auth/firebase_auth/ios/Classes/FLTFirebaseAuthPlugin.m
@@ -911,7 +911,7 @@ NSString *const kErrMsgInvalidCredential =
   @synchronized(self->_authChangeListeners) {
     if (_authChangeListeners[auth.app.name] == nil) {
       _authChangeListeners[auth.app.name] =
-          [[FIRAuth auth] addAuthStateDidChangeListener:authStateChangeListener];
+          [auth addAuthStateDidChangeListener:authStateChangeListener];
     }
   }
 
@@ -927,7 +927,7 @@ NSString *const kErrMsgInvalidCredential =
   @synchronized(self->_idTokenChangeListeners) {
     if (_idTokenChangeListeners[auth.app.name] == nil) {
       _idTokenChangeListeners[auth.app.name] =
-          [[FIRAuth auth] addIDTokenDidChangeListener:idTokenChangeListener];
+          [auth addIDTokenDidChangeListener:idTokenChangeListener];
     }
   }
 


### PR DESCRIPTION
## Description

Secondary apps correctly get the cached authenticated user, however on iOS, the default app user was always being returned and setting the current user (for the wrong app instance).

## Related Issues

Fixes https://github.com/FirebaseExtended/flutterfire/issues/3283

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] If the pull request affects only one plugin, the PR title starts with the name of the plugin in brackets (e.g. [cloud_firestore])
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [ ] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [ ] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
