### PR TITLE
[docs] Add Google Analytics to Docs

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -116,10 +116,15 @@ module.exports = {
       ],
       copyright: `<div style="margin-top: 3rem"><small>Except as otherwise noted, this work is licensed under a Creative Commons Attribution 4.0 International License, and code samples are licensed under the BSD License.</small></div>`,
     },
+    googleAnalytics: {
+      trackingID: 'G-8PJJN5LRR7',
+      anonymizeIP: true,
+    },
   },
   plugins: [
     require.resolve('docusaurus-plugin-sass'),
     require.resolve('@docusaurus/plugin-ideal-image'),
+    require.resolve('@docusaurus/plugin-google-analytics'),
     path.resolve(__dirname, './docusaurus-plugins/favicon-tags'),
     path.resolve(__dirname, './docusaurus-plugins/source-versions'),
     path.resolve(__dirname, './docusaurus-plugins/source-api-reference'),


### PR DESCRIPTION
## Description

Add Google Analytics to FlutterFire documentation.