### PR TITLE
[docs] Try gtag for docs analytics

### DIFF
--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -116,7 +116,7 @@ module.exports = {
       ],
       copyright: `<div style="margin-top: 3rem"><small>Except as otherwise noted, this work is licensed under a Creative Commons Attribution 4.0 International License, and code samples are licensed under the BSD License.</small></div>`,
     },
-    googleAnalytics: {
+    gtag: {
       trackingID: 'G-8PJJN5LRR7',
       anonymizeIP: true,
     },
@@ -124,7 +124,7 @@ module.exports = {
   plugins: [
     require.resolve('docusaurus-plugin-sass'),
     require.resolve('@docusaurus/plugin-ideal-image'),
-    require.resolve('@docusaurus/plugin-google-analytics'),
+    require.resolve('@docusaurus/plugin-google-gtag'),
     path.resolve(__dirname, './docusaurus-plugins/favicon-tags'),
     path.resolve(__dirname, './docusaurus-plugins/source-versions'),
     path.resolve(__dirname, './docusaurus-plugins/source-api-reference'),


### PR DESCRIPTION
## Description

Google Analytics docusauras plugin does not seem to work. Trying the gtag plugin instead.