### PR TITLE
refactor(firebase_crashlytics): changes context to reason (#1542)

### DIFF
--- a/packages/firebase_crashlytics/firebase_crashlytics/android/src/main/java/io/flutter/plugins/firebase/crashlytics/Constants.java
+++ b/packages/firebase_crashlytics/firebase_crashlytics/android/src/main/java/io/flutter/plugins/firebase/crashlytics/Constants.java
@@ -2,7 +2,7 @@ package io.flutter.plugins.firebase.crashlytics;
 
 public class Constants {
   public static final String EXCEPTION = "exception";
-  public static final String CONTEXT = "context";
+  public static final String REASON = "reason";
   public static final String INFORMATION = "information";
   public static final String STACK_TRACE_ELEMENTS = "stackTraceElements";
   public static final String FLUTTER_ERROR_EXCEPTION = "flutter_error_exception";

--- a/packages/firebase_crashlytics/firebase_crashlytics/android/src/main/java/io/flutter/plugins/firebase/crashlytics/FlutterFirebaseCrashlyticsPlugin.java
+++ b/packages/firebase_crashlytics/firebase_crashlytics/android/src/main/java/io/flutter/plugins/firebase/crashlytics/FlutterFirebaseCrashlyticsPlugin.java
@@ -115,16 +115,16 @@ public class FlutterFirebaseCrashlyticsPlugin
 
           final String dartExceptionMessage =
               (String) Objects.requireNonNull(arguments.get(Constants.EXCEPTION));
-          final String context = (String) arguments.get(Constants.CONTEXT);
+          final String reason = (String) arguments.get(Constants.REASON);
           final String information =
               (String) Objects.requireNonNull(arguments.get(Constants.INFORMATION));
 
           Exception exception;
-          if (context != null) {
+          if (reason != null) {
             // Set a "reason" (to match iOS) to show where the exception was thrown.
-            crashlytics.setCustomKey(Constants.FLUTTER_ERROR_REASON, "thrown " + context);
+            crashlytics.setCustomKey(Constants.FLUTTER_ERROR_REASON, "thrown " + reason);
             exception =
-                new FlutterError(dartExceptionMessage + ". " + "Error thrown " + context + ".");
+                new FlutterError(dartExceptionMessage + ". " + "Error thrown " + reason + ".");
           } else {
             exception = new FlutterError(dartExceptionMessage);
           }

--- a/packages/firebase_crashlytics/firebase_crashlytics/example/lib/main.dart
+++ b/packages/firebase_crashlytics/firebase_crashlytics/example/lib/main.dart
@@ -182,10 +182,10 @@ class _MyAppState extends State<MyApp> {
                               ));
                               throw 'error_example';
                             } catch (e, s) {
-                              // "context" will append the word "thrown" in the
+                              // "reason" will append the word "thrown" in the
                               // Crashlytics console.
                               await FirebaseCrashlytics.instance
-                                  .recordError(e, s, context: 'as an example');
+                                  .recordError(e, s, reason: 'as an example');
                             }
                           }),
                     ],

--- a/packages/firebase_crashlytics/firebase_crashlytics/example/test_driver/firebase_crashlytics_e2e.dart
+++ b/packages/firebase_crashlytics/firebase_crashlytics/example/test_driver/firebase_crashlytics_e2e.dart
@@ -64,7 +64,7 @@ void main() {
         await crashlytics.recordFlutterError(FlutterErrorDetails(
             exception: 'foo exception',
             stack: StackTrace.fromString(''),
-            context: DiagnosticsNode.message('bar context'),
+            context: DiagnosticsNode.message('bar reason'),
             informationCollector: () => <DiagnosticsNode>[
                   DiagnosticsNode.message('first message'),
                   DiagnosticsNode.message('second message')

--- a/packages/firebase_crashlytics/firebase_crashlytics/ios/Classes/FLTFirebaseCrashlyticsPlugin.m
+++ b/packages/firebase_crashlytics/firebase_crashlytics/ios/Classes/FLTFirebaseCrashlyticsPlugin.m
@@ -13,7 +13,7 @@ NSString *const kFLTFirebaseCrashlyticsChannelName = @"plugins.flutter.io/fireba
 NSString *const kCrashlyticsArgumentException = @"exception";
 NSString *const kCrashlyticsArgumentInformation = @"information";
 NSString *const kCrashlyticsArgumentStackTraceElements = @"stackTraceElements";
-NSString *const kCrashlyticsArgumentContext = @"context";
+NSString *const kCrashlyticsArgumentReason = @"reason";
 NSString *const kCrashlyticsArgumentIdentifier = @"identifier";
 NSString *const kCrashlyticsArgumentKey = @"key";
 NSString *const kCrashlyticsArgumentValue = @"value";
@@ -100,7 +100,7 @@ NSString *const kCrashlyticsArgumentDidCrashOnPreviousExecution = @"didCrashOnPr
 #pragma mark - Firebase Crashlytics API
 
 - (void)recordError:(id)arguments withMethodCallResult:(FLTFirebaseMethodCallResult *)result {
-  NSString *context = arguments[kCrashlyticsArgumentContext];
+  NSString *reason = arguments[kCrashlyticsArgumentReason];
   NSString *information = arguments[kCrashlyticsArgumentInformation];
   NSString *dartExceptionMessage = arguments[kCrashlyticsArgumentException];
   NSArray *errorElements = arguments[kCrashlyticsArgumentStackTraceElements];
@@ -116,11 +116,10 @@ NSString *const kCrashlyticsArgumentDidCrashOnPreviousExecution = @"didCrashOnPr
     [frames addObject:[self generateFrame:errorElement]];
   }
 
-  NSString *reason;
-  if (![context isEqual:[NSNull null]]) {
-    reason = [NSString stringWithFormat:@"%@. Error thrown %@.", dartExceptionMessage, context];
+  if (![reason isEqual:[NSNull null]]) {
+    reason = [NSString stringWithFormat:@"%@. Error thrown %@.", dartExceptionMessage, reason];
     // Log additional custom value to match Android.
-    [[FIRCrashlytics crashlytics] setCustomValue:[NSString stringWithFormat:@"thrown %@", context]
+    [[FIRCrashlytics crashlytics] setCustomValue:[NSString stringWithFormat:@"thrown %@", reason]
                                           forKey:@"flutter_error_reason"];
   } else {
     reason = dartExceptionMessage;

--- a/packages/firebase_crashlytics/firebase_crashlytics/lib/src/firebase_crashlytics.dart
+++ b/packages/firebase_crashlytics/firebase_crashlytics/lib/src/firebase_crashlytics.dart
@@ -91,7 +91,7 @@ class FirebaseCrashlytics extends FirebasePluginPlatform {
 
   /// Submits a Crashlytics report of a caught error.
   Future<void> recordError(dynamic exception, StackTrace stack,
-      {dynamic context,
+      {dynamic reason,
       Iterable<DiagnosticsNode> information,
       bool printDetails}) async {
     // If [null] is provided, use the debug flag instead.
@@ -104,9 +104,9 @@ class FirebaseCrashlytics extends FirebasePluginPlatform {
     if (printDetails) {
       print('----------------FIREBASE CRASHLYTICS----------------');
 
-      // If available, give context to the exception.
-      if (context != null) {
-        print('The following exception was thrown $context:');
+      // If available, give a reason to the exception.
+      if (reason != null) {
+        print('The following exception was thrown $reason:');
       }
 
       // Need to print the exception to explain why the exception was thrown.
@@ -134,7 +134,7 @@ class FirebaseCrashlytics extends FirebasePluginPlatform {
 
     return _delegate.recordError(
       exception: exception.toString(),
-      context: context?.toString(),
+      reason: reason?.toString(),
       information: _information,
       stackTraceElements: stackTraceElements,
     );
@@ -146,7 +146,7 @@ class FirebaseCrashlytics extends FirebasePluginPlatform {
     FlutterError.dumpErrorToConsole(flutterErrorDetails, forceReport: true);
     return recordError(
         flutterErrorDetails.exceptionAsString(), flutterErrorDetails.stack,
-        context: flutterErrorDetails.context,
+        reason: flutterErrorDetails.context,
         printDetails: false,
         information: flutterErrorDetails.informationCollector == null
             ? null

--- a/packages/firebase_crashlytics/firebase_crashlytics/test/firebase_crashlytics_test.dart
+++ b/packages/firebase_crashlytics/firebase_crashlytics/test/firebase_crashlytics_test.dart
@@ -66,14 +66,14 @@ void main() {
       test('with stack', () async {
         final stack = StackTrace.current;
         final exception = 'foo exception';
-        final exceptionContext = 'bar context';
+        final exceptionReason = 'bar reason';
 
         await crashlytics.recordError(exception, stack,
-            context: exceptionContext, printDetails: false);
+            reason: exceptionReason, printDetails: false);
         expect(methodCallLog, <Matcher>[
           isMethodCall('Crashlytics#recordError', arguments: {
             'exception': exception,
-            'context': exceptionContext,
+            'reason': exceptionReason,
             'information': '',
             'stackTraceElements': getStackTraceElements(
                 Trace.format(stack).trimRight().split('\n'))
@@ -89,13 +89,12 @@ void main() {
 
       test('without stack', () async {
         final exception = 'foo exception';
-        final exceptionContext = 'bar context';
+        final exceptionReason = 'bar reason';
 
-        await crashlytics.recordError(exception, null,
-            context: exceptionContext);
+        await crashlytics.recordError(exception, null, reason: exceptionReason);
         expect(methodCallLog[0].method, 'Crashlytics#recordError');
         expect(methodCallLog[0].arguments['exception'], exception);
-        expect(methodCallLog[0].arguments['context'], exceptionContext);
+        expect(methodCallLog[0].arguments['reason'], exceptionReason);
 
         // Confirm that the stack trace contains current stack.
         expect(
@@ -108,7 +107,7 @@ void main() {
 
     test('recordFlutterError', () async {
       final exception = 'foo exception';
-      final exceptionContext = 'bar context';
+      final exceptionReason = 'bar reason';
       final exceptionLibrary = 'baz library';
       final exceptionFirstMessage = 'first message';
       final exceptionSecondMessage = 'second message';
@@ -121,13 +120,13 @@ void main() {
           DiagnosticsNode.message(exceptionFirstMessage),
           DiagnosticsNode.message(exceptionSecondMessage),
         ],
-        context: ErrorDescription(exceptionContext),
+        context: ErrorDescription(exceptionReason),
       );
       await crashlytics.recordFlutterError(details);
       expect(methodCallLog, <Matcher>[
         isMethodCall('Crashlytics#recordError', arguments: {
           'exception': exception,
-          'context': exceptionContext,
+          'reason': exceptionReason,
           'information': '$exceptionFirstMessage\n$exceptionSecondMessage',
           'stackTraceElements':
               getStackTraceElements(Trace.format(stack).trimRight().split('\n'))

--- a/packages/firebase_crashlytics/firebase_crashlytics_platform_interface/lib/src/method_channel/method_channel_crashlytics.dart
+++ b/packages/firebase_crashlytics/firebase_crashlytics_platform_interface/lib/src/method_channel/method_channel_crashlytics.dart
@@ -73,14 +73,14 @@ class MethodChannelFirebaseCrashlytics extends FirebaseCrashlyticsPlatform {
   @override
   Future<void> recordError({
     String exception,
-    String context,
+    String reason,
     String information,
     List<Map<String, String>> stackTraceElements,
   }) {
     return channel
         .invokeMethod<void>('Crashlytics#recordError', <String, dynamic>{
       'exception': exception,
-      'context': context,
+      'reason': reason,
       'information': information,
       'stackTraceElements': stackTraceElements ?? [],
     }).catchError(catchPlatformException);

--- a/packages/firebase_crashlytics/firebase_crashlytics_platform_interface/lib/src/platform_interface/platform_interface_crashlytics.dart
+++ b/packages/firebase_crashlytics/firebase_crashlytics_platform_interface/lib/src/platform_interface/platform_interface_crashlytics.dart
@@ -106,7 +106,7 @@ abstract class FirebaseCrashlyticsPlatform extends PlatformInterface {
   /// Submits a Crashlytics report of a caught error.
   Future<void> recordError({
     String exception,
-    String context,
+    String reason,
     String information,
     List<Map<String, String>> stackTraceElements,
   }) {

--- a/packages/firebase_crashlytics/firebase_crashlytics_platform_interface/test/method_channel_tests/method_channel_crashlytics_test.dart
+++ b/packages/firebase_crashlytics/firebase_crashlytics_platform_interface/test/method_channel_tests/method_channel_crashlytics_test.dart
@@ -27,7 +27,7 @@ void main() {
 
   Map<String, dynamic> kMockError = <String, dynamic>{
     'exception': 'Test exception',
-    'context': 'MethodChannelTest',
+    'reason': 'MethodChannelTest',
     'information': 'This is a test exception',
     'stackTraceElements': <Map<String, String>>[
       <String, String>{
@@ -195,7 +195,7 @@ void main() {
       test('should call delegate method successfully', () async {
         await crashlytics.recordError(
             exception: kMockError['exception'],
-            context: kMockError['context'],
+            reason: kMockError['reason'],
             information: kMockError['information'],
             stackTraceElements: kMockError['stackTraceElements']);
 
@@ -205,7 +205,7 @@ void main() {
             'Crashlytics#recordError',
             arguments: <String, dynamic>{
               'exception': kMockError['exception'],
-              'context': kMockError['context'],
+              'reason': kMockError['reason'],
               'information': kMockError['information'],
               'stackTraceElements': kMockError['stackTraceElements'],
             },


### PR DESCRIPTION
## Description

The `context` parameter of `recordError()` should be renamed to `reason` as it's very easy to be confused with Flutter's `BuildContext` `context` parameter that's very common on Flutter Widgets.

Also, `reason` matches the iOS API, and the Firebase Console uses `reason` to show this `String`:

![image](https://user-images.githubusercontent.com/8120472/91110475-566f5680-e654-11ea-9406-70b016a03283.png)


I am not experienced with iOS, I didn't see any method channel code in the iOS folder so I don't know how this breaking change will affect iOS devices.

I also changed one of the tests to add a `contain` clause to the test file path. I don't think it was breaking for any changes that I did, maybe it's a difference in IDE or OS behavior, so I thought `contains` would make it more generic.

## Related Issues

Closes #1542

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] If the pull request affects only one plugin, the PR title starts with the name of the plugin in brackets (e.g. [cloud_firestore])
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [x] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
