### PR TITLE
[firebase_messaging] fixed platform dependency error

### DIFF
--- a/packages/firebase_messaging/CHANGELOG.md
+++ b/packages/firebase_messaging/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 7.0.1
+
+* Fix the `platform` dependency error on Flutter master
+
 ## 7.0.0
 
 * Depend on `firebase_core` and migrate plugin to use `firebase_core` native SDK versioning features;

--- a/packages/firebase_messaging/example/pubspec.yaml
+++ b/packages/firebase_messaging/example/pubspec.yaml
@@ -7,8 +7,7 @@ dependencies:
     sdk: flutter
   firebase_messaging:
     path: ../
-  firebase_core: 
-    path: ../../firebase_core/firebase_core
+  firebase_core: ^0.5.0
 
 dev_dependencies:
   pedantic: ^1.8.0

--- a/packages/firebase_messaging/example/pubspec.yaml
+++ b/packages/firebase_messaging/example/pubspec.yaml
@@ -8,7 +8,7 @@ dependencies:
   firebase_messaging:
     path: ../
   firebase_core: 
-    path: ../firebase_core/firebase_core
+    path: ../../firebase_core/firebase_core
 
 dev_dependencies:
   pedantic: ^1.8.0

--- a/packages/firebase_messaging/pubspec.yaml
+++ b/packages/firebase_messaging/pubspec.yaml
@@ -26,8 +26,6 @@ dev_dependencies:
   mockito: ^3.0.0
   flutter_test:
     sdk: flutter
-  flutter_driver:
-    sdk: flutter
 
 environment:
   sdk: ">=2.0.0 <3.0.0"

--- a/packages/firebase_messaging/pubspec.yaml
+++ b/packages/firebase_messaging/pubspec.yaml
@@ -15,7 +15,6 @@ flutter:
 
 dependencies:
   meta: ^1.0.4
-  # platform: ^2.0.0
   flutter:
     sdk: flutter
   firebase_core:
@@ -27,7 +26,9 @@ dev_dependencies:
   mockito: ^3.0.0
   flutter_test:
     sdk: flutter
+  flutter_driver:
+    sdk: flutter
 
 environment:
   sdk: ">=2.0.0 <3.0.0"
-  # flutter: ">=1.12.13+hotfix.5 <2.0.0"
+  flutter: ">=1.12.13+hotfix.5 <2.0.0"

--- a/packages/firebase_messaging/pubspec.yaml
+++ b/packages/firebase_messaging/pubspec.yaml
@@ -2,7 +2,7 @@ name: firebase_messaging
 description: Flutter plugin for Firebase Cloud Messaging, a cross-platform
   messaging solution that lets you reliably deliver messages on Android and iOS.
 homepage: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/firebase_messaging
-version: 7.0.0
+version: 7.0.1
 
 flutter:
   plugin:

--- a/packages/firebase_messaging/pubspec.yaml
+++ b/packages/firebase_messaging/pubspec.yaml
@@ -29,4 +29,4 @@ dev_dependencies:
 
 environment:
   sdk: ">=2.0.0 <3.0.0"
-  flutter: ">=1.12.13+hotfix.5 <2.0.0"
+  # flutter: ">=1.12.13+hotfix.5 <2.0.0"

--- a/packages/firebase_messaging/pubspec.yaml
+++ b/packages/firebase_messaging/pubspec.yaml
@@ -17,8 +17,7 @@ dependencies:
   meta: ^1.0.4
   flutter:
     sdk: flutter
-  firebase_core:
-    path: ../firebase_core/firebase_core
+  firebase_core: ^0.5.0
 
 dev_dependencies:
   pedantic: ^1.8.0

--- a/packages/firebase_messaging/pubspec.yaml
+++ b/packages/firebase_messaging/pubspec.yaml
@@ -15,10 +15,11 @@ flutter:
 
 dependencies:
   meta: ^1.0.4
-  platform: ^2.0.0
+  # platform: ^2.0.0
   flutter:
     sdk: flutter
-  firebase_core: ^0.5.0
+  firebase_core:
+    path: ../firebase_core/firebase_core
 
 dev_dependencies:
   pedantic: ^1.8.0


### PR DESCRIPTION
## Description

This PR solves the package `firebase_messaging` from working `flutter 1.22.0-2.0.pre.36`, the problem was related to the package `platform`, the solution was to remove the package.

## Related Issues

* https://github.com/FirebaseExtended/flutterfire/issues/3312

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] If the pull request affects only one plugin, the PR title starts with the name of the plugin in brackets (e.g. [cloud_firestore])
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
