### PR TITLE
feat(cloud_firestore): add a [] operator to DocumentSnapshot, acting as get()

### DIFF
--- a/packages/cloud_firestore/cloud_firestore/CHANGELOG.md
+++ b/packages/cloud_firestore/cloud_firestore/CHANGELOG.md
@@ -32,7 +32,7 @@ Along with the below changes, the plugin has undergone a quality of life update 
 - **BREAKING**: Getting a collection parent document via `parent()` has been changed to a getter `parent`.
 - **BREAKING**: Getting the collection `path` now always returns the `path` without leading and trailing slashes.
 - **DEPRECATED**: Calling `document()` is deprecated in favor of `doc()`.
-- **FIX**: Equality checking of `CollectionReference` now does not depend on the original path used to create the `CollectionReference`. 
+- **FIX**: Equality checking of `CollectionReference` now does not depend on the original path used to create the `CollectionReference`.
 
 **`Query`**:
 - **BREAKING**: The internal query logic has been overhauled to better assert invalid queries locally.

--- a/packages/cloud_firestore/cloud_firestore/lib/src/document_snapshot.dart
+++ b/packages/cloud_firestore/cloud_firestore/lib/src/document_snapshot.dart
@@ -47,4 +47,11 @@ class DocumentSnapshot {
   /// at the specified path, a [StateError] will be thrown.
   dynamic get(dynamic field) =>
       _CodecUtility.valueDecode(_delegate.get(field), _firestore);
+
+  /// Gets a nested field by [String] or [FieldPath] from this [DocumentSnapshot].
+  ///
+  /// Data can be accessed by providing a dot-notated path or [FieldPath]
+  /// which recursively finds the specified data. If no data could be found
+  /// at the specified path, a [StateError] will be thrown.
+  dynamic operator [](dynamic field) => get(field);
 }

--- a/packages/cloud_firestore/cloud_firestore/test/document_snapshot_test.dart
+++ b/packages/cloud_firestore/cloud_firestore/test/document_snapshot_test.dart
@@ -177,11 +177,93 @@ void main() {
         expect(ds.get(FieldPath(['dot.field'])), isTrue);
       });
 
-      test('throws when geting a field containing a "." using [String]',
+      test('throws when getting a field containing a "." using [String]',
           () async {
         DocumentSnapshot ds = await firestore.doc('doc/get-test').get();
         try {
           ds.get('dot.field');
+        } on StateError {
+          return;
+        }
+        fail("Did not throw a StateError");
+      });
+    });
+
+    group('[]', () {
+      test('throws if field is invalid', () async {
+        DocumentSnapshot ds = await firestore.doc('doc/exists').get();
+        expect(() => ds[null], throwsAssertionError);
+        expect(() => ds[123], throwsAssertionError);
+        expect(() => ds[{}], throwsAssertionError);
+      });
+
+      test('gets a top-level field by [String]', () async {
+        DocumentSnapshot ds = await firestore.doc('doc/exists').get();
+        expect(ds['foo'], equals('bar'));
+      });
+
+      test('gets a top-level field by [FieldPath]', () async {
+        DocumentSnapshot ds = await firestore.doc('doc/exists').get();
+        expect(ds[FieldPath(['foo'])], equals('bar'));
+      });
+
+      test('throws a [StateError] if document does not exist', () async {
+        DocumentSnapshot ds = await firestore.doc('doc/not-exists').get();
+        try {
+          ds['foo'];
+        } on StateError {
+          return;
+        }
+        fail("Did not throw a StateError");
+      });
+
+      test('throws a [StateError] if a top-level field was not found',
+          () async {
+        DocumentSnapshot ds = await firestore.doc('doc/exists').get();
+        try {
+          ds['bar'];
+        } on StateError {
+          return;
+        }
+        fail("Did not throw a StateError");
+      });
+
+      test('gets a nested Map field by [String]', () async {
+        DocumentSnapshot ds = await firestore.doc('doc/get-test').get();
+        expect(ds['foo.bar'], equals('baz'));
+      });
+
+      test('gets a nested Map field by [FieldPath]', () async {
+        DocumentSnapshot ds = await firestore.doc('doc/get-test').get();
+        expect(ds[FieldPath(['foo', 'bar'])], equals('baz'));
+      });
+
+      test('gets a Map field', () async {
+        DocumentSnapshot ds = await firestore.doc('doc/get-test').get();
+        expect(ds['foo'], equals({'bar': 'baz'}));
+      });
+
+      test('gets a List field', () async {
+        DocumentSnapshot ds = await firestore.doc('doc/get-test').get();
+        expect(ds['baz'], equals([123, '456']));
+      });
+
+      test('gets a deep Map field', () async {
+        DocumentSnapshot ds = await firestore.doc('doc/get-test').get();
+        expect(ds['ben.foo.bar'], equals('baz'));
+      });
+
+      test('gets a field containing a "." using [FieldPath]', () async {
+        DocumentSnapshot ds = await firestore.doc('doc/get-test').get();
+
+        expect(ds[FieldPath(['dot.field'])], isTrue);
+      });
+
+      test('throws when getting a field containing a "." using [String]',
+          () async {
+        DocumentSnapshot ds = await firestore.doc('doc/get-test').get();
+        try {
+          ds['dot.field'];
         } on StateError {
           return;
         }

--- a/packages/cloud_firestore/cloud_firestore_platform_interface/lib/src/platform_interface/platform_interface_document_snapshot.dart
+++ b/packages/cloud_firestore/cloud_firestore_platform_interface/lib/src/platform_interface/platform_interface_document_snapshot.dart
@@ -112,4 +112,11 @@ class DocumentSnapshotPlatform extends PlatformInterface {
 
     return _findComponent(0, snapshotData);
   }
+
+  /// Gets a nested field by [String] or [FieldPath] from the snapshot.
+  ///
+  /// Data can be accessed by providing a dot-notated path or [FieldPath]
+  /// which recursively finds the specified data. If no data could be found
+  /// at the specified path, a [StateError] will be thrown.
+  dynamic operator [](dynamic field) => get(field);
 }

--- a/packages/cloud_firestore/cloud_firestore_platform_interface/test/platform_interface_tests/platform_interface_document_snapshot_test.dart
+++ b/packages/cloud_firestore/cloud_firestore_platform_interface/test/platform_interface_tests/platform_interface_document_snapshot_test.dart
@@ -65,5 +65,10 @@ void main() {
       final snapshot = TestDocumentSnapshot._();
       expect(snapshot.get('foo'), 'bar');
     });
+
+    test("[]", () {
+      final snapshot = TestDocumentSnapshot._();
+      expect(snapshot['foo'], 'bar');
+    });
   });
 }


### PR DESCRIPTION
## Description

Add a [] operator to DocumentSnapshot, acting as get()

## Related Issues

No issues, but the idea came up [here](https://github.com/FirebaseExtended/flutterfire/discussions/3369#discussioncomment-58145)

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] If the pull request affects only one plugin, the PR title starts with the name of the plugin in brackets (e.g. [cloud_firestore])
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
