### PR TITLE
[firebase_auth] Auth exception enum codes

### DIFF
--- a/packages/firebase_auth/firebase_auth_platform_interface/lib/src/auth_exception_status_code.dart
+++ b/packages/firebase_auth/firebase_auth_platform_interface/lib/src/auth_exception_status_code.dart
@@ -1,0 +1,26 @@
+/// The codes of the auth exceptions.
+enum AuthExceptionStatusCode {
+  /// Used if the email address is not valid.
+  invalidEmail,
+
+  /// Used if the user corresponding to the given email has been disabled.
+  userDisabled,
+
+  /// Used if there is no user corresponding to the given email.
+  userNotFound,
+
+  /// Used if the password is invalid for the given email, or the account corresponding to the email does not have a password set.
+  wrongPassword,
+
+  /// Used if the Firebase Authentication quota is reached.
+  tooManyRequests,
+
+  /// Used if specific auth provider is not enabled.
+  operationNotAllowed,
+
+  /// Used if the email exists for multiple Firebase user's providers.
+  accountExistsWithDifferentCredential,
+
+  /// Used if the status is undefined.
+  undefined
+}

--- a/packages/firebase_auth/firebase_auth_platform_interface/lib/src/auth_exception_status_code.dart
+++ b/packages/firebase_auth/firebase_auth_platform_interface/lib/src/auth_exception_status_code.dart
@@ -21,6 +21,9 @@ enum AuthExceptionStatusCode {
   /// Used if the email exists for multiple Firebase user's providers.
   accountExistsWithDifferentCredential,
 
+  /// Used if the request failed due to network issues.
+  networkRequestFailed,
+
   /// Used if the status is undefined.
   undefined
 }

--- a/packages/firebase_auth/firebase_auth_platform_interface/lib/src/firebase_auth_exception.dart
+++ b/packages/firebase_auth/firebase_auth_platform_interface/lib/src/firebase_auth_exception.dart
@@ -56,6 +56,8 @@ class FirebaseAuthException extends FirebaseException implements Exception {
         return AuthExceptionStatusCode.operationNotAllowed;
       case 'account-exists-with-different-credential':
         return AuthExceptionStatusCode.accountExistsWithDifferentCredential;
+      case 'network-request-failed':
+        return AuthExceptionStatusCode.networkRequestFailed;
       default:
         return AuthExceptionStatusCode.undefined;
     }

--- a/packages/firebase_auth/firebase_auth_platform_interface/lib/src/firebase_auth_exception.dart
+++ b/packages/firebase_auth/firebase_auth_platform_interface/lib/src/firebase_auth_exception.dart
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+import 'package:firebase_auth_platform_interface/src/auth_exception_status_code.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:meta/meta.dart';
 import 'auth_credential.dart';
@@ -37,4 +38,26 @@ class FirebaseAuthException extends FirebaseException implements Exception {
 
   /// The tenant ID being used for sign-in/linking.
   final String tenantId;
+
+  /// The exception code parsed into the [AuthExceptionStatusCode] enum.
+  AuthExceptionStatusCode get statusCode {
+    switch (code) {
+      case 'invalid-email':
+        return AuthExceptionStatusCode.invalidEmail;
+      case 'user-disabled':
+        return AuthExceptionStatusCode.userDisabled;
+      case 'user-not-found':
+        return AuthExceptionStatusCode.userNotFound;
+      case 'wrong-password':
+        return AuthExceptionStatusCode.wrongPassword;
+      case 'too-many-requests':
+        return AuthExceptionStatusCode.tooManyRequests;
+      case 'operation-not-allowed':
+        return AuthExceptionStatusCode.operationNotAllowed;
+      case 'account-exists-with-different-credential':
+        return AuthExceptionStatusCode.accountExistsWithDifferentCredential;
+      default:
+        return AuthExceptionStatusCode.undefined;
+    }
+  }
 }


### PR DESCRIPTION
## Description

The `FirebaseAuthException` codes should be static typed to prevent any typo bugs in the client code. Therefore there should be an enum that ensures the AuthException type.

At the same time, this static typed code of the exception serves as an implicit documentation of the possible states of an `FirebaseAuthException`.

## Related Issues
[#3273](https://github.com/FirebaseExtended/flutterfire/issues/3273)

## Checklist
- [x] creating `AuthExceptionStatusCode` enum type.
- [x] add parsing of the exception string codes to the `FirebaseAuthException` class via the `statusCode` getter method.

## Breaking Change

- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
