### PR TITLE
fix(firebase_crashlytics): await _recordError

### DIFF
--- a/packages/firebase_crashlytics/lib/src/firebase_crashlytics.dart
+++ b/packages/firebase_crashlytics/lib/src/firebase_crashlytics.dart
@@ -32,7 +32,7 @@ class Crashlytics {
     // forceReport=true.
     FlutterError.dumpErrorToConsole(details, forceReport: true);
 
-    _recordError(details.exceptionAsString(), details.stack,
+    await _recordError(details.exceptionAsString(), details.stack,
         context: details.context,
         information: details.informationCollector == null
             ? null
@@ -47,7 +47,7 @@ class Crashlytics {
       {dynamic context}) async {
     print('Error caught by Crashlytics plugin <recordError>:');
 
-    _recordError(exception, stack, context: context);
+    await _recordError(exception, stack, context: context);
   }
 
   void crash() {


### PR DESCRIPTION
## Description

Await `_recordError` method, which returns `Future<void>`. Previously, it wasn't awaited. As custom keys setting is a global synchronous operation, previous behavior could result in exceptions custom keys being mixed up in the report.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] If the pull request affects only one plugin, the PR title starts with the name of the plugin in brackets (e.g. [cloud_firestore])
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [ ] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
