### PR TITLE
fix(firebase_auth): check for Stream existence before sending event

### DIFF
--- a/packages/cloud_firestore/cloud_firestore_platform_interface/lib/src/method_channel/method_channel_firestore.dart
+++ b/packages/cloud_firestore/cloud_firestore_platform_interface/lib/src/method_channel/method_channel_firestore.dart
@@ -61,12 +61,20 @@ class MethodChannelFirebaseFirestore extends FirebaseFirestorePlatform {
   /// When a [snapshotsInSync] event is fired on the [MethodChannel], trigger
   /// a new Stream event.
   void _handleSnapshotsInSync(Map<dynamic, dynamic> arguments) async {
+    if (!snapshotInSyncObservers.containsKey(arguments['handle'])) {
+      return;
+    }
+
     snapshotInSyncObservers[arguments['handle']].add(null);
   }
 
   /// When a [QuerySnapshot] event is fired on the [MethodChannel],
   /// add a [MethodChannelQuerySnapshot] to the [StreamController].
   void _handleQuerySnapshotEvent(Map<dynamic, dynamic> arguments) async {
+    if (!queryObservers.containsKey(arguments['handle'])) {
+      return;
+    }
+
     try {
       queryObservers[arguments['handle']]
           .add(MethodChannelQuerySnapshot(this, arguments['snapshot']));
@@ -87,6 +95,10 @@ class MethodChannelFirebaseFirestore extends FirebaseFirestorePlatform {
   /// When a [DocumentSnapshot] event is fired on the [MethodChannel],
   /// add a [DocumentSnapshotPlatform] to the [StreamController].
   void _handleDocumentSnapshotEvent(Map<dynamic, dynamic> arguments) async {
+    if (!documentObservers.containsKey(arguments['handle'])) {
+      return;
+    }
+
     try {
       Map<String, dynamic> snapshotMap =
           Map<String, dynamic>.from(arguments['snapshot']);
@@ -156,7 +168,9 @@ class MethodChannelFirebaseFirestore extends FirebaseFirestorePlatform {
   /// Attach a [FirebaseException] to a given [StreamController].
   void _handleError(
       StreamController controller, Map<dynamic, dynamic> arguments) async {
-    assert(controller != null);
+    if (controller == null) {
+      return;
+    }
 
     if (arguments['error'] is Map) {
       // Map means its an error from Native.


### PR DESCRIPTION
## Description

There's currently a race condition somewhere which causes a native event to be sent to user land after the Dart stream has been removed, causing an error/crash.

This PR adds a check to ensure events are only sent when those Streams are still available.

Although this doesn't fully solve the issue, it does prevent crashes. I don't think there is any side effects here, since if the Dart listener is removed users don't care about the events anyway.

## Related Issues

Resolves https://github.com/FirebaseExtended/flutterfire/issues/3222 & https://github.com/FirebaseExtended/flutterfire/issues/3382

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] If the pull request affects only one plugin, the PR title starts with the name of the plugin in brackets (e.g. [cloud_firestore])
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [ ] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [ ] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
