### PR TITLE
docs(firebase_auth): remove use of toString() on error

### DIFF
--- a/docs/auth/usage.mdx
+++ b/docs/auth/usage.mdx
@@ -133,7 +133,7 @@ try {
     print('The account already exists for that email.');
   }
 } catch (e) {
-  print(e.toString());
+  print(e);
 }
 ```
 


### PR DESCRIPTION
## Description

Use of toString() method  is not required when printing objects to the console as the print(obj) function already uses obj.toString()

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

- [x] No, this is *not* a breaking change.


cc @TahaTesser 