### PR TITLE
docs(cloud_firestore): Fixed docs typo

### DIFF
--- a/packages/cloud_firestore/cloud_firestore/lib/src/document_reference.dart
+++ b/packages/cloud_firestore/cloud_firestore/lib/src/document_reference.dart
@@ -89,7 +89,7 @@ class DocumentReference {
     return set(data, options);
   }
 
-  /// Updates data on the documnent. Data will be merged with any existing
+  /// Updates data on the document. Data will be merged with any existing
   /// document data.
   ///
   /// If no document exists yet, the update will fail.

--- a/packages/cloud_firestore/cloud_firestore_platform_interface/lib/src/blob.dart
+++ b/packages/cloud_firestore/cloud_firestore_platform_interface/lib/src/blob.dart
@@ -9,7 +9,7 @@ import 'package:collection/collection.dart';
 
 /// Represents binary data stored in [Uint8List].
 class Blob {
-  /// Create a blob.
+  /// Creates a blob.
   const Blob(this.bytes);
 
   /// The bytes that are contained in this blob.


### PR DESCRIPTION
## Description

No behavior was changed. Document was spelled as "documnent" in the description of the `update` method for the `DocumentReference` class. This was changed to the correct spelling of "document"

## Related Issues

No related issues.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] If the pull request affects only one plugin, the PR title starts with the name of the plugin in brackets (e.g. [cloud_firestore])
- [X] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [X] All existing and new tests are passing.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [X] I read and followed the [Flutter Style Guide].
- [ ] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [ ] I updated CHANGELOG.md to add a description of the change.
- [X] I signed the [CLA].
- [X] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [X] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
