### PR TITLE
[firebase_messaging] Support Android v2 embedding

### DIFF
--- a/packages/firebase_messaging/CHANGELOG.md
+++ b/packages/firebase_messaging/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 7.0.1
+
+* Add support for Android v2 embedding.
+
 ## 7.0.0
 
 * Depend on `firebase_core` and migrate plugin to use `firebase_core` native SDK versioning features;

--- a/packages/firebase_messaging/CHANGELOG.md
+++ b/packages/firebase_messaging/CHANGELOG.md
@@ -1,6 +1,11 @@
-## 7.0.1
+## 8.0.0
 
 * Add support for Android v2 embedding.
+* **Breaking Change** This will cause applications with v2 embedding that declare the background handler and
+  call `FlutterFirebaseMessagingService.setPluginRegistrant` in their `Application.java` `onCreate` method
+  to crash on startup or when receiving background notifications.
+  To have this plugin work with these applications, you can read the updated README or
+  you can delete your `Application.java` and remove the `android:name=".Application"` reference in your manifest.
 
 ## 7.0.0
 

--- a/packages/firebase_messaging/README.md
+++ b/packages/firebase_messaging/README.md
@@ -73,42 +73,6 @@ By default background messaging is not enabled. To handle messages in the backgr
    
    Note: you can find out what the latest version of the plugin is [here ("Cloud Messaging")](https://firebase.google.com/support/release-notes/android#latest_sdk_versions).
 
-1. Add an `Application.java` class to your app in the same directory as your `MainActivity.java`. This is typically found in `<app-name>/android/app/src/main/java/<app-organization-path>/`.
-
-   ```java
-   package io.flutter.plugins.firebasemessagingexample;
-   
-   import io.flutter.app.FlutterApplication;
-   import io.flutter.plugin.common.PluginRegistry;
-   import io.flutter.plugin.common.PluginRegistry.PluginRegistrantCallback;
-   import io.flutter.plugins.GeneratedPluginRegistrant;
-   import io.flutter.plugins.firebasemessaging.FlutterFirebaseMessagingService;
-   
-   public class Application extends FlutterApplication implements PluginRegistrantCallback {
-     @Override
-     public void onCreate() {
-       super.onCreate();
-       FlutterFirebaseMessagingService.setPluginRegistrant(this);
-     }
-   
-     @Override
-     public void registerWith(PluginRegistry registry) {
-       GeneratedPluginRegistrant.registerWith(registry);
-     }
-   }
-   ```
-
-1. In `Application.java`, make sure to change `package io.flutter.plugins.firebasemessagingexample;` to your package's identifier. Your package's identifier should be something like `com.domain.myapplication`.
-
-   ```java
-   package com.domain.myapplication;
-   ```
-
-1. Set name property of application in `AndroidManifest.xml`. This is typically found in `<app-name>/android/app/src/main/`.
-
-   ```xml
-   <application android:name=".Application" ...>
-   ```
 
 1. Define a **TOP-LEVEL** or **STATIC** function to handle background messages
 
@@ -154,6 +118,51 @@ By default background messaging is not enabled. To handle messages in the backgr
    Note: `configure` should be called early in the lifecycle of your application
    so that it can be ready to receive messages as early as possible. See the
    [example app](https://github.com/FirebaseExtended/flutterfire/tree/master/packages/firebase_messaging/example) for a demonstration.
+
+
+>If you are using a Flutter version prior to 1.12 or you are using v1 embedding, you need to complete additional steps.
+For more information about v1/v2 embedding, check [Upgrading pre 1.12 Android](https://github.com/flutter/flutter/wiki/Upgrading-pre-1.12-Android-projects).
+
+Additional steps for v1 embedding:
+
+1. Add an `Application.java` class to your app in the same directory as your `MainActivity.java`. This is typically found in `<app-name>/android/app/src/main/java/<app-organization-path>/`.
+
+   ```java
+   package io.flutter.plugins.firebasemessagingexample;
+   
+   import io.flutter.app.FlutterApplication;
+   import io.flutter.plugin.common.PluginRegistry;
+   import io.flutter.plugin.common.PluginRegistry.PluginRegistrantCallback;
+   import io.flutter.plugins.GeneratedPluginRegistrant;
+   import io.flutter.plugins.firebasemessaging.FlutterFirebaseMessagingService;
+   
+   public class Application extends FlutterApplication implements PluginRegistrantCallback {
+     @Override
+     public void onCreate() {
+       super.onCreate();
+       FlutterFirebaseMessagingService.setPluginRegistrant(this);
+     }
+   
+     @Override
+     public void registerWith(PluginRegistry registry) {
+       GeneratedPluginRegistrant.registerWith(registry);
+     }
+   }
+   ```
+
+   Note: Calls to `FlutterFirebaseMessagingService.setPluginRegistrant` while using v2 embedding will result in a build time error.
+
+1. In `Application.java`, make sure to change `package io.flutter.plugins.firebasemessagingexample;` to your package's identifier. Your package's identifier should be something like `com.domain.myapplication`.
+
+   ```java
+   package com.domain.myapplication;
+   ```
+
+1. Set name property of application in `AndroidManifest.xml`. This is typically found in `<app-name>/android/app/src/main/`.
+
+   ```xml
+   <application android:name=".Application" ...>
+   ```
 
 ### iOS Integration
 

--- a/packages/firebase_messaging/android/src/main/java/io/flutter/plugins/firebasemessaging/FirebaseMessagingPlugin.java
+++ b/packages/firebase_messaging/android/src/main/java/io/flutter/plugins/firebasemessaging/FirebaseMessagingPlugin.java
@@ -55,6 +55,8 @@ public class FirebaseMessagingPlugin extends BroadcastReceiver
     this.applicationContext = context;
     channel = new MethodChannel(binaryMessenger, "plugins.flutter.io/firebase_messaging");
     channel.setMethodCallHandler(this);
+
+    //Add reference to this class as the MethodCallHandler
     FlutterFirebaseMessagingService.setFirebaseMessagingPlugin(this);
 
     // Register broadcast receiver
@@ -66,9 +68,17 @@ public class FirebaseMessagingPlugin extends BroadcastReceiver
   }
 
   public void initializeBackgroundMethodChannel(BinaryMessenger binaryMessenger) {
+
+    // backgroundChannel is the channel responsible for receiving the following messages from
+    // the background isolate that was setup by this plugin:
+    // - "FcmDartService#initialized"
+    //
+    // This channel is also responsible for sending requests from Android to Dart to execute Dart
+    // callbacks in the background isolate.
     final MethodChannel backgroundCallbackChannel =
         new MethodChannel(binaryMessenger, "plugins.flutter.io/firebase_messaging_background");
     backgroundCallbackChannel.setMethodCallHandler(this);
+
     FlutterFirebaseMessagingService.setBackgroundChannel(backgroundCallbackChannel);
   }
 

--- a/packages/firebase_messaging/android/src/main/java/io/flutter/plugins/firebasemessaging/FirebaseMessagingPlugin.java
+++ b/packages/firebase_messaging/android/src/main/java/io/flutter/plugins/firebasemessaging/FirebaseMessagingPlugin.java
@@ -66,7 +66,8 @@ public class FirebaseMessagingPlugin extends BroadcastReceiver
   }
 
   public void initializeBackgroundMethodChannel(BinaryMessenger binaryMessenger) {
-    final MethodChannel backgroundCallbackChannel = new MethodChannel(binaryMessenger, "plugins.flutter.io/firebase_messaging_background");
+    final MethodChannel backgroundCallbackChannel =
+        new MethodChannel(binaryMessenger, "plugins.flutter.io/firebase_messaging_background");
     backgroundCallbackChannel.setMethodCallHandler(this);
     FlutterFirebaseMessagingService.setBackgroundChannel(backgroundCallbackChannel);
   }

--- a/packages/firebase_messaging/android/src/main/java/io/flutter/plugins/firebasemessaging/FirebaseMessagingPlugin.java
+++ b/packages/firebase_messaging/android/src/main/java/io/flutter/plugins/firebasemessaging/FirebaseMessagingPlugin.java
@@ -54,12 +54,8 @@ public class FirebaseMessagingPlugin extends BroadcastReceiver
   private void onAttachedToEngine(Context context, BinaryMessenger binaryMessenger) {
     this.applicationContext = context;
     channel = new MethodChannel(binaryMessenger, "plugins.flutter.io/firebase_messaging");
-    final MethodChannel backgroundCallbackChannel =
-        new MethodChannel(binaryMessenger, "plugins.flutter.io/firebase_messaging_background");
-
     channel.setMethodCallHandler(this);
-    backgroundCallbackChannel.setMethodCallHandler(this);
-    FlutterFirebaseMessagingService.setBackgroundChannel(backgroundCallbackChannel);
+    FlutterFirebaseMessagingService.setFirebaseMessagingPlugin(this);
 
     // Register broadcast receiver
     IntentFilter intentFilter = new IntentFilter();
@@ -67,6 +63,12 @@ public class FirebaseMessagingPlugin extends BroadcastReceiver
     intentFilter.addAction(FlutterFirebaseMessagingService.ACTION_REMOTE_MESSAGE);
     LocalBroadcastManager manager = LocalBroadcastManager.getInstance(applicationContext);
     manager.registerReceiver(this, intentFilter);
+  }
+
+  public void initializeBackgroundMethodChannel(BinaryMessenger binaryMessenger) {
+    final MethodChannel backgroundCallbackChannel = new MethodChannel(binaryMessenger, "plugins.flutter.io/firebase_messaging_background");
+    backgroundCallbackChannel.setMethodCallHandler(this);
+    FlutterFirebaseMessagingService.setBackgroundChannel(backgroundCallbackChannel);
   }
 
   private void setActivity(Activity flutterActivity) {

--- a/packages/firebase_messaging/android/src/main/java/io/flutter/plugins/firebasemessaging/FlutterFirebaseMessagingService.java
+++ b/packages/firebase_messaging/android/src/main/java/io/flutter/plugins/firebasemessaging/FlutterFirebaseMessagingService.java
@@ -24,8 +24,6 @@ import io.flutter.plugin.common.MethodChannel;
 import io.flutter.plugin.common.PluginRegistry;
 import io.flutter.view.FlutterCallbackInformation;
 import io.flutter.view.FlutterMain;
-import io.flutter.view.FlutterNativeView;
-import io.flutter.view.FlutterRunArguments;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
@@ -74,7 +72,6 @@ public class FlutterFirebaseMessagingService extends FirebaseMessagingService {
   public void onCreate() {
     super.onCreate();
 
-    
     backgroundContext = getApplicationContext();
     //FlutterMain.ensureInitializationComplete(backgroundContext, null);
 
@@ -154,7 +151,7 @@ public class FlutterFirebaseMessagingService extends FirebaseMessagingService {
 
     String appBundlePath = FlutterMain.findAppBundlePath();
     AssetManager assets = context.getAssets();
-    if(!isIsolateRunning.get()){
+    if (!isIsolateRunning.get()) {
       backgroundFlutterEngine = new FlutterEngine(context);
 
       // We need to create an instance of `FlutterEngine` before looking up the
@@ -170,14 +167,13 @@ public class FlutterFirebaseMessagingService extends FirebaseMessagingService {
       executor.executeDartCallback(dartCallback);
 
       // The pluginRegistrantCallback should only be set in the V1 embedding as
-      // plugin registration is done via reflection in the V2 embedding. 
+      // plugin registration is done via reflection in the V2 embedding.
       // If set while using V2 embedding, the application will crash.
       if (pluginRegistrantCallback != null) {
         Log.d(TAG, "Proceeding with v1 embedding");
         pluginRegistrantCallback.registerWith(new ShimPluginRegistry(backgroundFlutterEngine));
       }
     }
-
   }
 
   /**
@@ -198,8 +194,8 @@ public class FlutterFirebaseMessagingService extends FirebaseMessagingService {
   }
 
   /**
-   * Set the Firebase messaging plugin instance that is used to register method channels. This method is only
-   * called when the plugin registers.
+   * Set the Firebase messaging plugin instance that is used to register method channels. This
+   * method is only called when the plugin registers.
    *
    * @param plugin Firebase messaging plugin instance.
    */
@@ -354,5 +350,4 @@ public class FlutterFirebaseMessagingService extends FirebaseMessagingService {
     }
     return false;
   }
-
 }

--- a/packages/firebase_messaging/android/src/main/java/io/flutter/plugins/firebasemessaging/FlutterFirebaseMessagingService.java
+++ b/packages/firebase_messaging/android/src/main/java/io/flutter/plugins/firebasemessaging/FlutterFirebaseMessagingService.java
@@ -50,7 +50,6 @@ public class FlutterFirebaseMessagingService extends FirebaseMessagingService {
   // TODO(kroikie): make isIsolateRunning per-instance, not static.
   private static AtomicBoolean isIsolateRunning = new AtomicBoolean(false);
 
-  /** Background Dart execution context. */
   private static FlutterEngine backgroundFlutterEngine;
 
   private static MethodChannel backgroundChannel;
@@ -73,7 +72,6 @@ public class FlutterFirebaseMessagingService extends FirebaseMessagingService {
     super.onCreate();
 
     backgroundContext = getApplicationContext();
-    //FlutterMain.ensureInitializationComplete(backgroundContext, null);
 
     // If background isolate is not running start it.
     if (!isIsolateRunning.get()) {
@@ -311,6 +309,10 @@ public class FlutterFirebaseMessagingService extends FirebaseMessagingService {
    * message handling is enabled.
    *
    * @param callback Application class which implements PluginRegistrantCallback.
+   * 
+   * <p>Note: this is only necessary for applications using the V1 engine embedding API as plugins
+   * are automatically registered via reflection in the V2 engine embedding API. If not set, messaging
+   * callbacks will not be able to utilize functionality from other plugins nor the background message handler.
    */
   public static void setPluginRegistrant(PluginRegistry.PluginRegistrantCallback callback) {
     pluginRegistrantCallback = callback;

--- a/packages/firebase_messaging/pubspec.yaml
+++ b/packages/firebase_messaging/pubspec.yaml
@@ -2,7 +2,7 @@ name: firebase_messaging
 description: Flutter plugin for Firebase Cloud Messaging, a cross-platform
   messaging solution that lets you reliably deliver messages on Android and iOS.
 homepage: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/firebase_messaging
-version: 7.0.0
+version: 7.0.1
 
 flutter:
   plugin:

--- a/packages/firebase_messaging/pubspec.yaml
+++ b/packages/firebase_messaging/pubspec.yaml
@@ -2,7 +2,7 @@ name: firebase_messaging
 description: Flutter plugin for Firebase Cloud Messaging, a cross-platform
   messaging solution that lets you reliably deliver messages on Android and iOS.
 homepage: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/firebase_messaging
-version: 7.0.1
+version: 8.0.0
 
 flutter:
   plugin:


### PR DESCRIPTION
## Description

The firebase_messaging plugin is not ready for Android v2 embedding. It is currently using v1 embedding and requires the applications to declare a PluginRegistrantCallback to work. **This current behaviour results in a crash** if you don't declare the callback and your application is using v2 embedding. 

To make it work with v2 embedding, and following the [Upgrading pre 1.12 Android projects](https://github.com/flutter/flutter/wiki/Upgrading-pre-1.12-Android-projects) guide and the [Android Alarm Manager](https://github.com/flutter/plugins/tree/master/packages/android_alarm_manager) plugin implementation, this PR has the following changes:

- Removed the references to FlutterMain.ensureInitializationComplete which is called twice in the java code.
- Changed FlutterNativeView related code to FlutterEngine related code.
- Changed pluginRegistrantCallback mandatory requirement to optional (since it will only be used in v1 embedding)

## Related Issues

- [#1754](https://github.com/FirebaseExtended/flutterfire/issues/1754)

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] If the pull request affects only one plugin, the PR title starts with the name of the plugin in brackets (e.g. [cloud_firestore])
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [x] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [ ] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
