### PR TITLE
Add example for Sign-In with Apple

### DIFF
--- a/docs/auth/social.mdx
+++ b/docs/auth/social.mdx
@@ -202,7 +202,81 @@ services (such as Facebook, Twitter, Google etc) must also have an Apple Sign-In
 To integrate Apple Sign-In on your iOS application, you will need to install a 3rd party library to authenticate with Apple.
 Once authentication is successful, a Firebase credential can then be used to sign the user into Firebase with their Apple account
 
-> This example is still TODO. PRs are welcome to provide an example (there's an 'Edit this page' link at the bottom of this page). 
+The example below is based on [sign_in_with_apple](https://pub.dev/packages/sign_in_with_apple) Flutter package.
+
+```dart
+import 'dart:math';
+import 'package:crypto/crypto.dart';
+import 'package:sign_in_with_apple/sign_in_with_apple.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+
+String _createNonce(int length) {
+  final random = Random();
+  final charCodes = List<int>.generate(length, (_) {
+    int codeUnit;
+
+    switch (random.nextInt(3)) {
+      case 0:
+        codeUnit = random.nextInt(10) + 48;
+        break;
+      case 1:
+        codeUnit = random.nextInt(26) + 65;
+        break;
+      case 2:
+        codeUnit = random.nextInt(26) + 97;
+        break;
+    }
+
+    return codeUnit;
+  });
+
+  return String.fromCharCodes(charCodes);
+}
+
+Future<OAuthCredential> _createAppleOAuthCred() async {
+  final nonce = _createNonce(32);
+  final nativeAppleCred = Platform.isIOS
+      ? await SignInWithApple.getAppleIDCredential(
+          scopes: [
+            AppleIDAuthorizationScopes.email,
+            AppleIDAuthorizationScopes.fullName,
+          ],
+          nonce: sha256.convert(utf8.encode(nonce)).toString(),
+        )
+      : await SignInWithApple.getAppleIDCredential(
+          scopes: [
+            AppleIDAuthorizationScopes.email,
+            AppleIDAuthorizationScopes.fullName,
+          ],
+          webAuthenticationOptions: WebAuthenticationOptions(
+            redirectUri: Uri.parse(
+                'https://your-project-name.firebaseapp.com/__/auth/handler'),
+            clientId: 'your.app.bundle.name',
+          ),
+          nonce: sha256.convert(utf8.encode(nonce)).toString(),
+        );
+
+  return new OAuthCredential(
+    providerId: "apple.com", // MUST be "apple.com"
+    signInMethod: "oauth",   // MUST be "oauth"
+    accessToken: nativeAppleCred.identityToken, // propagate Apple ID token to BOTH accessToken and idToken parameters
+    idToken: nativeAppleCred.identityToken,
+    rawNonce: nonce,
+  );
+}
+
+// sign in with Apple OAuth2 credential:
+
+final oauthCred = await _createAppleOAuthCred();
+await FirebaseAuth.instance.signInWithCredential(oauthCred);
+
+// or link Apple OAuth2 credential to existing account:
+
+final oauthCred = await _createAppleOAuthCred();
+await FirebaseAuth.instance.currentUser.linkWithCredential(oauthCred);
+
+```
+
 
 ## Twitter
 

--- a/docs/auth/social.mdx
+++ b/docs/auth/social.mdx
@@ -206,6 +206,8 @@ The example below is based on [sign_in_with_apple](https://pub.dev/packages/sign
 
 ```dart
 import 'dart:math';
+import 'dart:convert';
+import 'dart:io';
 import 'package:crypto/crypto.dart';
 import 'package:sign_in_with_apple/sign_in_with_apple.dart';
 import 'package:firebase_auth/firebase_auth.dart';


### PR DESCRIPTION
The example for Apple Sign-In was tested on iOS. It's supposed to work on Android as well (Android currently seems broken due to [this issue](https://github.com/firebase/firebase-android-sdk/issues/1943))

## Description

*Provide code example for Sign-In with apple*

## Related Issues

*Not applicable*

## Checklist

*Not applicable - no code changes*

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
