### PR TITLE
chore: promote Crashlytics to stable

### DIFF
--- a/packages/firebase_crashlytics/firebase_crashlytics/CHANGELOG.md
+++ b/packages/firebase_crashlytics/firebase_crashlytics/CHANGELOG.md
@@ -1,26 +1,4 @@
-## 0.2.0-dev.5
-
-* Bump to update changelog.
-* See the version `0.2.0-dev.1` changelog for accumulated changes in this dev release.
-
-## 0.2.0-dev.4
-
-* Fixed an error when hot restarting on iOS/macOS (#3432).
-* See the version `0.2.0-dev.1` changelog for accumulated changes in this dev release.
-
-## 0.2.0-dev.3
-
-* Fixed an issue with iOS logs appearing as `null` on the Firebase Console.
-* Ensure cosmetic Android exception classes keep their name when app obfuscated.
-* Fixed an error when hot restarting on Android (#3432).
-* See the version `0.2.0-dev.1` changelog for accumulated changes in this dev release.
-
-## 0.2.0-dev.2
-
-* Fixed an iOS variable naming collision that could cause builds to fail when used alongside `firebase_auth`.
-* See the version `0.2.0-dev.1` changelog for accumulated changes in this dev release.
-
-## 0.2.0-dev.1
+## 0.2.0
 
 For help migrating to this release please see the [migration guide](https://firebase.flutter.dev/docs/migration).
 

--- a/packages/firebase_crashlytics/firebase_crashlytics/pubspec.yaml
+++ b/packages/firebase_crashlytics/firebase_crashlytics/pubspec.yaml
@@ -2,7 +2,7 @@ name: firebase_crashlytics
 description:
   Flutter plugin for Firebase Crashlytics. It reports uncaught errors to the
   Firebase console.
-version: 0.2.0-dev.5
+version: 0.2.0
 homepage: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/firebase_crashlytics
 
 flutter:
@@ -22,7 +22,7 @@ dependencies:
   stack_trace: ^1.9.5
   firebase_core: ^0.5.0
   firebase_core_platform_interface: ^2.0.0
-  firebase_crashlytics_platform_interface: ^1.0.0-dev.2
+  firebase_crashlytics_platform_interface: ^1.0.0
 
 dev_dependencies:
   pedantic: ^1.8.0

--- a/packages/firebase_crashlytics/firebase_crashlytics_platform_interface/CHANGELOG.md
+++ b/packages/firebase_crashlytics/firebase_crashlytics_platform_interface/CHANGELOG.md
@@ -1,7 +1,3 @@
-## 1.0.0-dev.2
-
-* Fixed various code documentation typos.
-
-## 1.0.0-dev.1
+## 1.0.0
 
 * Initial release of the `firebase_crashlytics_platform_interface` package.

--- a/packages/firebase_crashlytics/firebase_crashlytics_platform_interface/pubspec.yaml
+++ b/packages/firebase_crashlytics/firebase_crashlytics_platform_interface/pubspec.yaml
@@ -1,6 +1,6 @@
 name: firebase_crashlytics_platform_interface
 description: A common platform interface for the firebase_crashlytics plugin.
-version: 1.0.0-dev.2
+version: 1.0.0
 homepage: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/firebase_crashlytics/firebase_crashlytics_platform_interface
 
 dependencies:


### PR DESCRIPTION
## Description

Promoting Crashlytics to a stable release version. Additionally includes changes from https://github.com/FirebaseExtended/flutterfire/pull/3334.

## Related Issues

N/A

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] If the pull request affects only one plugin, the PR title starts with the name of the plugin in brackets (e.g. [cloud_firestore])
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [x] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [ ] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
