### PR TITLE
fix(firebase_crashlytics): Change minimum version of stack_trace package

### DIFF
--- a/packages/firebase_crashlytics/firebase_crashlytics/pubspec.yaml
+++ b/packages/firebase_crashlytics/firebase_crashlytics/pubspec.yaml
@@ -19,7 +19,7 @@ flutter:
 dependencies:
   flutter:
     sdk: flutter
-  stack_trace: ^1.9.5
+  stack_trace: ^1.9.3
   firebase_core: ^0.5.0
   firebase_core_platform_interface: ^2.0.0
   firebase_crashlytics_platform_interface: ^1.0.0


### PR DESCRIPTION
## Description

Change minimum version of stack_trace package dependency to ^1.9.3 to support the minimum flutter version we support.
I have not updated the changelog in hopes that this can make it in to the published 2.0 release... (in which case, it's not a change)

## Related Issues

fixes #3503 

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] If the pull request affects only one plugin, the PR title starts with the name of the plugin in brackets (e.g. [cloud_firestore])
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
