### PR TITLE
docs: fix typo in getting started guide

### DIFF
--- a/docs/overview.mdx
+++ b/docs/overview.mdx
@@ -101,7 +101,7 @@ void main() {
 }
 
 class App extends StatelessWidget {
-  // Create the initilization Future outside of `build`:
+  // Create the initialization Future outside of `build`:
   final Future<FirebaseApp> _initialization = Firebase.initializeApp();
 
   @override


### PR DESCRIPTION
From "initilization" to "initialization".