### PR TITLE
docs: update section on Android package name

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -48,3 +48,4 @@ Stephen Beitzel <sbeitzel@pobox.com>
 Mark Veenstra <markdark81@gmail.com>
 Ben Hagen <ben@ottomatic.io>
 Yongliang Zhan <yzhan94@gmail.com>
+Akora Ing. DKB <akoraingdkb@gmail.com>

--- a/docs/installation/android.mdx
+++ b/docs/installation/android.mdx
@@ -10,8 +10,8 @@ On the [Firebase Console](https://console.firebase.google.com/project/_/overview
 existing Android app for your Firebase project.
 
 The "Android package name" must match your local project's package name that was created when you started the
-Flutter project. The current package name can be found in the `manifest` tag within the project's
-`/android/app/src/main/AndroidManifest.xml` file.
+Flutter project. The current package name can be found in your module (app-level) Gradle file,
+usually `android/app/build.gradle`, `defaultConfig` section (example package name: `com.yourcompany.yourproject`).
 
 > When creating a new Android app "debug signing certificate SHA-1" is optional, however, it is required for Dynamic Links
 > & Phone Authentication. To generate a certificate run `cd android && ./gradlew signingReport` and copy the SHA1 from


### PR DESCRIPTION
## Description

This PR updated the [paragraph](https://firebase.flutter.dev/docs/installation/android#generating-a-firebase-project-configuration-file) that talks about adding the package name when setting up Firebase for Android to match the [official documentation](https://firebase.google.com/docs/android/setup#register-app).

## Related Issues

Fixes [3698]

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] If the pull request affects only one plugin, the PR title starts with the name of the plugin in brackets (e.g. [cloud_firestore])
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [ ] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [ ] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[3698]: https://github.com/FirebaseExtended/flutterfire/issues/3698
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
