### PR TITLE
fix: remove `platform` package usage

### DIFF
--- a/packages/firebase_admob/pubspec.yaml
+++ b/packages/firebase_admob/pubspec.yaml
@@ -15,7 +15,6 @@ flutter:
 
 dependencies:
   meta: ^1.0.4
-  platform: ^2.0.0
   flutter:
     sdk: flutter
   firebase_core: ^0.5.0

--- a/packages/firebase_messaging/lib/firebase_messaging.dart
+++ b/packages/firebase_messaging/lib/firebase_messaging.dart
@@ -9,7 +9,6 @@ import 'dart:ui';
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 import 'package:meta/meta.dart';
-import 'package:platform/platform.dart';
 
 typedef Future<dynamic> MessageHandler(Map<String, dynamic> message);
 
@@ -58,16 +57,12 @@ class FirebaseMessaging {
   factory FirebaseMessaging() => _instance;
 
   @visibleForTesting
-  FirebaseMessaging.private(MethodChannel channel, Platform platform)
-      : _channel = channel,
-        _platform = platform;
+  FirebaseMessaging.private(MethodChannel channel) : _channel = channel;
 
   static final FirebaseMessaging _instance = FirebaseMessaging.private(
-      const MethodChannel('plugins.flutter.io/firebase_messaging'),
-      const LocalPlatform());
+      const MethodChannel('plugins.flutter.io/firebase_messaging'));
 
   final MethodChannel _channel;
-  final Platform _platform;
 
   MessageHandler _onMessage;
   MessageHandler _onBackgroundMessage;
@@ -81,7 +76,7 @@ class FirebaseMessaging {
   FutureOr<bool> requestNotificationPermissions([
     IosNotificationSettings iosSettings = const IosNotificationSettings(),
   ]) {
-    if (!_platform.isIOS) {
+    if (!Platform.isIOS) {
       return null;
     }
     return _channel.invokeMethod<bool>(

--- a/packages/firebase_messaging/lib/firebase_messaging.dart
+++ b/packages/firebase_messaging/lib/firebase_messaging.dart
@@ -3,12 +3,13 @@
 // found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:io';
 import 'dart:ui';
 
 import 'package:flutter/services.dart';
 import 'package:flutter/widgets.dart';
 import 'package:meta/meta.dart';
+import 'package:flutter/foundation.dart'
+    show defaultTargetPlatform, TargetPlatform;
 
 typedef Future<dynamic> MessageHandler(Map<String, dynamic> message);
 
@@ -76,7 +77,7 @@ class FirebaseMessaging {
   FutureOr<bool> requestNotificationPermissions([
     IosNotificationSettings iosSettings = const IosNotificationSettings(),
   ]) {
-    if (!Platform.isIOS) {
+    if (defaultTargetPlatform != TargetPlatform.iOS) {
       return null;
     }
     return _channel.invokeMethod<bool>(

--- a/packages/firebase_messaging/pubspec.yaml
+++ b/packages/firebase_messaging/pubspec.yaml
@@ -15,7 +15,6 @@ flutter:
 
 dependencies:
   meta: ^1.0.4
-  platform: ^2.0.0
   flutter:
     sdk: flutter
   firebase_core: ^0.5.0

--- a/packages/firebase_messaging/test/firebase_messaging_test.dart
+++ b/packages/firebase_messaging/test/firebase_messaging_test.dart
@@ -3,13 +3,14 @@
 // found in the LICENSE file.
 
 import 'dart:async';
-import 'dart:io';
 
 import 'package:flutter/services.dart';
 import 'package:firebase_messaging/firebase_messaging.dart';
 import 'package:flutter_test/flutter_test.dart' show TestWidgetsFlutterBinding;
 import 'package:mockito/mockito.dart';
 import 'package:test/test.dart';
+import 'package:flutter/foundation.dart'
+    show defaultTargetPlatform, TargetPlatform;
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
@@ -31,7 +32,7 @@ void main() {
       'alert': true,
       'provisional': false
     }));
-  }, skip: !Platform.isIOS);
+  }, skip: defaultTargetPlatform != TargetPlatform.iOS);
 
   test('requestNotificationPermissions on ios with custom permissions', () {
     firebaseMessaging.requestNotificationPermissions(

--- a/packages/firebase_messaging/test/firebase_messaging_test.dart
+++ b/packages/firebase_messaging/test/firebase_messaging_test.dart
@@ -3,12 +3,12 @@
 // found in the LICENSE file.
 
 import 'dart:async';
+import 'dart:io';
 
 import 'package:flutter/services.dart';
 import 'package:firebase_messaging/firebase_messaging.dart';
 import 'package:flutter_test/flutter_test.dart' show TestWidgetsFlutterBinding;
 import 'package:mockito/mockito.dart';
-import 'package:platform/platform.dart';
 import 'package:test/test.dart';
 
 void main() {
@@ -19,8 +19,7 @@ void main() {
 
   setUp(() {
     mockChannel = MockMethodChannel();
-    firebaseMessaging = FirebaseMessaging.private(
-        mockChannel, FakePlatform(operatingSystem: 'ios'));
+    firebaseMessaging = FirebaseMessaging.private(mockChannel);
   });
 
   test('requestNotificationPermissions on ios with default permissions', () {
@@ -32,7 +31,7 @@ void main() {
       'alert': true,
       'provisional': false
     }));
-  });
+  }, skip: !Platform.isIOS);
 
   test('requestNotificationPermissions on ios with custom permissions', () {
     firebaseMessaging.requestNotificationPermissions(
@@ -44,22 +43,6 @@ void main() {
       'alert': true,
       'provisional': true
     }));
-  });
-
-  test('requestNotificationPermissions on android', () {
-    firebaseMessaging = FirebaseMessaging.private(
-        mockChannel, FakePlatform(operatingSystem: 'android'));
-
-    firebaseMessaging.requestNotificationPermissions();
-    verifyZeroInteractions(mockChannel);
-  });
-
-  test('requestNotificationPermissions on android', () {
-    firebaseMessaging = FirebaseMessaging.private(
-        mockChannel, FakePlatform(operatingSystem: 'android'));
-
-    firebaseMessaging.requestNotificationPermissions();
-    verifyZeroInteractions(mockChannel);
   });
 
   test('configure', () {

--- a/packages/firebase_messaging/test/firebase_messaging_test.dart
+++ b/packages/firebase_messaging/test/firebase_messaging_test.dart
@@ -44,7 +44,7 @@ void main() {
       'alert': true,
       'provisional': true
     }));
-  });
+  }, skip: defaultTargetPlatform != TargetPlatform.iOS);
 
   test('configure', () {
     firebaseMessaging.configure();
@@ -84,7 +84,7 @@ void main() {
     iosSettingsFromStream = firebaseMessaging.onIosSettingsRegistered.first;
     await handler(MethodCall('onIosSettingsRegistered', iosSettings.toMap()));
     expect((await iosSettingsFromStream).toMap(), iosSettings.toMap());
-  });
+  }, skip: defaultTargetPlatform != TargetPlatform.iOS);
 
   test('incoming messages', () async {
     final Completer<dynamic> onMessage = Completer<dynamic>();


### PR DESCRIPTION
## Description

`platform` package is currently causing issues with versioning. Removing for now. 

Not in use on `admob` anyway.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`). This will ensure a smooth and quick review process.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] If the pull request affects only one plugin, the PR title starts with the name of the plugin in brackets (e.g. [cloud_firestore])
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [ ] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
