### PR TITLE
fix(cloud_firestore): fix returning of transaction result

### DIFF
--- a/packages/cloud_firestore/cloud_firestore/lib/src/firestore.dart
+++ b/packages/cloud_firestore/cloud_firestore/lib/src/firestore.dart
@@ -168,11 +168,15 @@ class FirebaseFirestore extends FirebasePluginPlatform {
   /// By default transactions are limited to 5 seconds of execution time. This
   /// timeout can be adjusted by setting the timeout parameter.
   Future<T> runTransaction<T>(TransactionHandler<T> transactionHandler,
-      {Duration timeout = const Duration(seconds: 30)}) {
+      {Duration timeout = const Duration(seconds: 30)}) async {
     assert(transactionHandler != null, "transactionHandler cannot be null");
-    return _delegate.runTransaction<T>((transaction) {
-      return transactionHandler(Transaction._(this, transaction));
+
+    T output;
+    await _delegate.runTransaction((transaction) async {
+      output = await transactionHandler(Transaction._(this, transaction));
     }, timeout: timeout);
+
+    return output;
   }
 
   /// Specifies custom settings to be used to configure this [FirebaseFirestore] instance.

--- a/packages/cloud_firestore/cloud_firestore_platform_interface/lib/src/method_channel/method_channel_firestore.dart
+++ b/packages/cloud_firestore/cloud_firestore_platform_interface/lib/src/method_channel/method_channel_firestore.dart
@@ -341,6 +341,8 @@ class MethodChannelFirebaseFirestore extends FirebaseFirestorePlatform {
       exception = e;
     });
 
+    // The #create call only resolves once all transaction attempts have succeeded
+    // or something failed.
     await channel.invokeMethod<T>('Transaction#create', <String, dynamic>{
       'firestore': this,
       'transactionId': transactionId,
@@ -349,7 +351,7 @@ class MethodChannelFirebaseFirestore extends FirebaseFirestorePlatform {
       exception = e;
     });
 
-    // The transaction is successful, cleanup the stream
+    // The transaction has completed (may have errored), cleanup the stream
     await subscription.cancel();
     _transactionStreamControllerHandlers.remove(transactionId);
 

--- a/packages/cloud_firestore/cloud_firestore_web/lib/cloud_firestore_web.dart
+++ b/packages/cloud_firestore/cloud_firestore_web/lib/cloud_firestore_web.dart
@@ -86,16 +86,15 @@ class FirebaseFirestoreWeb extends FirebaseFirestorePlatform {
   // }
 
   @override
-  Future<T> runTransaction<T>(TransactionHandler transactionHandler,
+  Future<T> runTransaction<T>(TransactionHandler<T> transactionHandler,
       {Duration timeout = const Duration(seconds: 30)}) async {
     try {
-      dynamic result = await _webFirestore.runTransaction((transaction) async {
+      await _webFirestore.runTransaction((transaction) async {
         return transactionHandler(
             TransactionWeb(this, _webFirestore, transaction));
       }).timeout(timeout);
-      // Workaround for 'Runtime type information not available for type_variable_local'
-      // See: https://github.com/dart-lang/sdk/issues/29722
-      return result as T;
+
+      return null;
     } catch (e) {
       throw getFirebaseException(e);
     }


### PR DESCRIPTION
## Description

This fixes an issue (specifically for web) whereby returning a none-standard value from a transaction threw an error. This change ignores the return value of the delegate transaction handler and instead only returns the user result.

## Related Issues

- Fixes https://github.com/FirebaseExtended/flutterfire/issues/3495

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] If the pull request affects only one plugin, the PR title starts with the name of the plugin in brackets (e.g. [cloud_firestore])
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
