### PR TITLE
docs(firebase_crashlytics): corrects plugin apply location

### DIFF
--- a/docs/crashlytics/overview.mdx
+++ b/docs/crashlytics/overview.mdx
@@ -50,14 +50,16 @@ dependencies {
 }
 ```
 
-2. Apply the following to the bottom of your `android/app/build.gradle` file.
+2. Apply the following to your `android/app/build.gradle` file.
 
-```groovy {5} title="android/app/build.gradle"
-dependencies {
-  // ... your dependencies
-}
+```groovy {3} title="android/app/build.gradle"
+// ... other imports
 
 apply plugin: 'com.google.firebase.crashlytics'
+
+android {
+  // ... your android config
+}
 ```
 
 #### b. iOS


### PR DESCRIPTION
## Description

This fixes a small error in the crashlytics overview docs where it is incorrectly stated that the plugin should be applied at the bottom of the file.

## Related Issues

- [Issue #3741](https://github.com/FirebaseExtended/flutterfire/issues/3741)

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] If the pull request affects only one plugin, the PR title starts with the name of the plugin in brackets (e.g. [cloud_firestore])
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
