### PR TITLE
docs(admob): update README.md to use kotlin instead of java

### DIFF
--- a/packages/firebase_admob/README.md
+++ b/packages/firebase_admob/README.md
@@ -271,7 +271,7 @@ identifier after adding the `FirebaseAdMobPlugin` to the `FlutterEngine`. (Addin
 future, so you may not see it being added here). You should also unregister the factory in
 `cleanUpFlutterEngine(engine)`.
 
-You're `MainActivity.kt` should look similar to:
+Your `MainActivity.kt` should look similar to:
 
 ```kotlin
 package my.app.path

--- a/packages/firebase_admob/README.md
+++ b/packages/firebase_admob/README.md
@@ -17,7 +17,7 @@ to do so will result in a crash on launch of your app.  The line should look lik
     android:value="[ADMOB_APP_ID]"/>
 ```
 
-where `[ADMOB_APP_ID]` is your App ID.  You must pass the same value when you 
+where `[ADMOB_APP_ID]` is your App ID.  You must pass the same value when you
 initialize the plugin in your Dart code.
 
 See https://goo.gl/fQ2neu for more information about configuring `AndroidManifest.xml`
@@ -58,7 +58,7 @@ Starting in version 17.0.0, if you are an AdMob publisher you are now required t
 
 Failure to add this tag will result in the app crashing at app launch with a message starting with *"The Google Mobile Ads SDK was initialized incorrectly."*
 
-On Android, this value must be the same as the App ID value set in your 
+On Android, this value must be the same as the App ID value set in your
 `AndroidManifest.xml`.
 
 ### iOS
@@ -79,13 +79,13 @@ You are also required to ensure that you have Google Service file from Firebase 
 
 ### iOS
 
-Create an "App" in firebase and generate a GoogleService-info.plist file. This file needs to be embedded in the projects "Runner/Runner" folder using Xcode. 
+Create an "App" in firebase and generate a GoogleService-info.plist file. This file needs to be embedded in the projects "Runner/Runner" folder using Xcode.
 
 https://firebase.google.com/docs/ios/setup#create-firebase-project -> Steps 1-3
 
 ### Android
 
-Create an "App" in firebase and generate a google-service.json file. This file needs to be embedded in you projects "android/app" folder. 
+Create an "App" in firebase and generate a google-service.json file. This file needs to be embedded in you projects "android/app" folder.
 
 https://firebase.google.com/docs/android/setup#create-firebase-project -> Steps 1-3.1
 
@@ -217,23 +217,24 @@ that takes a
 and custom options and returns a
 [UnifiedNativeAdView](https://developers.google.com/android/reference/com/google/android/gms/ads/formats/UnifiedNativeAdView).
 
-You can implement this in your `MainActivity.java` or create a separate class in the same directory
-as `MainActivity.java` as seen below:
+You can implement this in your `MainActivity.kt` or create a separate class in the same directory
+as `MainActivity.kt` as seen below:
 
-```java
-package my.app.path;
+```kotlin
+package my.app.path
 
-import com.google.android.gms.ads.formats.UnifiedNativeAd;
-import com.google.android.gms.ads.formats.UnifiedNativeAdView;
-import io.flutter.plugins.firebaseadmob.FirebaseAdMobPlugin.NativeAdFactory;
-import java.util.Map;
+import com.google.android.gms.ads.formats.UnifiedNativeAd
+import com.google.android.gms.ads.formats.UnifiedNativeAdView
+import io.flutter.plugins.firebaseadmob.FirebaseAdMobPlugin.NativeAdFactory
+import kotlin.collections.Map
 
-class NativeAdFactoryExample implements NativeAdFactory {
-  @Override
-  public UnifiedNativeAdView createNativeAd(
-      UnifiedNativeAd nativeAd, Map<String, Object> customOptions) {
-    // Create UnifiedNativeAdView
-  }
+class NativeAdFactoryExample : NativeAdFactory {
+    override fun createNativeAd(
+        nativeAd: UnifiedNativeAd,
+        customOptions: Map<String, Any>
+    ): UnifiedNativeAdView {
+        // Create UnifiedNativeAdView
+    }
 }
 ```
 
@@ -241,26 +242,26 @@ An instance of a `NativeAdFactory` should also be added to the `FirebaseAdMobPlu
 slightly differently depending on whether you are using Embedding V1 or Embedding V2.
 
 If you're using the Embedding V1, you need to register your `NativeAdFactory` with a unique `String`
-identifier after calling `GeneratedPluginRegistrant.registerWith(this);`.
+identifier after calling `GeneratedPluginRegistrant.registerWith(this@MainActivity)`.
 
-You're `MainActivity.java` should look similar to:
+Your `MainActivity.kt` should look similar to:
 
-```java
-package my.app.path;
+```kotlin
+package my.app.path
 
-import android.os.Bundle;
-import io.flutter.app.FlutterActivity;
-import io.flutter.plugins.GeneratedPluginRegistrant;
-import io.flutter.plugins.firebaseadmob.FirebaseAdMobPlugin;
+import android.os.Bundle
+import io.flutter.app.FlutterActivity
+import io.flutter.plugins.GeneratedPluginRegistrant
+import io.flutter.plugins.firebaseadmob.FirebaseAdMobPlugin
 
-public class MainActivity extends FlutterActivity {
-  @Override
-  protected void onCreate(Bundle savedInstanceState) {
-    super.onCreate(savedInstanceState);
-    GeneratedPluginRegistrant.registerWith(this);
+class MainActivity : FlutterActivity {
+    override fun onCreate(savedInstanceState: Bundle) {
+        super.onCreate(savedInstanceState)
+        GeneratedPluginRegistrant.registerWith(this@MainActivity)
 
-    FirebaseAdMobPlugin.registerNativeAdFactory(this, "adFactoryExample", new NativeAdFactoryExample());
-  }
+        FirebaseAdMobPlugin.registerNativeAdFactory(this@MainActivity, "adFactoryExample",
+           NativeAdFactoryExample())
+    }
 }
 ```
 
@@ -270,27 +271,25 @@ identifier after adding the `FirebaseAdMobPlugin` to the `FlutterEngine`. (Addin
 future, so you may not see it being added here). You should also unregister the factory in
 `cleanUpFlutterEngine(engine)`.
 
-You're `MainActivity.java` should look similar to:
+You're `MainActivity.kt` should look similar to:
 
-```java
-package my.app.path;
+```kotlin
+package my.app.path
 
-import io.flutter.embedding.android.FlutterActivity;
-import io.flutter.embedding.engine.FlutterEngine;
-import io.flutter.plugins.firebaseadmob.FirebaseAdMobPlugin;
+import io.flutter.embedding.android.FlutterActivity
+import io.flutter.embedding.engine.FlutterEngine
+import io.flutter.plugins.firebaseadmob.FirebaseAdMobPlugin
 
-public class MainActivity extends FlutterActivity {
-  @Override
-  public void configureFlutterEngine(FlutterEngine flutterEngine) {
-    flutterEngine.getPlugins().add(new FirebaseAdMobPlugin());
+class MainActivity : FlutterActivity {
+    override fun configureFlutterEngine(flutterEngine: FlutterEngine) {
+        flutterEngine.getPlugins().add(FirebaseAdMobPlugin())
 
-    FirebaseAdMobPlugin.registerNativeAdFactory(flutterEngine, "adFactoryExample", NativeAdFactoryExample());
-  }
+        FirebaseAdMobPlugin.registerNativeAdFactory(flutterEngine, "adFactoryExample", NativeAdFactoryExample());
+    }
 
-  @Override
-  public void cleanUpFlutterEngine(FlutterEngine flutterEngine) {
-    FirebaseAdMobPlugin.unregisterNativeAdFactory(flutterEngine, "adFactoryExample");
-  }
+    override fun cleanUpFlutterEngine(flutterEngine: FlutterEngine) {
+        FirebaseAdMobPlugin.unregisterNativeAdFactory(flutterEngine, "adFactoryExample")
+    }
 }
 ```
 

--- a/packages/firebase_messaging/README.md
+++ b/packages/firebase_messaging/README.md
@@ -66,40 +66,42 @@ By default background messaging is not enabled. To handle messages in the backgr
    ```gradle
    dependencies {
      // ...
-
+   
      implementation 'com.google.firebase:firebase-messaging:<latest_version>'
    }
    ```
-
+   
    Note: you can find out what the latest version of the plugin is [here ("Cloud Messaging")](https://firebase.google.com/support/release-notes/android#latest_sdk_versions).
 
-1. Add an `Application.kt` class to your app in the same directory as your `MainActivity.kt`. This is typically found in `<app-name>/android/app/src/main/kotlin/<app-organization-path>/`.
+1. Add an `Application.java` class to your app in the same directory as your `MainActivity.java`. This is typically found in `<app-name>/android/app/src/main/java/<app-organization-path>/`.
 
-   ```kotlin
-   package io.flutter.plugins.firebasemessagingexample
-
-   import io.flutter.app.FlutterApplication
-   import io.flutter.plugin.common.PluginRegistry
-   import io.flutter.plugin.common.PluginRegistry.PluginRegistrantCallback
-   import io.flutter.plugins.GeneratedPluginRegistrant
-   import io.flutter.plugins.firebasemessaging.FlutterFirebaseMessagingService
-
-   class Application : FlutterApplications, PluginRegistrantCallback {
-       override fun onCreate() {
-           super.onCreate()
-           FlutterFirebaseMessagingService.setPluginRegistrant(this@Application)
-       }
-
-       override fun registerWith(registry: PluginRegistry) {
-           GeneratedPluginRegistrant.registerWith(registry)
-       }
+   ```java
+   package io.flutter.plugins.firebasemessagingexample;
+   
+   import io.flutter.app.FlutterApplication;
+   import io.flutter.plugin.common.PluginRegistry;
+   import io.flutter.plugin.common.PluginRegistry.PluginRegistrantCallback;
+   import io.flutter.plugins.GeneratedPluginRegistrant;
+   import io.flutter.plugins.firebasemessaging.FlutterFirebaseMessagingService;
+   
+   public class Application extends FlutterApplication implements PluginRegistrantCallback {
+     @Override
+     public void onCreate() {
+       super.onCreate();
+       FlutterFirebaseMessagingService.setPluginRegistrant(this);
+     }
+   
+     @Override
+     public void registerWith(PluginRegistry registry) {
+       GeneratedPluginRegistrant.registerWith(registry);
+     }
    }
    ```
 
-1. In `Application.kt`, make sure to change `package io.flutter.plugins.firebasemessagingexample` to your package's identifier. Your package's identifier should be something like `com.domain.myapplication`.
+1. In `Application.java`, make sure to change `package io.flutter.plugins.firebasemessagingexample;` to your package's identifier. Your package's identifier should be something like `com.domain.myapplication`.
 
-   ```kotlin
-   package com.domain.myapplication
+   ```java
+   package com.domain.myapplication;
    ```
 
 1. Set name property of application in `AndroidManifest.xml`. This is typically found in `<app-name>/android/app/src/main/`.
@@ -116,18 +118,18 @@ By default background messaging is not enabled. To handle messages in the backgr
        // Handle data message
        final dynamic data = message['data'];
      }
-
+   
      if (message.containsKey('notification')) {
        // Handle notification message
        final dynamic notification = message['notification'];
      }
-
+   
      // Or do other work.
    }
    ```
 
    Note: the protocol of `data` and `notification` are in line with the
-   fields defined by a [RemoteMessage](https://firebase.google.com/docs/reference/android/com/google/firebase/messaging/RemoteMessage).
+   fields defined by a [RemoteMessage](https://firebase.google.com/docs/reference/android/com/google/firebase/messaging/RemoteMessage). 
 
 1. Set `onBackgroundMessage` handler when calling `configure`
 

--- a/packages/firebase_messaging/README.md
+++ b/packages/firebase_messaging/README.md
@@ -66,42 +66,40 @@ By default background messaging is not enabled. To handle messages in the backgr
    ```gradle
    dependencies {
      // ...
-   
+
      implementation 'com.google.firebase:firebase-messaging:<latest_version>'
    }
    ```
-   
+
    Note: you can find out what the latest version of the plugin is [here ("Cloud Messaging")](https://firebase.google.com/support/release-notes/android#latest_sdk_versions).
 
-1. Add an `Application.java` class to your app in the same directory as your `MainActivity.java`. This is typically found in `<app-name>/android/app/src/main/java/<app-organization-path>/`.
+1. Add an `Application.kt` class to your app in the same directory as your `MainActivity.kt`. This is typically found in `<app-name>/android/app/src/main/kotlin/<app-organization-path>/`.
 
-   ```java
-   package io.flutter.plugins.firebasemessagingexample;
-   
-   import io.flutter.app.FlutterApplication;
-   import io.flutter.plugin.common.PluginRegistry;
-   import io.flutter.plugin.common.PluginRegistry.PluginRegistrantCallback;
-   import io.flutter.plugins.GeneratedPluginRegistrant;
-   import io.flutter.plugins.firebasemessaging.FlutterFirebaseMessagingService;
-   
-   public class Application extends FlutterApplication implements PluginRegistrantCallback {
-     @Override
-     public void onCreate() {
-       super.onCreate();
-       FlutterFirebaseMessagingService.setPluginRegistrant(this);
-     }
-   
-     @Override
-     public void registerWith(PluginRegistry registry) {
-       GeneratedPluginRegistrant.registerWith(registry);
-     }
+   ```kotlin
+   package io.flutter.plugins.firebasemessagingexample
+
+   import io.flutter.app.FlutterApplication
+   import io.flutter.plugin.common.PluginRegistry
+   import io.flutter.plugin.common.PluginRegistry.PluginRegistrantCallback
+   import io.flutter.plugins.GeneratedPluginRegistrant
+   import io.flutter.plugins.firebasemessaging.FlutterFirebaseMessagingService
+
+   class Application : FlutterApplications, PluginRegistrantCallback {
+       override fun onCreate() {
+           super.onCreate()
+           FlutterFirebaseMessagingService.setPluginRegistrant(this@Application)
+       }
+
+       override fun registerWith(registry: PluginRegistry) {
+           GeneratedPluginRegistrant.registerWith(registry)
+       }
    }
    ```
 
-1. In `Application.java`, make sure to change `package io.flutter.plugins.firebasemessagingexample;` to your package's identifier. Your package's identifier should be something like `com.domain.myapplication`.
+1. In `Application.kt`, make sure to change `package io.flutter.plugins.firebasemessagingexample` to your package's identifier. Your package's identifier should be something like `com.domain.myapplication`.
 
-   ```java
-   package com.domain.myapplication;
+   ```kotlin
+   package com.domain.myapplication
    ```
 
 1. Set name property of application in `AndroidManifest.xml`. This is typically found in `<app-name>/android/app/src/main/`.
@@ -118,18 +116,18 @@ By default background messaging is not enabled. To handle messages in the backgr
        // Handle data message
        final dynamic data = message['data'];
      }
-   
+
      if (message.containsKey('notification')) {
        // Handle notification message
        final dynamic notification = message['notification'];
      }
-   
+
      // Or do other work.
    }
    ```
 
    Note: the protocol of `data` and `notification` are in line with the
-   fields defined by a [RemoteMessage](https://firebase.google.com/docs/reference/android/com/google/firebase/messaging/RemoteMessage). 
+   fields defined by a [RemoteMessage](https://firebase.google.com/docs/reference/android/com/google/firebase/messaging/RemoteMessage).
 
 1. Set `onBackgroundMessage` handler when calling `configure`
 


### PR DESCRIPTION
## Description

As mentioned in #3601, bootstrapping a Flutter app, now generates the `MainActivity` in Kotlin, instead of java.
This PR should update the `README.md` files in the `firebase_admob` ~and `firebase_messaging`~ package to show Kotlin usage instead of java.

**Update:** I have reverted the firebase_messaging changes in favor of #3457 

## Related Issues

Fix #3601 

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
