### PR TITLE
Added isNotEqual to Firestore

### DIFF
--- a/packages/cloud_firestore/cloud_firestore/ios/Classes/FLTFirebaseFirestoreReader.m
+++ b/packages/cloud_firestore/cloud_firestore/ios/Classes/FLTFirebaseFirestoreReader.m
@@ -143,6 +143,8 @@
       id value = condition[2];
       if ([operator isEqualToString:@"=="]) {
         query = [query queryWhereFieldPath:fieldPath isEqualTo:value];
+      } else if ([operator isEqualToString:@"!="]) {
+        query = [query queryWhereFieldPath:fieldPath isNotEqualTo:value];
       } else if ([operator isEqualToString:@"<"]) {
         query = [query queryWhereFieldPath:fieldPath isLessThan:value];
       } else if ([operator isEqualToString:@"<="]) {

--- a/packages/cloud_firestore/cloud_firestore/lib/src/query.dart
+++ b/packages/cloud_firestore/cloud_firestore/lib/src/query.dart
@@ -339,6 +339,7 @@ class Query {
   Query where(
     dynamic field, {
     dynamic isEqualTo,
+    dynamic isNotEqualTo,
     dynamic isLessThan,
     dynamic isLessThanOrEqualTo,
     dynamic isGreaterThan,
@@ -376,6 +377,7 @@ class Query {
     }
 
     if (isEqualTo != null) addCondition(field, '==', isEqualTo);
+    if (isNotEqualTo != null) addCondition(field, '!=', isNotEqualTo);
     if (isLessThan != null) addCondition(field, '<', isLessThan);
     if (isLessThanOrEqualTo != null) {
       addCondition(field, '<=', isLessThanOrEqualTo);


### PR DESCRIPTION
As shown here http://firebase.googleblog.com/2020/09/cloud-firestore-not-equal-queries.html , Firestore now supports not equal operator for queries