### PR TITLE
docs(firebase_storage): storage usage example update 

### DIFF
--- a/docs/storage/usage.mdx
+++ b/docs/storage/usage.mdx
@@ -303,7 +303,7 @@ import 'package:path_provider/path_provider.dart';
 
 Future<void> downloadFileExample() async {
   Directory appDocDir = await getApplicationDocumentsDirectory();
-  File downloadToFile = File('${appDocDir.absolute}/download-logo.png');
+  File downloadToFile = File('${appDocDir.path}/download-logo.png');
 
   try {
     await firebase_storage.FirebaseStorage.instance
@@ -366,7 +366,7 @@ Future<void> handleTaskExample2(String filePath) async {
     print('Task state: ${snapshot.state}');
     print(
         'Progress: ${(snapshot.totalBytes / snapshot.bytesTransferred) * 100} %');
-  }, onError: (firebase_core.FirebaseException e) {
+  }, onError: (e) {
     // The final snapshot is also available on the task via `.snapshot`,
     // this can include 2 additional states, `TaskState.error` & `TaskState.canceled`
     print(task.snapshot);


### PR DESCRIPTION
## Description

- Couldn't find directory if I didn't use `path` property.
- Wrong error type caused error.


## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [X] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
