### PR TITLE
docs: clarify Xcode project name

### DIFF
--- a/docs/installation/ios.mdx
+++ b/docs/installation/ios.mdx
@@ -15,8 +15,8 @@ Download the `GoogleService-Info.plist` file for the Firebase app.
 ## Installing your Firebase configuration file
 
 Next you must add the file to the project using Xcode (adding manually via the filesystem won't link the file to the
-project). Using Xcode, open the project's `ios/{projectName}.xcworkspace` file. Right click the project name within Xcode
-and select "Add files", as seen below:
+project). Using Xcode, open the project's `ios/{projectName}.xcworkspace` file. Right click `Runner` from the left-hand
+side project navigation within Xcode and select "Add files", as seen below:
 
 ![hide:Add files via Xcode](ios-add-files-via-xcode.png)
 

--- a/docs/installation/macos.mdx
+++ b/docs/installation/macos.mdx
@@ -15,8 +15,8 @@ Download the `GoogleService-Info.plist` file for the Firebase app.
 ## Installing your Firebase configuration file
 
 Next you must add the file to the project using Xcode (adding manually via the filesystem won't link the file to the
-project). Using Xcode, open the project's `macos/{projectName}.xcworkspace` file. Right click the project name within Xcode
-and select "Add files", as seen below:
+project). Using Xcode, open the project's `macos/{projectName}.xcworkspace` file. Right click `Runner` from the left-hand
+side project navigation within Xcode and select "Add files", as seen below:
 
 ![hide:Add files via Xcode](ios-add-files-via-xcode.png)
 


### PR DESCRIPTION
## Description

Updates the ios and macos installation docs wording to explicitly specify a click target as "`Runner` from the left-hand ..." rather than "project name" to match the description in migration-guide.mdx.

This can help avoid confusion, since "Runner" isn't a name chosen by the user, the user may be seeing it now for the first time, and the user may be unfamiliar with Xcode (in which case they wouldn't know that the text at this specific location is indeed the project's name.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
