### PR TITLE
fix(ios): don't replace `UNUserNotificationCenter` delegate when protocol conforms to `FlutterApplicationLifeCycleDelegate`

### DIFF
--- a/packages/firebase_messaging/firebase_messaging/ios/Classes/FLTFirebaseMessagingPlugin.m
+++ b/packages/firebase_messaging/firebase_messaging/ios/Classes/FLTFirebaseMessagingPlugin.m
@@ -225,14 +225,16 @@ NSString *const kMessagingPresentationOptionsUserDefaults =
 
     if (notificationCenter.delegate != nil) {
 #if !TARGET_OS_OSX
-      // If there's an existing delegate and it is a FlutterApplicationLifeCycleDelegate then we
+      // If the App delegate exists and it conforms to UNUserNotificationCenterDelegate then we
       // don't want to replace it on iOS as the earlier call to `[_registrar
       // addApplicationDelegate:self];` will automatically delgate calls to this plugin. If we
       // replace it, it will cause a stack overflow as our original delegate forwarding handler
       // below causes an infinite loop of forwarding. See
       // https://github.com/FirebaseExtended/flutterfire/issues/4026.
-      if ([notificationCenter.delegate
-              conformsToProtocol:@protocol(FlutterApplicationLifeCycleDelegate)]) {
+      if ([GULApplication sharedApplication].delegate != nil &&
+          [[GULApplication sharedApplication].delegate
+              conformsToProtocol:@protocol(UNUserNotificationCenterDelegate)]) {
+        // Note this one only executes if Firebase swizzling is **enabled**.
         shouldReplaceDelegate = NO;
       }
 #endif

--- a/packages/firebase_messaging/firebase_messaging/ios/Classes/FLTFirebaseMessagingPlugin.m
+++ b/packages/firebase_messaging/firebase_messaging/ios/Classes/FLTFirebaseMessagingPlugin.m
@@ -227,7 +227,7 @@ NSString *const kMessagingPresentationOptionsUserDefaults =
 #if !TARGET_OS_OSX
       // If the App delegate exists and it conforms to UNUserNotificationCenterDelegate then we
       // don't want to replace it on iOS as the earlier call to `[_registrar
-      // addApplicationDelegate:self];` will automatically delgate calls to this plugin. If we
+      // addApplicationDelegate:self];` will automatically delegate calls to this plugin. If we
       // replace it, it will cause a stack overflow as our original delegate forwarding handler
       // below causes an infinite loop of forwarding. See
       // https://github.com/FirebaseExtended/flutterfire/issues/4026.

--- a/packages/firebase_messaging/firebase_messaging/ios/Classes/FLTFirebaseMessagingPlugin.m
+++ b/packages/firebase_messaging/firebase_messaging/ios/Classes/FLTFirebaseMessagingPlugin.m
@@ -219,24 +219,44 @@ NSString *const kMessagingPresentationOptionsUserDefaults =
 
   // Set UNUserNotificationCenter but preserve original delegate if necessary.
   if (@available(iOS 10.0, macOS 10.14, *)) {
+    BOOL shouldReplaceDelegate = YES;
     UNUserNotificationCenter *notificationCenter =
         [UNUserNotificationCenter currentNotificationCenter];
+
     if (notificationCenter.delegate != nil) {
-      _originalNotificationCenterDelegate = notificationCenter.delegate;
-      _originalNotificationCenterDelegateRespondsTo.openSettingsForNotification =
-          (unsigned int)[_originalNotificationCenterDelegate
-              respondsToSelector:@selector(userNotificationCenter:openSettingsForNotification:)];
-      _originalNotificationCenterDelegateRespondsTo.willPresentNotification =
-          (unsigned int)[_originalNotificationCenterDelegate
-              respondsToSelector:@selector(userNotificationCenter:
-                                          willPresentNotification:withCompletionHandler:)];
-      _originalNotificationCenterDelegateRespondsTo.didReceiveNotificationResponse =
-          (unsigned int)[_originalNotificationCenterDelegate
-              respondsToSelector:@selector(userNotificationCenter:
-                                     didReceiveNotificationResponse:withCompletionHandler:)];
+#if !TARGET_OS_OSX
+      // If there's an existing delegate and it is a FlutterApplicationLifeCycleDelegate then we
+      // don't want to replace it on iOS as the earlier call to `[_registrar
+      // addApplicationDelegate:self];` will automatically delgate calls to this plugin. If we
+      // replace it, it will cause a stack overflow as our original delegate forwarding handler
+      // below causes an infinite loop of forwarding. See
+      // https://github.com/FirebaseExtended/flutterfire/issues/4026.
+      if ([notificationCenter.delegate
+              conformsToProtocol:@protocol(FlutterApplicationLifeCycleDelegate)]) {
+        shouldReplaceDelegate = NO;
+      }
+#endif
+
+      if (shouldReplaceDelegate) {
+        _originalNotificationCenterDelegate = notificationCenter.delegate;
+        _originalNotificationCenterDelegateRespondsTo.openSettingsForNotification =
+            (unsigned int)[_originalNotificationCenterDelegate
+                respondsToSelector:@selector(userNotificationCenter:openSettingsForNotification:)];
+        _originalNotificationCenterDelegateRespondsTo.willPresentNotification =
+            (unsigned int)[_originalNotificationCenterDelegate
+                respondsToSelector:@selector(userNotificationCenter:
+                                            willPresentNotification:withCompletionHandler:)];
+        _originalNotificationCenterDelegateRespondsTo.didReceiveNotificationResponse =
+            (unsigned int)[_originalNotificationCenterDelegate
+                respondsToSelector:@selector(userNotificationCenter:
+                                       didReceiveNotificationResponse:withCompletionHandler:)];
+      }
     }
-    __strong FLTFirebasePlugin<UNUserNotificationCenterDelegate> *strongSelf = self;
-    notificationCenter.delegate = strongSelf;
+
+    if (shouldReplaceDelegate) {
+      __strong FLTFirebasePlugin<UNUserNotificationCenterDelegate> *strongSelf = self;
+      notificationCenter.delegate = strongSelf;
+    }
   }
 
   // We automatically register for remote notifications as


### PR DESCRIPTION
## Description

*Replace this paragraph with a description of what this PR is doing. If you're modifying existing behavior, describe the existing behavior, how this PR is changing it, and what motivated the change.*

## Related Issues

 - Fixes #4026
 - Fixes #4034 

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [ ] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
