### PR TITLE
fix(firebase_core,web): ensure list items are converted

### DIFF
--- a/packages/firebase_core/firebase_core_web/lib/src/interop/utils/utils.dart
+++ b/packages/firebase_core/firebase_core_web/lib/src/interop/utils/utils.dart
@@ -22,7 +22,7 @@ dynamic dartify(Object jsObject,
 
   // Handle list
   if (jsObject is Iterable) {
-    return jsObject.map(dartify).toList();
+    return jsObject.map((item) => dartify(item, customDartify)).toList();
   }
 
   var jsDate = js.dartifyDate(jsObject);
@@ -45,8 +45,8 @@ dynamic dartify(Object jsObject,
 }
 
 // Converts an Iterable into a JS Array
-dynamic jsifyList(Iterable list) {
-  return js.toJSArray(list.map(jsify).toList());
+dynamic jsifyList(Iterable list, [Object Function(Object object) customJsify]) {
+  return js.toJSArray(list.map((item) => jsify(item, customJsify)).toList());
 }
 
 // Returns the JS implementation from Dart Object.
@@ -56,7 +56,7 @@ dynamic jsify(Object dartObject, [Object Function(Object object) customJsify]) {
   }
 
   if (dartObject is Iterable) {
-    return jsifyList(dartObject);
+    return jsifyList(dartObject, customJsify);
   }
 
   if (dartObject is Map) {


### PR DESCRIPTION
## Description

Iterable lists are currently being converted without a custom converteor, in cases of Firestore this means sub-items within an array/list are not converted as expected.

## Related Issues

Fixes #4063

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
