### PR TITLE
docs(firebase_functions): updated usage doc

### DIFF
--- a/docs/functions/usage.mdx
+++ b/docs/functions/usage.mdx
@@ -74,7 +74,8 @@ FirebaseFunctions.instance
   .httpsCallable('myCloudFunction');
 ```
 
-### iOS
+
+### iOS
 
 When using the Firebase emulator while debugging an iOS application, you may receive an error regarding App Transport Security. To fix it, please use the following steps:
 

--- a/docs/functions/usage.mdx
+++ b/docs/functions/usage.mdx
@@ -74,6 +74,18 @@ FirebaseFunctions.instance
   .httpsCallable('myCloudFunction');
 ```
 
+### iOS
+
+When using the Firebase emulator while debugging an iOS application, you may receive an error regarding App Transport Security. To fix it, please use the following steps:
+
+1. Open ios/Runner.xcworkspace in Xcode.
+2. Open Runner/info.plist.
+3. Add a property called App Transport Security Settings.
+4. Right click on that property and click Add Row.
+5. Add a property called Allows Local Networking and enter its value as YES.
+
+### Android
+
 If you are targeting apps using Android 8.0+, the platform will block the http endpoint.  The simplest solution is to change
 this in your **debug** builds by adding the following to your `android/app/src/main/AndroidManifest.xml` file:
 
@@ -82,5 +94,6 @@ this in your **debug** builds by adding the following to your `android/app/src/m
   android:usesCleartextTraffic="true"
 />
 ```
+
 
 If you are concerned about security, you can set a more advanced [per-host network security file](https://developer.android.com/training/articles/security-config)


### PR DESCRIPTION
## Description

Added fix for an error that is encountered on the iOS simulator while using the local Firebase emulator for Cloud Functions. 

## Related Issues

 - Fixes #2792
 - Fixes #3505

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.
