### PR TITLE
feat(firebase_core): add FirebaseException.stackTrace support

### DIFF
--- a/packages/firebase_core/firebase_core_platform_interface/lib/src/firebase_exception.dart
+++ b/packages/firebase_core/firebase_core_platform_interface/lib/src/firebase_exception.dart
@@ -10,7 +10,7 @@ part of firebase_core_platform_interface;
 /// ```dart
 /// try {
 ///   await Firebase.initializeApp();
-/// } catch (e) {
+/// } on FirebaseException catch (e) {
 ///   print(e.toString());
 /// }
 /// ```
@@ -26,7 +26,10 @@ class FirebaseException implements Exception {
   /// }
   /// ```
   FirebaseException(
-      {@required this.plugin, @required this.message, this.code = 'unknown'});
+      {@required this.plugin,
+      @required this.message,
+      this.code = 'unknown',
+      this.stackTrace});
 
   /// The plugin the exception is for.
   ///
@@ -44,20 +47,30 @@ class FirebaseException implements Exception {
   /// not exist.
   final String code;
 
+  /// The stack trace which provides information to the user about the call
+  /// sequence that triggered an exception
+  final StackTrace stackTrace;
+
   @override
   bool operator ==(dynamic other) {
     if (identical(this, other)) return true;
     if (other is! FirebaseException) return false;
-    return other.toString() == this.toString();
+    return other.hashCode == hashCode;
   }
 
   @override
   int get hashCode {
-    return this.toString().hashCode;
+    return hash3(plugin, code, message);
   }
 
   @override
   String toString() {
-    return "[$plugin/$code] $message";
+    String output = "[$plugin/$code] $message";
+
+    if (stackTrace != null) {
+      output += "\n\n${stackTrace.toString()}";
+    }
+
+    return output;
   }
 }

--- a/packages/firebase_core/firebase_core_platform_interface/test/firebase_exception_test.dart
+++ b/packages/firebase_core/firebase_core_platform_interface/test/firebase_exception_test.dart
@@ -25,6 +25,17 @@ void main() {
       expect(e.toString(), '[foo/baz] bar');
     });
 
+    test('should return a formatted message with a stack trace', () async {
+      FirebaseException e = FirebaseException(
+          plugin: 'foo',
+          message: 'bar',
+          code: 'baz',
+          stackTrace: StackTrace.current);
+
+      // Anything with a stack trace adds 2 blanks lines following the message.
+      expect(e.toString(), startsWith('[foo/baz] bar\n\n'));
+    });
+
     test('should override the == operator', () async {
       FirebaseException e1 =
           FirebaseException(plugin: 'foo', message: 'bar', code: 'baz');


### PR DESCRIPTION
## Description

Cherry picks stack trace support on FirebaseException from https://github.com/FirebaseExtended/flutterfire/pull/3159


## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
