### PR TITLE
fix(firebase_auth): stop authStateChange firing twice for initial event

### DIFF
--- a/packages/firebase_auth/firebase_auth/android/src/main/java/io/flutter/plugins/firebase/auth/FlutterFirebaseAuthPlugin.java
+++ b/packages/firebase_auth/firebase_auth/android/src/main/java/io/flutter/plugins/firebase/auth/FlutterFirebaseAuthPlugin.java
@@ -511,13 +511,13 @@ public class FlutterFirebaseAuthPlugin
                     event.put(Constants.USER, parseFirebaseUser(user));
                   }
 
-                  if(initialAuthState){
+                  if (initialAuthState) {
                     initialAuthState = false;
                   } else {
                     channel.invokeMethod(
-                      "Auth#authStateChanges",
-                      event,
-                      getMethodChannelResultHandler("Auth#authStateChanges"));
+                        "Auth#authStateChanges",
+                        event,
+                        getMethodChannelResultHandler("Auth#authStateChanges"));
                   }
                 };
 

--- a/packages/firebase_auth/firebase_auth/android/src/main/java/io/flutter/plugins/firebase/auth/FlutterFirebaseAuthPlugin.java
+++ b/packages/firebase_auth/firebase_auth/android/src/main/java/io/flutter/plugins/firebase/auth/FlutterFirebaseAuthPlugin.java
@@ -77,6 +77,7 @@ public class FlutterFirebaseAuthPlugin
   private PluginRegistry.Registrar registrar;
   private MethodChannel channel;
   private Activity activity;
+  private static Boolean initialAuthState = true;
 
   @SuppressWarnings("unused")
   public static void registerWith(PluginRegistry.Registrar registrar) {
@@ -510,10 +511,14 @@ public class FlutterFirebaseAuthPlugin
                     event.put(Constants.USER, parseFirebaseUser(user));
                   }
 
-                  channel.invokeMethod(
+                  if(initialAuthState){
+                    initialAuthState = false;
+                  } else {
+                    channel.invokeMethod(
                       "Auth#authStateChanges",
                       event,
                       getMethodChannelResultHandler("Auth#authStateChanges"));
+                  }
                 };
 
             firebaseAuth.addAuthStateListener(newAuthStateListener);

--- a/packages/firebase_auth/firebase_auth/ios/Classes/FLTFirebaseAuthPlugin.m
+++ b/packages/firebase_auth/firebase_auth/ios/Classes/FLTFirebaseAuthPlugin.m
@@ -43,6 +43,8 @@ NSString *const kErrCodeInvalidCredential = @"invalid-credential";
 NSString *const kErrMsgInvalidCredential =
     @"The supplied auth credential is malformed, has expired or is not currently supported.";
 
+BOOL static initialAuthState = true;
+
 @interface FLTFirebaseAuthPlugin ()
 @property(nonatomic, retain) FlutterMethodChannel *channel;
 @end
@@ -903,12 +905,16 @@ NSString *const kErrMsgInvalidCredential =
   __weak __typeof__(self) weakSelf = self;
 
   id authStateChangeListener = ^(FIRAuth *_Nonnull auth, FIRUser *_Nullable user) {
-    [weakSelf.channel
+    if (initialAuthState) {
+      initialAuthState = false;
+    } else {
+      [weakSelf.channel
         invokeMethod:@"Auth#authStateChanges"
-           arguments:@{
-             @"appName" : [FLTFirebasePlugin firebaseAppNameFromIosName:auth.app.name],
-             @"user" : user != nil ? [weakSelf getNSDictionaryFromUser:user] : [NSNull null]
-           }];
+          arguments:@{
+            @"appName" : [FLTFirebasePlugin firebaseAppNameFromIosName:auth.app.name],
+            @"user" : user != nil ? [weakSelf getNSDictionaryFromUser:user] : [NSNull null]
+          }];
+    }
   };
 
   @synchronized(self->_authChangeListeners) {

--- a/packages/firebase_auth/firebase_auth/ios/Classes/FLTFirebaseAuthPlugin.m
+++ b/packages/firebase_auth/firebase_auth/ios/Classes/FLTFirebaseAuthPlugin.m
@@ -909,11 +909,11 @@ BOOL static initialAuthState = true;
       initialAuthState = false;
     } else {
       [weakSelf.channel
-        invokeMethod:@"Auth#authStateChanges"
-          arguments:@{
-            @"appName" : [FLTFirebasePlugin firebaseAppNameFromIosName:auth.app.name],
-            @"user" : user != nil ? [weakSelf getNSDictionaryFromUser:user] : [NSNull null]
-          }];
+          invokeMethod:@"Auth#authStateChanges"
+             arguments:@{
+               @"appName" : [FLTFirebasePlugin firebaseAppNameFromIosName:auth.app.name],
+               @"user" : user != nil ? [weakSelf getNSDictionaryFromUser:user] : [NSNull null]
+             }];
     }
   };
 


### PR DESCRIPTION
## Description

Stops `authStateChanges` from firing twice initially on native platforms. 

## Related Issues

fixes #4049 

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [X] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [X] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [X] I read and followed the [Flutter Style Guide].
- [X] I signed the [CLA].
- [X] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
