### PR TITLE
test(firebase_storage): Opt-out from null safety.

### DIFF
--- a/.github/workflows/scripts/drive-example.sh
+++ b/.github/workflows/scripts/drive-example.sh
@@ -43,6 +43,6 @@ then
   melos bootstrap
   chromedriver --port=4444 &
   melos exec -c 1 --scope="$FLUTTERFIRE_PLUGIN_SCOPE_EXAMPLE" --dir-exists=web -- \
-    flutter drive --no-pub --verbose-system-logs --browser-name=chrome --target=./test_driver/MELOS_PARENT_PACKAGE_NAME_e2e.dart
+    flutter drive --no-pub --verbose-system-logs --device-id=web --target=./test_driver/MELOS_PARENT_PACKAGE_NAME_e2e.dart
   exit
 fi

--- a/packages/firebase_storage/firebase_storage/example/pubspec.yaml
+++ b/packages/firebase_storage/firebase_storage/example/pubspec.yaml
@@ -19,6 +19,8 @@ dependency_overrides:
     path: ../
   firebase_storage_platform_interface:
     path: ../../firebase_storage_platform_interface
+  firebase_storage_web:
+    path: ../../firebase_storage_web
 
 dev_dependencies:
   pedantic: ^1.8.0

--- a/packages/firebase_storage/firebase_storage/example/test_driver/firebase_storage_e2e.dart
+++ b/packages/firebase_storage/firebase_storage/example/test_driver/firebase_storage_e2e.dart
@@ -1,3 +1,5 @@
+// @dart = 2.9
+
 // Copyright 2020, the Chromium project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.

--- a/packages/firebase_storage/firebase_storage/example/test_driver/firebase_storage_e2e_test.dart
+++ b/packages/firebase_storage/firebase_storage/example/test_driver/firebase_storage_e2e_test.dart
@@ -1,3 +1,5 @@
+// @dart = 2.9
+
 // Copyright 2020, the Chromium project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.

--- a/packages/firebase_storage/firebase_storage/example/test_driver/instance_e2e.dart
+++ b/packages/firebase_storage/firebase_storage/example/test_driver/instance_e2e.dart
@@ -1,3 +1,5 @@
+// @dart = 2.9
+
 import 'package:firebase_storage/firebase_storage.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:flutter_test/flutter_test.dart';

--- a/packages/firebase_storage/firebase_storage/example/test_driver/list_result_e2e.dart
+++ b/packages/firebase_storage/firebase_storage/example/test_driver/list_result_e2e.dart
@@ -1,3 +1,5 @@
+// @dart = 2.9
+
 import 'package:firebase_storage/firebase_storage.dart';
 import 'package:flutter_test/flutter_test.dart';
 

--- a/packages/firebase_storage/firebase_storage/example/test_driver/reference_e2e.dart
+++ b/packages/firebase_storage/firebase_storage/example/test_driver/reference_e2e.dart
@@ -1,3 +1,5 @@
+// @dart = 2.9
+
 import 'dart:convert';
 import 'dart:io';
 import 'dart:typed_data';

--- a/packages/firebase_storage/firebase_storage/example/test_driver/task_e2e.dart
+++ b/packages/firebase_storage/firebase_storage/example/test_driver/task_e2e.dart
@@ -1,3 +1,5 @@
+// @dart = 2.9
+
 import 'dart:async';
 import 'dart:convert';
 import 'dart:io';

--- a/packages/firebase_storage/firebase_storage/example/test_driver/test_utils.dart
+++ b/packages/firebase_storage/firebase_storage/example/test_driver/test_utils.dart
@@ -1,3 +1,5 @@
+// @dart = 2.9
+
 import 'dart:io';
 import 'dart:math';
 


### PR DESCRIPTION
## Description

This change opts-out tests from firebase_storage so they are not compiled with null-safety, which had started failing.

<details>

<summary><tt>flutter drive --target test_driver/firebase_storage_e2e.dart -d web</tt></summary>

```
Warning: You are using these overridden dependencies:                   
! firebase_core 0.5.2 from path ../../../firebase_core/firebase_core    
! firebase_storage 5.0.1 from path ..                                   
! firebase_storage_platform_interface 1.0.1 from path ../../firebase_storage_platform_interface
! firebase_storage_web 0.1.0 from path ../../firebase_storage_web       
Running "flutter pub get" in example...                            540ms
Launching test_driver/firebase_storage_e2e.dart on Web Server in debug mode...
Syncing files to device Web Server...                              15.0s
test_driver/firebase_storage_e2e.dart is being served at http://localhost:34309
The web-server device requires the Dart Debug Chrome extension for debugging. Consider using the Chrome or Edge devices for an improved development workflow.
Application finished.
  [LOG]: 00:00 +0: (setUpAll)


------------------------------
|         Drive Tests        |
------------------------------

Running suite with 58 tests...

  [LOG]: 00:00 +1: FirebaseStorage (setUpAll)
  [LOG]: 00:00 +2: FirebaseStorage instance

  FirebaseStorage
     \u2714 instance
       [LOG]: 00:00 +3: FirebaseStorage instanceFor
     \u2714 instanceFor
       [LOG]: 00:00 +4: FirebaseStorage default bucket cannot be null
     \u2714 default bucket cannot be null
       [LOG]: 00:00 +5: FirebaseStorage ref uses default path if none provided

  ref
     \u2714 uses default path if none provided
       [LOG]: 00:00 +6: FirebaseStorage ref accepts a custom path
     \u2714 accepts a custom path
       [LOG]: 00:00 +7: FirebaseStorage ref strips leading / from custom path
     \u2714 strips leading / from custom path
       [LOG]: 00:00 +8: FirebaseStorage refFromURL accepts a gs url

  refFromURL
     \u2714 accepts a gs url
       [LOG]: 00:00 +9: FirebaseStorage refFromURL accepts a https url
     \u2714 accepts a https url
       [LOG]: 00:00 +10: FirebaseStorage refFromURL accepts a https encoded url
     \u2714 accepts a https encoded url
       [LOG]: 00:00 +11: FirebaseStorage refFromURL throws an error if https url could not be parsed
     \u2714 throws an error if https url could not be parsed
       [LOG]: 00:00 +12: FirebaseStorage refFromURL accepts a gs url without a fullPath
     \u2714 accepts a gs url without a fullPath
       [LOG]: 00:00 +13: FirebaseStorage refFromURL throws an error if url does not start with gs:// or https://
     \u2714 throws an error if url does not start with gs:// or https://
       [LOG]: 00:00 +14: FirebaseStorage setMaxOperationRetryTime should set

  setMaxOperationRetryTime
     \u2714 should set
       [LOG]: 00:00 +15: FirebaseStorage setMaxUploadRetryTime should set

  setMaxUploadRetryTime
     \u2714 should set
       [LOG]: 00:00 +16: FirebaseStorage setMaxDownloadRetryTime should set

  setMaxDownloadRetryTime
     \u2714 should set
       [LOG]: 00:00 +17: FirebaseStorage toString
     \u2714 toString
       [LOG]: 00:00 +18: FirebaseStorage (tearDownAll)
       [LOG]: 00:00 +19: ListResult (setUpAll)
       [LOG]: 00:01 +20: ListResult items

  ListResult
     \u2714 items
       [LOG]: 00:01 +21: ListResult nextPageToken
     \u2714 nextPageToken
       [LOG]: 00:01 +22: ListResult prefixes
     \u2714 prefixes
       [LOG]: 00:01 +23: ListResult (tearDownAll)
       [LOG]: 00:01 +24: Reference (setUpAll)
       [LOG]: 00:01 +25: Reference bucket returns the storage bucket as a string

  bucket
     \u2714 returns the storage bucket as a string
       [LOG]: 00:01 +26: Reference fullPath returns the full path as a string

  fullPath
     \u2714 returns the full path as a string
       [LOG]: 00:01 +27: Reference name returns the file name as a string

  name
     \u2714 returns the file name as a string
       [LOG]: 00:01 +28: Reference parent returns the parent directory as a reference

  parent
     \u2714 returns the parent directory as a reference
       [LOG]: 00:01 +29: Reference parent returns null if already at root
     \u2714 returns null if already at root
       [LOG]: 00:01 +30: Reference root returns a reference to the root of the bucket

  root
     \u2714 returns a reference to the root of the bucket
       [LOG]: 00:01 +31: Reference child() returns a reference to a child path

  child()
     \u2714 returns a reference to a child path
       [LOG]: 00:01 +32: Reference delete() (setUpAll)
       [LOG]: 00:01 +33: Reference delete() should delete a file

  delete()
     \u2714 should delete a file
       [LOG]: 00:02 +34: Reference delete() throws error if file does not exist
     \u2714 throws error if file does not exist
       [LOG]: 00:02 +35: Reference delete() throws error if no write permission
     \u2714 throws error if no write permission
       [LOG]: 00:02 +36: Reference delete() (tearDownAll)
       [LOG]: 00:02 +37: Reference getDownloadURL gets a download url

  getDownloadURL
     \u2714 gets a download url
       [LOG]: 00:02 +38: Reference getDownloadURL errors if permission denied
     \u2714 errors if permission denied
       [LOG]: 00:03 +39: Reference getDownloadURL throws error if file does not exist
     \u2714 throws error if file does not exist
       [LOG]: 00:03 +40: Reference list returns list results

  list
     \u2714 returns list results
       [LOG]: 00:03 +41: Reference list errors if maxResults is less than 0 
     \u2714 errors if maxResults is less than 0
       [LOG]: 00:03 +42: Reference list errors if maxResults is 0 
     \u2714 errors if maxResults is 0
       [LOG]: 00:03 +43: Reference list errors if maxResults is more than 1000 
     \u2714 errors if maxResults is more than 1000
       [LOG]: 00:03 +44: Reference listAll

  Reference
     \u2714 listAll
       [LOG]: 00:03 +45: Reference putData uploads a file with buffer

  putData
     \u2714 uploads a file with buffer
       [LOG]: 00:04 +46: Reference putData errors if permission denied
     \u2714 errors if permission denied
       [LOG]: 00:04 +47: Reference putBlob throws [UnimplementedError] for native platforms
       [LOG]: 00:04 +47 ~1: Reference putFile uploads a file
       [LOG]: 00:04 +47 ~2: Reference putFile errors if permission denied
       [LOG]: 00:04 +47 ~3: Reference putString uploads a string

  putString
     \u2714 uploads a string
       [LOG]: 00:04 +48 ~3: Reference putString errors if permission denied
     \u2714 errors if permission denied
       [LOG]: 00:04 +49 ~3: Reference updateMetadata updates metadata

  updateMetadata
     \u2714 updates metadata
       [LOG]: 00:05 +50 ~3: Reference updateMetadata errors if metadata update removes existing data
     \u2714 errors if metadata update removes existing data
       [LOG]: 00:06 +51 ~3: Reference updateMetadata errors if property does not exist
     \u2714 errors if property does not exist
       [LOG]: 00:06 +52 ~3: Reference updateMetadata errors if permission denied
     \u2714 errors if permission denied
       [LOG]: 00:06 +53 ~3: Reference writeToFile downloads a file
       [LOG]: 00:06 +53 ~4: Reference writeToFile errors if permission denied
       [LOG]: 00:06 +53 ~5: Reference toString
     \u2714 toString
       [LOG]: 00:06 +54 ~5: Reference (tearDownAll)
       [LOG]: 00:06 +55 ~5: Task (setUpAll)
       [LOG]: 00:06 +56 ~5: Task pause() resume() onComplete() successfully pauses and resumes a download task
       [LOG]: 00:06 +56 ~6: Task pause() resume() onComplete() successfully pauses and resumes a upload task

  pause() resume() onComplete()
     \u2714 successfully pauses and resumes a upload task
       [LOG]: 00:07 +57 ~6: Task pause() resume() onComplete() handles errors, e.g. if permission denied
     \u2714 handles errors, e.g. if permission denied
       [LOG]: 00:07 +58 ~6: Task snapshot returns the latest snapshot for download task
       [LOG]: 00:07 +58 ~7: Task snapshot returns the latest snapshot for upload task

  snapshot
     \u2714 returns the latest snapshot for upload task
       [LOG]: 00:07 +59 ~7: Task cancel() successfully cancels download task
       [LOG]: 00:07 +59 ~8: Task cancel() successfully cancels upload task

  cancel()
     \u2714 successfully cancels upload task
       [LOG]: 00:07 +60 ~8: Task (tearDownAll)
       [LOG]: 00:07 +61 ~8: (tearDownAll)

------------------------------

 \u2714 50 tests completed successfully.
```

</details>

----

<details>

<summary><tt>flutter --version</tt></summary>

```
Flutter 1.24.0-10.2.pre - channel unknown - unknown source
Framework - revision 022b333a08 (5 days ago) - 2020-11-18 11:35:09 -0800
Engine - revision 07c1eed46b
Tools - Dart 2.12.0 (build 2.12.0-29.10.beta)
```

(Tip of the `beta` branch in `flutter/flutter`)

</details>

------------------------------

## Related Issues

n/a

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
