### PR TITLE
docs: update code doc typo

### DIFF
--- a/packages/cloud_functions/cloud_functions_platform_interface/lib/src/method_channel/method_channel_firebase_functions.dart
+++ b/packages/cloud_functions/cloud_functions_platform_interface/lib/src/method_channel/method_channel_firebase_functions.dart
@@ -16,7 +16,7 @@ class MethodChannelFirebaseFunctions extends FirebaseFunctionsPlatform {
     return MethodChannelFirebaseFunctions._();
   }
 
-  /// The [MethodChannelFirebaseAuth] method channel.
+  /// The [MethodChannelFirebaseFunctions] method channel.
   static const MethodChannel channel = MethodChannel(
     'plugins.flutter.io/firebase_functions',
   );


### PR DESCRIPTION
Fix typo in method channel comment.
