### PR TITLE
docs: Links to social media auth. are broken

### DIFF
--- a/docs/auth/usage.mdx
+++ b/docs/auth/usage.mdx
@@ -338,10 +338,10 @@ listeners.
 
 Firebase also supports authenticating with external provides. To learn more, view the documentation for your authentication method:
 
-- [Apple Sign-In.](social#apple)
-- [Facebook Sign-In.](social#facebook)
-- [Twitter Sign-In.](social#twitter)
-- [Google Sign-In.](social#google)
+- [Apple Sign-In.](/docs/auth/social#apple)
+- [Facebook Sign-In.](/docs/auth/social#facebook)
+- [Twitter Sign-In.](/docs/auth/social#twitter)
+- [Google Sign-In.](/docs/auth/social#google)
 - [Phone Number Sign-In.](phone)
 
 ## User management

--- a/docs/auth/usage.mdx
+++ b/docs/auth/usage.mdx
@@ -338,11 +338,11 @@ listeners.
 
 Firebase also supports authenticating with external provides. To learn more, view the documentation for your authentication method:
 
-- [Apple Sign-In.](/docs/auth/social#apple)
-- [Facebook Sign-In.](/docs/auth/social#facebook)
-- [Twitter Sign-In.](/docs/auth/social#twitter)
-- [Google Sign-In.](/docs/auth/social#google)
-- [Phone Number Sign-In.](phone)
+- [Apple Sign-In.](../social#apple)
+- [Facebook Sign-In.](../social#facebook)
+- [Twitter Sign-In.](../social#twitter)
+- [Google Sign-In.](../social#google)
+- [Phone Number Sign-In.](../phone)
 
 ## User management
 


### PR DESCRIPTION
Links are broken. They are pointing to `docs/auth/usage` but the root is `docs/auth/social`

TBH, I'm not sure if this is the right way to fix the link.



