### PR TITLE
fix(cloud_firestore): ensure web FieldValue types are converted

### DIFF
--- a/packages/cloud_firestore/cloud_firestore/example/test_driver/field_value_e2e.dart
+++ b/packages/cloud_firestore/cloud_firestore/example/test_driver/field_value_e2e.dart
@@ -165,6 +165,22 @@ void runFieldValueTests() {
         DocumentSnapshot snapshot = await doc.get();
         expect(snapshot.data()['foo'], equals([3, 4]));
       });
+
+      test('updates with nested types', () async {
+        DocumentReference doc =
+            await initializeTest('field-value-nested-types');
+
+        DocumentReference ref = FirebaseFirestore.instance.doc('foo/bar');
+
+        await doc.set({
+          'foo': [1]
+        });
+        await doc.update({
+          'foo': FieldValue.arrayUnion([2, ref])
+        });
+        DocumentSnapshot snapshot = await doc.get();
+        expect(snapshot.data()['foo'], equals([1, 2, ref]));
+      });
     });
   });
 }

--- a/packages/cloud_firestore/cloud_firestore_web/lib/src/interop/firestore.dart
+++ b/packages/cloud_firestore/cloud_firestore_web/lib/src/interop/firestore.dart
@@ -588,7 +588,7 @@ class _FieldValueArrayUnion extends _FieldValueArray {
   firestore_interop.FieldValue _jsify() {
     // This uses var arg so cannot use js package
     return callMethod(
-        firestore_interop.fieldValues, 'arrayUnion', jsifyList(elements));
+        firestore_interop.fieldValues, 'arrayUnion', jsify(elements));
   }
 
   @override
@@ -602,7 +602,7 @@ class _FieldValueArrayRemove extends _FieldValueArray {
   firestore_interop.FieldValue _jsify() {
     // This uses var arg so cannot use js package
     return callMethod(
-        firestore_interop.fieldValues, 'arrayRemove', jsifyList(elements));
+        firestore_interop.fieldValues, 'arrayRemove', jsify(elements));
   }
 
   @override


### PR DESCRIPTION
## Description

FieldValues were currently going through the core `jsify` utils which skipped conversion of Firestore types. This forces the values back through the cloud firestore types.

## Related Issues

Fixes https://github.com/FirebaseExtended/flutterfire/issues/4224

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
