### PR TITLE
fix(firebase_analytics): remove screen_view from reservedEventNames

### DIFF
--- a/packages/firebase_analytics/firebase_analytics/lib/firebase_analytics.dart
+++ b/packages/firebase_analytics/firebase_analytics/lib/firebase_analytics.dart
@@ -915,7 +915,6 @@ const List<String> _reservedEventNames = <String>[
   'notification_open',
   'notification_receive',
   'os_update',
-  'screen_view',
   'session_start',
   'user_engagement',
 ];


### PR DESCRIPTION
## Description

The reserved events have changed. You can find the list here: https://firebase.google.com/docs/reference/swift/firebaseanalytics/api/reference/Classes/Analytics
The screen_view event is no longer in this list.

This PR removes screen_view from the list of reserved events. There are more events to update, but it looks like `screen_view` is the only removal. We should make future migrations as easy as possible and remove the screen_view so that users can already migrate to logging custom screen_view events.

Updating the other events is a potential breaking change, so I decided to keep them out of this PR. If you like to include them as well, please tell me, I'll add them.

## Related Issues

fixes #3267

## Checklist


- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.


## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
