### PR TITLE
fix: child() missing after ref()

### DIFF
--- a/docs/storage/usage.mdx
+++ b/docs/storage/usage.mdx
@@ -145,7 +145,7 @@ retrieve a long-lived download URL which can be used. To request a download URL,
 ```dart
 Future<void> downloadURLExample() async {
   String downloadURL = await firebase_storage.FirebaseStorage.instance
-      .ref('users/123/avatar.jpg')
+      .ref().child('users/123/avatar.jpg')
       .getDownloadURL();
 
   // Within your widgets:


### PR DESCRIPTION
Hi! Thanks for the great work. I was working with the `getDownloadUrl()` and I noticed that in the example above the ref() function have arguments and the child() function is missing. I tried the code and ref() expects 0 arguments. With  `ref().child(“string”).getDownloadUrl()` works perfectly. Thank you!

