### PR TITLE
fix(auth): web now fires once on authStateListener initialisation

### DIFF
--- a/packages/firebase_auth/firebase_auth_web/lib/firebase_auth_web.dart
+++ b/packages/firebase_auth/firebase_auth_web/lib/firebase_auth_web.dart
@@ -24,6 +24,7 @@ class FirebaseAuthWeb extends FirebaseAuthPlatform {
   final auth_interop.Auth _webAuth;
 
   static bool _initialAuthState = true;
+
   /// Called by PluginRegistry to register this plugin for Flutter Web
   static void registerWith(Registrar registrar) {
     FirebaseAuthPlatform.instance = FirebaseAuthWeb.instance;
@@ -71,7 +72,7 @@ class FirebaseAuthWeb extends FirebaseAuthPlatform {
           return UserWeb(this, webUser);
         }
       }).listen((UserWeb webUser) {
-        if(_initialAuthState){
+        if (_initialAuthState) {
           _initialAuthState = false;
         } else {
           _authStateChangesListeners[app.name].add(webUser);

--- a/packages/firebase_auth/firebase_auth_web/lib/firebase_auth_web.dart
+++ b/packages/firebase_auth/firebase_auth_web/lib/firebase_auth_web.dart
@@ -23,6 +23,7 @@ class FirebaseAuthWeb extends FirebaseAuthPlatform {
   /// instance of Auth from the web plugin
   final auth_interop.Auth _webAuth;
 
+  static bool _initialAuthState = true;
   /// Called by PluginRegistry to register this plugin for Flutter Web
   static void registerWith(Registrar registrar) {
     FirebaseAuthPlatform.instance = FirebaseAuthWeb.instance;
@@ -70,7 +71,11 @@ class FirebaseAuthWeb extends FirebaseAuthPlatform {
           return UserWeb(this, webUser);
         }
       }).listen((UserWeb webUser) {
-        _authStateChangesListeners[app.name].add(webUser);
+        if(_initialAuthState){
+          _initialAuthState = false;
+        } else {
+          _authStateChangesListeners[app.name].add(webUser);
+        }
       });
 
       // Also triggers `userChanged` events


### PR DESCRIPTION
## Description

stops the web `authStateListener` listener from firing twice upon initialisation.

## Related Issues

#4049

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [X] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
