### PR TITLE
fix(messaging): fixed callback handler type casting on Android

### DIFF
--- a/packages/firebase_messaging/firebase_messaging/android/src/main/java/io/flutter/plugins/firebase/messaging/FlutterFirebaseMessagingPlugin.java
+++ b/packages/firebase_messaging/firebase_messaging/android/src/main/java/io/flutter/plugins/firebase/messaging/FlutterFirebaseMessagingPlugin.java
@@ -291,13 +291,23 @@ public class FlutterFirebaseMessagingPlugin extends BroadcastReceiver
         @SuppressWarnings("unchecked")
         Map<String, Object> arguments = ((Map<String, Object>) call.arguments);
 
+        long pluginCallbackHandle = 0;
+        long userCallbackHandle = 0;
+
         Object arg1 = arguments.get("pluginCallbackHandle");
         Object arg2 = arguments.get("userCallbackHandle");
 
-        long pluginCallbackHandle =
-          (arg1 instanceof Long) ? (Long) arg1 : Long.valueOf((Integer) arg1);
-        long userCallbackHandle =
-          (arg2 instanceof Long) ? (Long) arg2 : Long.valueOf((Integer) arg2);
+        if (arg1 instanceof Long) {
+          pluginCallbackHandle = (Long) arg1;
+        } else {
+          pluginCallbackHandle = Long.valueOf((Integer) arg1);
+        }
+
+        if (arg2 instanceof Long) {
+          userCallbackHandle = (Long) arg2;
+        } else {
+          userCallbackHandle = Long.valueOf((Integer) arg2);
+        }
 
         FlutterShellArgs shellArgs = null;
         if (mainActivity != null) {

--- a/packages/firebase_messaging/firebase_messaging/android/src/main/java/io/flutter/plugins/firebase/messaging/FlutterFirebaseMessagingPlugin.java
+++ b/packages/firebase_messaging/firebase_messaging/android/src/main/java/io/flutter/plugins/firebase/messaging/FlutterFirebaseMessagingPlugin.java
@@ -294,8 +294,10 @@ public class FlutterFirebaseMessagingPlugin extends BroadcastReceiver
         Object arg1 = arguments.get("pluginCallbackHandle");
         Object arg2 = arguments.get("userCallbackHandle");
 
-        long pluginCallbackHandle = (arg1 instanceof Long) ? (Long) arg1 : Long.valueOf((Integer) arg1);
-        long userCallbackHandle = (arg2 instanceof Long) ? (Long) arg2 : Long.valueOf((Integer) arg2);
+        long pluginCallbackHandle =
+          (arg1 instanceof Long) ? (Long) arg1 : Long.valueOf((Integer) arg1);
+        long userCallbackHandle =
+          (arg2 instanceof Long) ? (Long) arg2 : Long.valueOf((Integer) arg2);
 
         FlutterShellArgs shellArgs = null;
         if (mainActivity != null) {

--- a/packages/firebase_messaging/firebase_messaging/android/src/main/java/io/flutter/plugins/firebase/messaging/FlutterFirebaseMessagingPlugin.java
+++ b/packages/firebase_messaging/firebase_messaging/android/src/main/java/io/flutter/plugins/firebase/messaging/FlutterFirebaseMessagingPlugin.java
@@ -289,11 +289,13 @@ public class FlutterFirebaseMessagingPlugin extends BroadcastReceiver
         // method channels.
       case "Messaging#startBackgroundIsolate":
         @SuppressWarnings("unchecked")
-        long pluginCallbackHandle =
-            (long) ((Map<String, Object>) call.arguments).get("pluginCallbackHandle");
-        @SuppressWarnings("unchecked")
-        long userCallbackHandle =
-            (long) ((Map<String, Object>) call.arguments).get("userCallbackHandle");
+        Map<String, Object> arguments = ((Map<String, Object>) call.arguments);
+
+        Object arg1 = arguments.get("pluginCallbackHandle");
+        Object arg2 = arguments.get("userCallbackHandle");
+
+        long pluginCallbackHandle = (arg1 instanceof Long) ? (Long) arg1 : Long.valueOf((Integer) arg1);
+        long userCallbackHandle = (arg2 instanceof Long) ? (Long) arg2 : Long.valueOf((Integer) arg2);
 
         FlutterShellArgs shellArgs = null;
         if (mainActivity != null) {


### PR DESCRIPTION
## Description

Added check for callback handler type (Long or Integer) for Android native code of plugin. Flutter's StandardMessageCodec packs Dart's int in to 32 or 64 bits (depends on the number). If RawHandler is suits for 32 bits, it will be packed as 32 bit int and then it will be unpacked to Integer on Java side.

## Related Issues

Fixes FirebaseExtended/flutterfire#2654
Fixes FirebaseExtended/flutterfire#170

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.
