### PR TITLE
feat(firebase_core, android): bump Android BoM to v25.13.0, fix firebase_ml_vision build

### DIFF
--- a/packages/firebase_core/firebase_core/android/gradle.properties
+++ b/packages/firebase_core/firebase_core/android/gradle.properties
@@ -1,1 +1,2 @@
-FirebaseSDKVersion=25.12.0
+FirebaseSDKVersion=25.13.0
+android.enableR8=true


### PR DESCRIPTION
## Description

The last commit from #4331 fixed builds on firebase_ml_vision for firebase-android-sdk >= 25.13.0

https://github.com/FirebaseExtended/flutterfire/commit/024a11cfe50e492e2ec46774d9cd32c34d894bc3

It was part of this PR originally but was committed already, so this PR is now *just* bumping the SDK to latest stable before the firebase-android-sdk v26.x.x breaking change

Original PR rationale here:

---------

Specifically, these BoMs are documented upstream to not contain the correct dependencies, and because they are deprecated (and then removed in later BoMs) there is no fix coming.

This workaround is the only way to allow for the module to compile and be used

This is identical to the work done in react-native-firebase: https://github.com/invertase/react-native-firebase/commit/dc4f57a952a7076a48a224087c9a8e7cdeaf4afc#diff-8a85188c69631f3ee1d3b09e01cdfcffae515432e9efdfb74683b880a8902172

And the upstream notes are here:

- https://firebase.google.com/support/release-notes/android#mlkit-self-serve-fixes
- https://github.com/firebase/firebase-android-sdk/issues/1904

Bumping the android version *would* be a breaking change if we did not include the dependencies in the module as we do here

## Related Issues

This is part of #4249 but these 2 commits may be considered and adopted both independently and immediately, helping users and shrinking that PR to it's core purpose.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
