### PR TITLE
fix(build): Use one version of firebase SDKs everywhere

### DIFF
--- a/packages/cloud_firestore/cloud_firestore/example/ios/Podfile
+++ b/packages/cloud_firestore/cloud_firestore/example/ios/Podfile
@@ -1,6 +1,10 @@
 # Uncomment this line to define a global platform for your project
 platform :ios, '9.0'
 
+require 'yaml'
+
+pubspec = YAML.load_file(File.join('..', File.join('..', 'pubspec.yaml')))
+
 # CocoaPods analytics sends network stats synchronously affecting flutter build latency.
 ENV['COCOAPODS_DISABLE_STATS'] = 'true'
 
@@ -29,8 +33,22 @@ flutter_ios_podfile_setup
 
 target 'Runner' do
   flutter_install_all_ios_pods File.dirname(File.realpath(__FILE__))
-  
-  pod 'FirebaseFirestore', :git => 'https://github.com/invertase/firestore-ios-sdk-frameworks.git', :tag => '6.33.0'
+
+  if defined?($FirebaseSDKVersion)
+    Pod::UI.puts "#{pubspec['name']}: Using user specified Firebase SDK version for FirebaseFirestore framework: '#{$FirebaseSDKVersion}'"
+    firebase_sdk_version = $FirebaseSDKVersion
+  else
+    firebase_core_script = File.join(File.expand_path('..', File.expand_path('..', File.expand_path('..', File.expand_path('..', File.dirname(__FILE__))))), 'firebase_core/firebase_core/ios/firebase_sdk_version.rb')
+    if File.exist?(firebase_core_script)
+      require firebase_core_script
+      firebase_sdk_version = firebase_sdk_version!
+      Pod::UI.puts "#{pubspec['name']}: Using Firebase SDK version '#{firebase_sdk_version}' defined in 'firebase_core for FirebaseFirestore framework'"
+    else
+      raise "Error - unable to locate firebase_ios_sdk.rb script in firebase_core, and no FirebaseSDKVersion specified"
+    end
+  end
+
+  pod 'FirebaseFirestore', :git => 'https://github.com/invertase/firestore-ios-sdk-frameworks.git', :tag => "#{firebase_sdk_version}"
 end
 
 post_install do |installer|

--- a/packages/cloud_firestore/cloud_firestore/ios/cloud_firestore.podspec
+++ b/packages/cloud_firestore/cloud_firestore/ios/cloud_firestore.podspec
@@ -3,7 +3,6 @@ require 'yaml'
 pubspec = YAML.load_file(File.join('..', 'pubspec.yaml'))
 library_version = pubspec['version'].gsub('+', '-')
 
-firebase_sdk_version = '6.33.0'
 if defined?($FirebaseSDKVersion)
   Pod::UI.puts "#{pubspec['name']}: Using user specified Firebase SDK version '#{$FirebaseSDKVersion}'"
   firebase_sdk_version = $FirebaseSDKVersion
@@ -34,8 +33,7 @@ Pod::Spec.new do |s|
   s.dependency 'Flutter'
 
   s.dependency 'firebase_core'
-  s.dependency 'Firebase/CoreOnly', "~> #{firebase_sdk_version}"
-  s.dependency 'Firebase/Firestore', "~> #{firebase_sdk_version}"
+  s.dependency 'Firebase/Firestore', firebase_sdk_version
   
   s.static_framework = true
   s.pod_target_xcconfig = {

--- a/packages/cloud_functions/cloud_functions/ios/cloud_functions.podspec
+++ b/packages/cloud_functions/cloud_functions/ios/cloud_functions.podspec
@@ -2,7 +2,6 @@ require 'yaml'
 pubspec = YAML.load_file(File.join('..', 'pubspec.yaml'))
 library_version = pubspec['version'].gsub('+', '-')
 
-firebase_sdk_version = '6.33.0'
 if defined?($FirebaseSDKVersion)
   Pod::UI.puts "#{pubspec['name']}: Using user specified Firebase SDK version '#{$FirebaseSDKVersion}'"
   firebase_sdk_version = $FirebaseSDKVersion
@@ -34,8 +33,7 @@ Pod::Spec.new do |s|
 
   # Firebase dependencies
   s.dependency 'firebase_core'
-  s.dependency 'Firebase/CoreOnly', "~> #{firebase_sdk_version}"
-  s.dependency 'Firebase/Functions', "~> #{firebase_sdk_version}"
+  s.dependency 'Firebase/Functions', firebase_sdk_version
 
   s.static_framework = true
   s.pod_target_xcconfig = {

--- a/packages/firebase_admob/ios/firebase_admob.podspec
+++ b/packages/firebase_admob/ios/firebase_admob.podspec
@@ -6,19 +6,6 @@ require 'yaml'
 pubspec = YAML.load_file(File.join('..', 'pubspec.yaml'))
 library_version = pubspec['version'].gsub('+', '-')
 
-firebase_sdk_version = '6.33.0'
-if defined?($FirebaseSDKVersion)
-  Pod::UI.puts "#{pubspec['name']}: Using user specified Firebase SDK version '#{$FirebaseSDKVersion}'"
-  firebase_sdk_version = $FirebaseSDKVersion
-else
-  firebase_core_script = File.join(File.expand_path('..', File.expand_path('..', File.dirname(__FILE__))), 'firebase_core/ios/firebase_sdk_version.rb')
-  if File.exist?(firebase_core_script)
-    require firebase_core_script
-    firebase_sdk_version = firebase_sdk_version!
-    Pod::UI.puts "#{pubspec['name']}: Using Firebase SDK version '#{firebase_sdk_version}' defined in 'firebase_core'"
-  end
-end
-
 Pod::Spec.new do |s|
   s.name             = pubspec['name']
   s.version          = library_version
@@ -32,7 +19,6 @@ Pod::Spec.new do |s|
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Flutter'
   s.dependency 'firebase_core'
-  s.dependency 'Firebase/CoreOnly', "~> #{firebase_sdk_version}"
   s.dependency 'Google-Mobile-Ads-SDK'
 
   s.ios.deployment_target = '8.0'

--- a/packages/firebase_analytics/firebase_analytics/ios/firebase_analytics.podspec
+++ b/packages/firebase_analytics/firebase_analytics/ios/firebase_analytics.podspec
@@ -3,7 +3,6 @@ require 'yaml'
 pubspec = YAML.load_file(File.join('..', 'pubspec.yaml'))
 library_version = pubspec['version'].gsub('+', '-')
 
-firebase_sdk_version = '6.33.0'
 if defined?($FirebaseSDKVersion)
   Pod::UI.puts "#{pubspec['name']}: Using user specified Firebase SDK version '#{$FirebaseSDKVersion}'"
   firebase_sdk_version = $FirebaseSDKVersion
@@ -34,8 +33,7 @@ Pod::Spec.new do |s|
   s.dependency 'Flutter'
 
   s.dependency 'firebase_core'
-  s.dependency 'Firebase/CoreOnly', "~> #{firebase_sdk_version}"
-  s.dependency 'Firebase/Analytics', "~> #{firebase_sdk_version}"
+  s.dependency 'Firebase/Analytics', firebase_sdk_version
   
   s.static_framework = true
   s.pod_target_xcconfig = { 

--- a/packages/firebase_auth/firebase_auth/ios/firebase_auth.podspec
+++ b/packages/firebase_auth/firebase_auth/ios/firebase_auth.podspec
@@ -3,7 +3,6 @@ require 'yaml'
 pubspec = YAML.load_file(File.join('..', 'pubspec.yaml'))
 library_version = pubspec['version'].gsub('+', '-')
 
-firebase_sdk_version = '6.33.0'
 if defined?($FirebaseSDKVersion)
   Pod::UI.puts "#{pubspec['name']}: Using user specified Firebase SDK version '#{$FirebaseSDKVersion}'"
   firebase_sdk_version = $FirebaseSDKVersion
@@ -33,8 +32,7 @@ Pod::Spec.new do |s|
   s.dependency 'Flutter'
 
   s.dependency 'firebase_core'
-  s.dependency 'Firebase/CoreOnly', "~> #{firebase_sdk_version}"
-  s.dependency 'Firebase/Auth', "~> #{firebase_sdk_version}"
+  s.dependency 'Firebase/Auth', firebase_sdk_version
   
   s.static_framework = true
   s.pod_target_xcconfig = { 

--- a/packages/firebase_core/firebase_core/android/build.gradle
+++ b/packages/firebase_core/firebase_core/android/build.gradle
@@ -36,7 +36,7 @@ android {
     }
     dependencies {
         implementation platform("com.google.firebase:firebase-bom:${getRootProjectExtOrDefaultProperty("FirebaseSDKVersion")}")
-        implementation "com.google.firebase:firebase-core"
+        implementation "com.google.firebase:firebase-common"
 
         implementation 'androidx.annotation:annotation:1.1.0'
     }

--- a/packages/firebase_core/firebase_core/example/android/app/build.gradle
+++ b/packages/firebase_core/firebase_core/example/android/app/build.gradle
@@ -24,13 +24,6 @@ if (flutterVersionName == null) {
 apply plugin: 'com.android.application'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
-// Optionally override the Firebase BoM SDK version that FlutterFire uses.
-// rootProject.ext {
-//     set("FlutterFire", [
-//             FirebaseSDKVersion: "25.3.1",
-//     ])
-// }
-
 android {
     compileSdkVersion 29
 

--- a/packages/firebase_core/firebase_core/ios/firebase_core.podspec
+++ b/packages/firebase_core/firebase_core/ios/firebase_core.podspec
@@ -3,7 +3,6 @@ require 'yaml'
 pubspec = YAML.load_file(File.join('..', 'pubspec.yaml'))
 library_version = pubspec['version'].gsub('+', '-')
 
-firebase_sdk_version = '6.33.0'
 if defined?($FirebaseSDKVersion)
   Pod::UI.puts "#{pubspec['name']}: Using user specified Firebase SDK version '#{$FirebaseSDKVersion}'"
   firebase_sdk_version = $FirebaseSDKVersion
@@ -34,7 +33,7 @@ Pod::Spec.new do |s|
   s.dependency 'Flutter'
   
   # Firebase dependencies
-  s.dependency 'Firebase/CoreOnly', "~> #{firebase_sdk_version}"
+  s.dependency 'Firebase/CoreOnly', firebase_sdk_version
    
   s.static_framework = true
   s.pod_target_xcconfig = {

--- a/packages/firebase_crashlytics/firebase_crashlytics/ios/firebase_crashlytics.podspec
+++ b/packages/firebase_crashlytics/firebase_crashlytics/ios/firebase_crashlytics.podspec
@@ -3,7 +3,6 @@ require 'yaml'
 pubspec = YAML.load_file(File.join('..', 'pubspec.yaml'))
 library_version = pubspec['version'].gsub('+', '-')
 
-firebase_sdk_version = '6.33.0'
 if defined?($FirebaseSDKVersion)
   Pod::UI.puts "#{pubspec['name']}: Using user specified Firebase SDK version '#{$FirebaseSDKVersion}'"
   firebase_sdk_version = $FirebaseSDKVersion
@@ -32,8 +31,7 @@ Pod::Spec.new do |s|
   s.ios.deployment_target = '8.0'
 
   s.dependency 'firebase_core'
-  s.dependency 'Firebase/CoreOnly', "~> #{firebase_sdk_version}"
-  s.dependency 'Firebase/Crashlytics', "~> #{firebase_sdk_version}"
+  s.dependency 'Firebase/Crashlytics', firebase_sdk_version
 
   s.static_framework = true
   s.pod_target_xcconfig = {

--- a/packages/firebase_database/ios/firebase_database.podspec
+++ b/packages/firebase_database/ios/firebase_database.podspec
@@ -3,7 +3,6 @@ require 'yaml'
 pubspec = YAML.load_file(File.join('..', 'pubspec.yaml'))
 library_version = pubspec['version'].gsub('+', '-')
 
-firebase_sdk_version = '6.33.0'
 if defined?($FirebaseSDKVersion)
   Pod::UI.puts "#{pubspec['name']}: Using user specified Firebase SDK version '#{$FirebaseSDKVersion}'"
   firebase_sdk_version = $FirebaseSDKVersion
@@ -33,8 +32,7 @@ Pod::Spec.new do |s|
   s.dependency 'Flutter'
 
   s.dependency 'firebase_core'
-  s.dependency 'Firebase/CoreOnly', "~> #{firebase_sdk_version}"
-  s.dependency 'Firebase/Database', "~> #{firebase_sdk_version}"
+  s.dependency 'Firebase/Database', firebase_sdk_version
   
   s.static_framework = true
   s.pod_target_xcconfig = {

--- a/packages/firebase_dynamic_links/ios/firebase_dynamic_links.podspec
+++ b/packages/firebase_dynamic_links/ios/firebase_dynamic_links.podspec
@@ -3,7 +3,6 @@ require 'yaml'
 pubspec = YAML.load_file(File.join('..', 'pubspec.yaml'))
 library_version = pubspec['version'].gsub('+', '-')
 
-firebase_sdk_version = '6.33.0'
 if defined?($FirebaseSDKVersion)
   Pod::UI.puts "#{pubspec['name']}: Using user specified Firebase SDK version '#{$FirebaseSDKVersion}'"
   firebase_sdk_version = $FirebaseSDKVersion
@@ -31,8 +30,7 @@ Pod::Spec.new do |s|
   s.ios.deployment_target = '8.0'
   s.static_framework = true
   s.dependency 'firebase_core'
-  s.dependency 'Firebase/CoreOnly', "~> #{firebase_sdk_version}"
-  s.dependency 'Firebase/DynamicLinks', "~> #{firebase_sdk_version}"
+  s.dependency 'Firebase/DynamicLinks', firebase_sdk_version
 
   s.pod_target_xcconfig = {
     'GCC_PREPROCESSOR_DEFINITIONS' => "LIBRARY_VERSION=\\@\\\"#{library_version}\\\" LIBRARY_NAME=\\@\\\"flutter-fire-dl\\\"",

--- a/packages/firebase_in_app_messaging/android/build.gradle
+++ b/packages/firebase_in_app_messaging/android/build.gradle
@@ -52,7 +52,7 @@ android {
 }
 
 dependencies {
-    implementation 'com.android.support:support-annotations:28.0.0'
+    implementation 'androidx.annotation:annotation:1.1.0'
 }
 
 // TODO(<github-username>): Remove this hack once androidx.lifecycle is included on stable. https://github.com/flutter/flutter/issues/42348

--- a/packages/firebase_in_app_messaging/ios/firebase_in_app_messaging.podspec
+++ b/packages/firebase_in_app_messaging/ios/firebase_in_app_messaging.podspec
@@ -3,7 +3,6 @@ require 'yaml'
 pubspec = YAML.load_file(File.join('..', 'pubspec.yaml'))
 library_version = pubspec['version'].gsub('+', '-')
 
-firebase_sdk_version = '6.33.0'
 if defined?($FirebaseSDKVersion)
   Pod::UI.puts "#{pubspec['name']}: Using user specified Firebase SDK version '#{$FirebaseSDKVersion}'"
   firebase_sdk_version = $FirebaseSDKVersion
@@ -29,8 +28,7 @@ Pod::Spec.new do |s|
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Flutter'
   s.dependency 'firebase_core'
-  s.dependency 'Firebase/CoreOnly', "~> #{firebase_sdk_version}"
-  s.dependency 'Firebase/InAppMessaging', "~> #{firebase_sdk_version}"
+  s.dependency 'Firebase/InAppMessaging', firebase_sdk_version
   s.static_framework = true
 
   s.ios.deployment_target = '8.0'

--- a/packages/firebase_messaging/firebase_messaging/example/android/app/build.gradle
+++ b/packages/firebase_messaging/firebase_messaging/example/android/app/build.gradle
@@ -25,13 +25,6 @@ apply plugin: 'com.android.application'
 apply plugin: 'com.google.gms.google-services'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
-rootProject.ext {
-  set('FlutterFire', [
-    FirebaseSDKVersion: '25.12.0'
-  ])
-}
-
-
 android {
     compileSdkVersion 29
 

--- a/packages/firebase_messaging/firebase_messaging/ios/firebase_messaging.podspec
+++ b/packages/firebase_messaging/firebase_messaging/ios/firebase_messaging.podspec
@@ -3,7 +3,6 @@ require 'yaml'
 pubspec = YAML.load_file(File.join('..', 'pubspec.yaml'))
 library_version = pubspec['version'].gsub('+', '-')
 
-firebase_sdk_version = '6.33.0'
 if defined?($FirebaseSDKVersion)
   Pod::UI.puts "#{pubspec['name']}: Using user specified Firebase SDK version '#{$FirebaseSDKVersion}'"
   firebase_sdk_version = $FirebaseSDKVersion
@@ -34,8 +33,7 @@ Pod::Spec.new do |s|
   s.dependency 'Flutter'
 
   s.dependency 'firebase_core'
-  s.dependency 'Firebase/CoreOnly', "~> #{firebase_sdk_version}"
-  s.dependency 'Firebase/Messaging', "~> #{firebase_sdk_version}"
+  s.dependency 'Firebase/Messaging', firebase_sdk_version
   s.static_framework = true
   s.pod_target_xcconfig = {
     'GCC_PREPROCESSOR_DEFINITIONS' => "LIBRARY_VERSION=\\@\\\"#{library_version}\\\" LIBRARY_NAME=\\@\\\"flutter-fire-fcm\\\"",

--- a/packages/firebase_ml_custom/android/build.gradle
+++ b/packages/firebase_ml_custom/android/build.gradle
@@ -21,6 +21,19 @@ rootProject.allprojects {
 
 apply plugin: 'com.android.library'
 
+def firebaseCoreProject = findProject(':firebase_core')
+if (firebaseCoreProject == null) {
+  throw new GradleException('Could not find the firebase_core FlutterFire plugin, have you added it as a dependency in your pubspec?')
+} else if (!firebaseCoreProject.properties['FirebaseSDKVersion']) {
+  throw new GradleException('A newer version of the firebase_core FlutterFire plugin is required, please update your firebase_core pubspec dependency.')
+}
+
+def getRootProjectExtOrCoreProperty(name, firebaseCoreProject) {
+  if (!rootProject.ext.has('FlutterFire')) return firebaseCoreProject.properties[name]
+  if (!rootProject.ext.get('FlutterFire')[name]) return firebaseCoreProject.properties[name]
+  return rootProject.ext.get('FlutterFire').get(name)
+}
+
 android {
     compileSdkVersion 29
 
@@ -32,9 +45,11 @@ android {
         disable 'InvalidPackage'
     }
     dependencies {
-        api 'com.google.firebase:firebase-ml-model-interpreter:22.0.3'
-        implementation 'androidx.annotation:annotation:1.0.0'
-        implementation 'androidx.exifinterface:exifinterface:1.0.0'
+        api firebaseCoreProject
+        implementation platform("com.google.firebase:firebase-bom:${getRootProjectExtOrCoreProperty("FirebaseSDKVersion", firebaseCoreProject)}")
+        api 'com.google.firebase:firebase-ml-model-interpreter'
+        implementation 'androidx.annotation:annotation:1.1.0'
+        implementation 'androidx.exifinterface:exifinterface:1.3.1'
     }
 }
 

--- a/packages/firebase_ml_custom/ios/firebase_ml_custom.podspec
+++ b/packages/firebase_ml_custom/ios/firebase_ml_custom.podspec
@@ -7,6 +7,18 @@ require 'yaml'
 pubspec = YAML.load_file(File.join('..', 'pubspec.yaml'))
 libraryVersion = pubspec['version'].gsub('+', '-')
 
+if defined?($FirebaseSDKVersion)
+  Pod::UI.puts "#{pubspec['name']}: Using user specified Firebase SDK version '#{$FirebaseSDKVersion}'"
+  firebase_sdk_version = $FirebaseSDKVersion
+else
+  firebase_core_script = File.join(File.expand_path('..', File.expand_path('..', File.dirname(__FILE__))), 'firebase_core/ios/firebase_sdk_version.rb')
+  if File.exist?(firebase_core_script)
+    require firebase_core_script
+    firebase_sdk_version = firebase_sdk_version!
+    Pod::UI.puts "#{pubspec['name']}: Using Firebase SDK version '#{firebase_sdk_version}' defined in 'firebase_core'"
+  end
+end
+
 Pod::Spec.new do |s|
   s.name             = 'firebase_ml_custom'
   s.version          = '0.0.1'
@@ -21,7 +33,8 @@ A new Flutter plugin.
   s.source_files = 'Classes/**/*'
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Flutter'
-  s.dependency 'Firebase/MLModelInterpreter', "~> 6.33.0"
+  s.dependency 'firebase_core'
+  s.dependency 'Firebase/MLModelInterpreter', firebase_sdk_version
   s.ios.deployment_target = '9.0'
   s.static_framework = true
 

--- a/packages/firebase_ml_vision/android/build.gradle
+++ b/packages/firebase_ml_vision/android/build.gradle
@@ -21,6 +21,19 @@ rootProject.allprojects {
 
 apply plugin: 'com.android.library'
 
+def firebaseCoreProject = findProject(':firebase_core')
+if (firebaseCoreProject == null) {
+  throw new GradleException('Could not find the firebase_core FlutterFire plugin, have you added it as a dependency in your pubspec?')
+} else if (!firebaseCoreProject.properties['FirebaseSDKVersion']) {
+  throw new GradleException('A newer version of the firebase_core FlutterFire plugin is required, please update your firebase_core pubspec dependency.')
+}
+
+def getRootProjectExtOrCoreProperty(name, firebaseCoreProject) {
+  if (!rootProject.ext.has('FlutterFire')) return firebaseCoreProject.properties[name]
+  if (!rootProject.ext.get('FlutterFire')[name]) return firebaseCoreProject.properties[name]
+  return rootProject.ext.get('FlutterFire').get(name)
+}
+
 android {
     compileSdkVersion 29
 
@@ -32,7 +45,7 @@ android {
         disable 'InvalidPackage'
     }
     dependencies {
-        implementation platform("com.google.firebase:firebase-bom:25.13.0")
+        implementation platform("com.google.firebase:firebase-bom:${getRootProjectExtOrCoreProperty("FirebaseSDKVersion", firebaseCoreProject)}")
         implementation 'com.google.firebase:firebase-common'
         api "com.google.firebase:firebase-ml-vision"
 

--- a/packages/firebase_ml_vision/example/android/app/build.gradle
+++ b/packages/firebase_ml_vision/example/android/app/build.gradle
@@ -24,6 +24,19 @@ if (flutterVersionName == null) {
 apply plugin: 'com.android.application'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
+def firebaseCoreProject = findProject(':firebase_core')
+if (firebaseCoreProject == null) {
+  throw new GradleException('Could not find the firebase_core FlutterFire plugin, have you added it as a dependency in your pubspec?')
+} else if (!firebaseCoreProject.properties['FirebaseSDKVersion']) {
+  throw new GradleException('A newer version of the firebase_core FlutterFire plugin is required, please update your firebase_core pubspec dependency.')
+}
+
+def getRootProjectExtOrCoreProperty(name, firebaseCoreProject) {
+  if (!rootProject.ext.has('FlutterFire')) return firebaseCoreProject.properties[name]
+  if (!rootProject.ext.get('FlutterFire')[name]) return firebaseCoreProject.properties[name]
+  return rootProject.ext.get('FlutterFire').get(name)
+}
+
 android {
     compileSdkVersion 29
 

--- a/packages/firebase_ml_vision/ios/firebase_ml_vision.podspec
+++ b/packages/firebase_ml_vision/ios/firebase_ml_vision.podspec
@@ -6,6 +6,18 @@ require 'yaml'
 pubspec = YAML.load_file(File.join('..', 'pubspec.yaml'))
 libraryVersion = pubspec['version'].gsub('+', '-')
 
+if defined?($FirebaseSDKVersion)
+  Pod::UI.puts "#{pubspec['name']}: Using user specified Firebase SDK version '#{$FirebaseSDKVersion}'"
+  firebase_sdk_version = $FirebaseSDKVersion
+else
+  firebase_core_script = File.join(File.expand_path('..', File.expand_path('..', File.dirname(__FILE__))), 'firebase_core/ios/firebase_sdk_version.rb')
+  if File.exist?(firebase_core_script)
+    require firebase_core_script
+    firebase_sdk_version = firebase_sdk_version!
+    Pod::UI.puts "#{pubspec['name']}: Using Firebase SDK version '#{firebase_sdk_version}' defined in 'firebase_core'"
+  end
+end
+
 Pod::Spec.new do |s|
   s.name             = 'firebase_ml_vision'
   s.version          = '0.1.1'
@@ -21,8 +33,8 @@ An SDK that brings Google's machine learning expertise to Android and iOS apps i
   s.source_files = 'Classes/**/*'
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Flutter'
-  s.dependency 'Firebase/Core'
-  s.dependency 'Firebase/MLVision'
+  s.dependency 'firebase_core'
+  s.dependency 'Firebase/MLVision', firebase_sdk_version
   s.ios.deployment_target = '9.0'
   s.static_framework = true
 

--- a/packages/firebase_performance/example/android/app/build.gradle
+++ b/packages/firebase_performance/example/android/app/build.gradle
@@ -22,6 +22,7 @@ if (flutterVersionName == null) {
 }
 
 apply plugin: 'com.android.application'
+apply plugin: "com.google.firebase.firebase-perf"
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {

--- a/packages/firebase_performance/example/android/build.gradle
+++ b/packages/firebase_performance/example/android/build.gradle
@@ -8,6 +8,7 @@ buildscript {
     dependencies {
         classpath 'com.android.tools.build:gradle:3.5.4'
         classpath 'com.google.gms:google-services:4.3.4'
+        classpath 'com.google.firebase:perf-plugin:1.3.2'
     }
 }
 

--- a/packages/firebase_performance/ios/firebase_performance.podspec
+++ b/packages/firebase_performance/ios/firebase_performance.podspec
@@ -6,7 +6,6 @@ require 'yaml'
 pubspec = YAML.load_file(File.join('..', 'pubspec.yaml'))
 library_version = pubspec['version'].gsub('+', '-')
 
-firebase_sdk_version = '6.33.0'
 if defined?($FirebaseSDKVersion)
   Pod::UI.puts "#{pubspec['name']}: Using user specified Firebase SDK version '#{$FirebaseSDKVersion}'"
   firebase_sdk_version = $FirebaseSDKVersion
@@ -32,8 +31,7 @@ Pod::Spec.new do |s|
   s.public_header_files = 'Classes/**/*.h'
   s.dependency 'Flutter'
   s.dependency 'firebase_core'
-  s.dependency 'Firebase/CoreOnly', "~> #{firebase_sdk_version}"
-  s.dependency 'Firebase/Performance', "~> #{firebase_sdk_version}"
+  s.dependency 'Firebase/Performance', firebase_sdk_version
   s.ios.deployment_target = '8.0'
   s.static_framework = true
 

--- a/packages/firebase_remote_config/ios/firebase_remote_config.podspec
+++ b/packages/firebase_remote_config/ios/firebase_remote_config.podspec
@@ -3,7 +3,6 @@ require 'yaml'
 pubspec = YAML.load_file(File.join('..', 'pubspec.yaml'))
 library_version = pubspec['version'].gsub('+', '-')
 
-firebase_sdk_version = '6.33.0'
 if defined?($FirebaseSDKVersion)
   Pod::UI.puts "#{pubspec['name']}: Using user specified Firebase SDK version '#{$FirebaseSDKVersion}'"
   firebase_sdk_version = $FirebaseSDKVersion
@@ -33,8 +32,7 @@ Pod::Spec.new do |s|
   s.dependency 'Flutter'
 
   s.dependency 'firebase_core'
-  s.dependency 'Firebase/CoreOnly', "~> #{firebase_sdk_version}"
-  s.dependency 'Firebase/RemoteConfig', "~> #{firebase_sdk_version}"
+  s.dependency 'Firebase/RemoteConfig', firebase_sdk_version
 
   s.static_framework = true
   s.pod_target_xcconfig = { 

--- a/packages/firebase_storage/firebase_storage/android/build.gradle
+++ b/packages/firebase_storage/firebase_storage/android/build.gradle
@@ -59,7 +59,7 @@ android {
         api firebaseCoreProject
         implementation platform("com.google.firebase:firebase-bom:${getRootProjectExtOrCoreProperty("FirebaseSDKVersion", firebaseCoreProject)}")
         implementation 'com.google.firebase:firebase-storage'
-        implementation 'androidx.annotation:annotation:1.0.0'
+        implementation 'androidx.annotation:annotation:1.1.0'
     }
 }
 

--- a/packages/firebase_storage/firebase_storage/ios/firebase_storage.podspec
+++ b/packages/firebase_storage/firebase_storage/ios/firebase_storage.podspec
@@ -3,7 +3,6 @@ require 'yaml'
 pubspec = YAML.load_file(File.join('..', 'pubspec.yaml'))
 library_version = pubspec['version'].gsub('+', '-')
 
-firebase_sdk_version = '6.33.0'
 if defined?($FirebaseSDKVersion)
   Pod::UI.puts "#{pubspec['name']}: Using user specified Firebase SDK version '#{$FirebaseSDKVersion}'"
   firebase_sdk_version = $FirebaseSDKVersion
@@ -33,8 +32,7 @@ Pod::Spec.new do |s|
   s.dependency 'Flutter'
 
   s.dependency 'firebase_core'
-  s.dependency 'Firebase/CoreOnly', "~> #{firebase_sdk_version}"
-  s.dependency 'Firebase/Storage', "~> #{firebase_sdk_version}"
+  s.dependency 'Firebase/Storage', firebase_sdk_version
   
   s.static_framework = true
   s.pod_target_xcconfig = {


### PR DESCRIPTION
## Description

The logic to specify a baseline firebase SDK version and accept an override for same is fairly standardized across the repository but not applied uniformly or used everywhere

This PR harmonizes the logic across the repository, depends on firebase_core as needed in place of lower-level direct pod dependencies on ios and uses the BoM and core pod versions where ever possible

## Related Issues

This is related to the forward port PR #4249 but is not a core part of that change, rather it makes that change easier while being independently correct and useful, so I'm submitting it separately for immediate consideration in order to shrink that PR and get feedback on utility

## Checklist


- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [ ] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
