### PR TITLE
fix(messaging): manually create a `FlutterShellArgs` instance from Android activity intent (fixes #4078)

### DIFF
--- a/packages/firebase_messaging/firebase_messaging/android/src/main/java/io/flutter/plugins/firebase/messaging/FlutterFirebaseMessagingPlugin.java
+++ b/packages/firebase_messaging/firebase_messaging/android/src/main/java/io/flutter/plugins/firebase/messaging/FlutterFirebaseMessagingPlugin.java
@@ -297,8 +297,11 @@ public class FlutterFirebaseMessagingPlugin extends BroadcastReceiver
 
         FlutterShellArgs shellArgs = null;
         if (mainActivity != null) {
-          shellArgs =
-              ((io.flutter.embedding.android.FlutterActivity) mainActivity).getFlutterShellArgs();
+          // Supports both Flutter Activity types:
+          //    io.flutter.embedding.android.FlutterFragmentActivity
+          //    io.flutter.embedding.android.FlutterActivity
+          // We could use `getFlutterShellArgs()` but this is only available on `FlutterActivity`.
+          shellArgs = FlutterShellArgs.fromIntent(mainActivity.getIntent());
         }
 
         FlutterFirebaseMessagingBackgroundService.setCallbackDispatcher(pluginCallbackHandle);


### PR DESCRIPTION
## Description

Manually create a `FlutterShellArgs` instance from an Android activity intent.

Doing it this way means we can supports both Flutter Activity types:
 - `io.flutter.embedding.android.FlutterFragmentActivity`
 - `io.flutter.embedding.android.FlutterActivity`

`getFlutterShellArgs()` that was used previously is only available on `FlutterActivity`.

## Related Issues

Fixes #4078.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
