### PR TITLE
fix(firebase_messaging): cast args lists to string values

### DIFF
--- a/packages/firebase_messaging/firebase_messaging_platform_interface/lib/src/remote_notification.dart
+++ b/packages/firebase_messaging/firebase_messaging_platform_interface/lib/src/remote_notification.dart
@@ -48,7 +48,7 @@ class RemoteNotification {
       _apple = AppleNotification(
           badge: map['apple']['badge'],
           subtitle: map['apple']['subtitle'],
-          subtitleLocArgs: map['apple']['subtitleLocArgs'] ?? [],
+          subtitleLocArgs: _toList(map['apple']['subtitleLocArgs']),
           subtitleLocKey: map['apple']['subtitleLocKey'],
           imageUrl: map['apple']['imageUrl'],
           sound: map['apple']['sound'] == null
@@ -61,10 +61,10 @@ class RemoteNotification {
 
     return RemoteNotification(
       title: map['title'],
-      titleLocArgs: map['titleLocArgs'] ?? [],
+      titleLocArgs: _toList(map['titleLocArgs']),
       titleLocKey: map['titleLocKey'],
       body: map['body'],
-      bodyLocArgs: map['bodyLocArgs'] ?? [],
+      bodyLocArgs: _toList(map['bodyLocArgs']),
       bodyLocKey: map['bodyLocKey'],
       android: _android,
       apple: _apple,
@@ -204,4 +204,13 @@ class AppleNotificationSound {
   ///
   /// This value is a number between 0.0 & 1.0.
   final num volume;
+}
+
+// Utility to correctly cast lists
+List<String> _toList(dynamic value) {
+  if (value == null) {
+    return List<String>(0);
+  }
+
+  return List<String>.from(value);
 }

--- a/packages/firebase_messaging/firebase_messaging_platform_interface/lib/src/remote_notification.dart
+++ b/packages/firebase_messaging/firebase_messaging_platform_interface/lib/src/remote_notification.dart
@@ -209,7 +209,7 @@ class AppleNotificationSound {
 // Utility to correctly cast lists
 List<String> _toList(dynamic value) {
   if (value == null) {
-    return List<String>(0);
+    return <String>[];
   }
 
   return List<String>.from(value);


### PR DESCRIPTION
## Description

List values returned from native are not being cast correctly, this change forces the list items contain `String` types.

## Related Issues

https://github.com/FirebaseExtended/flutterfire/issues/4359

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
