### PR TITLE
chore(firebase_storage): null safety hints

### DIFF
--- a/packages/firebase_storage/firebase_storage/example/lib/main.dart
+++ b/packages/firebase_storage/firebase_storage/example/lib/main.dart
@@ -221,16 +221,16 @@ class UploadTaskListTile extends StatelessWidget {
       : super(key: key);
 
   /// The [UploadTask].
-  final firebase_storage.UploadTask/*!*/ task;
+  final firebase_storage.UploadTask /*!*/ task;
 
   /// Triggered when the user dismisses the task from the list.
-  final VoidCallback/*!*/ onDismissed;
+  final VoidCallback /*!*/ onDismissed;
 
   /// Triggered when the user presses the download button on a completed upload task.
-  final VoidCallback/*!*/ onDownload;
+  final VoidCallback /*!*/ onDownload;
 
   /// Triggered when the user presses the "link" button on a completed upload task.
-  final VoidCallback/*!*/ onDownloadLink;
+  final VoidCallback /*!*/ onDownloadLink;
 
   /// Displays the current transferred bytes of the task.
   String _bytesTransferred(firebase_storage.TaskSnapshot snapshot) {

--- a/packages/firebase_storage/firebase_storage/example/lib/main.dart
+++ b/packages/firebase_storage/firebase_storage/example/lib/main.dart
@@ -221,16 +221,16 @@ class UploadTaskListTile extends StatelessWidget {
       : super(key: key);
 
   /// The [UploadTask].
-  final firebase_storage.UploadTask task;
+  final firebase_storage.UploadTask/*!*/ task;
 
   /// Triggered when the user dismisses the task from the list.
-  final VoidCallback onDismissed;
+  final VoidCallback/*!*/ onDismissed;
 
   /// Triggered when the user presses the download button on a completed upload task.
-  final VoidCallback onDownload;
+  final VoidCallback/*!*/ onDownload;
 
   /// Triggered when the user presses the "link" button on a completed upload task.
-  final VoidCallback onDownloadLink;
+  final VoidCallback/*!*/ onDownloadLink;
 
   /// Displays the current transferred bytes of the task.
   String _bytesTransferred(firebase_storage.TaskSnapshot snapshot) {

--- a/packages/firebase_storage/firebase_storage/example/test_driver/instance_e2e.dart
+++ b/packages/firebase_storage/firebase_storage/example/test_driver/instance_e2e.dart
@@ -8,9 +8,9 @@ import 'test_utils.dart';
 
 void runInstanceTests() {
   group('$FirebaseStorage', () {
-    FirebaseStorage storage;
-    FirebaseApp secondaryApp;
-    FirebaseApp secondaryAppWithoutBucket;
+    /*late*/ FirebaseStorage storage;
+    /*late*/ FirebaseApp secondaryApp;
+    /*late*/ FirebaseApp secondaryAppWithoutBucket;
 
     setUpAll(() async {
       await Firebase.initializeApp();

--- a/packages/firebase_storage/firebase_storage/example/test_driver/list_result_e2e.dart
+++ b/packages/firebase_storage/firebase_storage/example/test_driver/list_result_e2e.dart
@@ -5,8 +5,9 @@ import 'package:flutter_test/flutter_test.dart';
 
 void runListResultTests() {
   group('$ListResult', () {
-    FirebaseStorage storage;
-    ListResult result;
+    /*late*/ FirebaseStorage storage;
+    /*late*/ListResult result;
+    
     setUpAll(() async {
       storage = FirebaseStorage.instance;
       Reference ref = storage.ref('/list');

--- a/packages/firebase_storage/firebase_storage/example/test_driver/list_result_e2e.dart
+++ b/packages/firebase_storage/firebase_storage/example/test_driver/list_result_e2e.dart
@@ -6,8 +6,8 @@ import 'package:flutter_test/flutter_test.dart';
 void runListResultTests() {
   group('$ListResult', () {
     /*late*/ FirebaseStorage storage;
-    /*late*/ListResult result;
-    
+    /*late*/ ListResult result;
+
     setUpAll(() async {
       storage = FirebaseStorage.instance;
       Reference ref = storage.ref('/list');

--- a/packages/firebase_storage/firebase_storage/example/test_driver/reference_e2e.dart
+++ b/packages/firebase_storage/firebase_storage/example/test_driver/reference_e2e.dart
@@ -13,7 +13,7 @@ import './test_utils.dart';
 
 void runReferenceTests() {
   group('$Reference', () {
-    FirebaseStorage storage;
+    /*late*/ FirebaseStorage storage;
 
     setUpAll(() async {
       storage = FirebaseStorage.instance;

--- a/packages/firebase_storage/firebase_storage/example/test_driver/task_e2e.dart
+++ b/packages/firebase_storage/firebase_storage/example/test_driver/task_e2e.dart
@@ -92,7 +92,7 @@ void runTaskTests() {
       });
 
       test('handles errors, e.g. if permission denied', () async {
-       /*late*/ FirebaseException streamError;
+        /*late*/ FirebaseException streamError;
 
         List<int> list = utf8.encode('hello world');
         Uint8List data = Uint8List.fromList(list);
@@ -159,7 +159,7 @@ void runTaskTests() {
     });
 
     group('cancel()', () {
-      /*late*/ Task/*!*/ task;
+      /*late*/ Task /*!*/ task;
 
       final _testCancelTask = () async {
         List<TaskSnapshot> snapshots = [];

--- a/packages/firebase_storage/firebase_storage/example/test_driver/task_e2e.dart
+++ b/packages/firebase_storage/firebase_storage/example/test_driver/task_e2e.dart
@@ -13,10 +13,10 @@ import './test_utils.dart';
 
 void runTaskTests() {
   group('Task', () {
-    FirebaseStorage storage;
-    File file;
-    Reference uploadRef;
-    Reference downloadRef;
+    /*late*/ FirebaseStorage storage;
+    /*late*/ File file;
+    /*late*/ Reference uploadRef;
+    /*late*/ Reference downloadRef;
 
     setUpAll(() async {
       storage = FirebaseStorage.instance;
@@ -25,7 +25,7 @@ void runTaskTests() {
     });
 
     group('pause() resume() onComplete()', () {
-      Task task;
+      /*late*/ Task task;
 
       setUp(() {
         task = null;
@@ -92,7 +92,7 @@ void runTaskTests() {
       });
 
       test('handles errors, e.g. if permission denied', () async {
-        FirebaseException streamError;
+       /*late*/ FirebaseException streamError;
 
         List<int> list = utf8.encode('hello world');
         Uint8List data = Uint8List.fromList(list);
@@ -159,11 +159,7 @@ void runTaskTests() {
     });
 
     group('cancel()', () {
-      Task task;
-
-      setUp(() {
-        task = null;
-      });
+      /*late*/ Task/*!*/ task;
 
       final _testCancelTask = () async {
         List<TaskSnapshot> snapshots = [];

--- a/packages/firebase_storage/firebase_storage/lib/src/firebase_storage.dart
+++ b/packages/firebase_storage/firebase_storage/lib/src/firebase_storage.dart
@@ -11,7 +11,7 @@ class FirebaseStorage extends FirebasePluginPlatform {
   // instance with the default app before a user specifies an app.
   FirebaseStoragePlatform _delegatePackingProperty;
 
-  FirebaseStoragePlatform/*!*/ get _delegate {
+  FirebaseStoragePlatform /*!*/ get _delegate {
     if (_delegatePackingProperty == null) {
       _delegatePackingProperty = FirebaseStoragePlatform.instanceFor(
         app: app,
@@ -25,7 +25,7 @@ class FirebaseStorage extends FirebasePluginPlatform {
   FirebaseApp app;
 
   /// The storage bucket of this instance.
-  String/*!*/ bucket;
+  String /*!*/ bucket;
 
   /// The maximum time to retry operations other than uploads or downloads in milliseconds.
   Duration get maxOperationRetryTime {
@@ -58,7 +58,7 @@ class FirebaseStorage extends FirebasePluginPlatform {
   ///
   /// If [app] is not provided, the default Firebase app will be used.
   /// If [bucket] is not provided, the default storage bucket will be used.
-  static FirebaseStorage/*!*/ instanceFor({
+  static FirebaseStorage /*!*/ instanceFor({
     FirebaseApp app,
     String bucket,
   }) {
@@ -109,7 +109,7 @@ class FirebaseStorage extends FirebasePluginPlatform {
   ///
   /// If the [path] is empty, the reference will point to the root of the
   /// storage bucket.
-  Reference ref([String/*?*/ path]) {
+  Reference ref([String /*?*/ path]) {
     path ??= '/';
     path = path.isEmpty ? '/' : path;
     return Reference._(this, _delegate.ref(path));

--- a/packages/firebase_storage/firebase_storage/lib/src/firebase_storage.dart
+++ b/packages/firebase_storage/firebase_storage/lib/src/firebase_storage.dart
@@ -11,7 +11,7 @@ class FirebaseStorage extends FirebasePluginPlatform {
   // instance with the default app before a user specifies an app.
   FirebaseStoragePlatform _delegatePackingProperty;
 
-  FirebaseStoragePlatform get _delegate {
+  FirebaseStoragePlatform/*!*/ get _delegate {
     if (_delegatePackingProperty == null) {
       _delegatePackingProperty = FirebaseStoragePlatform.instanceFor(
         app: app,
@@ -25,7 +25,7 @@ class FirebaseStorage extends FirebasePluginPlatform {
   FirebaseApp app;
 
   /// The storage bucket of this instance.
-  String bucket;
+  String/*!*/ bucket;
 
   /// The maximum time to retry operations other than uploads or downloads in milliseconds.
   Duration get maxOperationRetryTime {
@@ -58,7 +58,7 @@ class FirebaseStorage extends FirebasePluginPlatform {
   ///
   /// If [app] is not provided, the default Firebase app will be used.
   /// If [bucket] is not provided, the default storage bucket will be used.
-  static FirebaseStorage instanceFor({
+  static FirebaseStorage/*!*/ instanceFor({
     FirebaseApp app,
     String bucket,
   }) {
@@ -68,6 +68,7 @@ class FirebaseStorage extends FirebasePluginPlatform {
     bucket ??= app.options.storageBucket;
 
     // A bucket must exist at this point
+    // TODO(ehesp): Check whether `app.options.storageBucket` can be nullable post migration
     if (bucket == null) {
       if (app.name == defaultFirebaseAppName) {
         _throwNoBucketError(
@@ -108,7 +109,7 @@ class FirebaseStorage extends FirebasePluginPlatform {
   ///
   /// If the [path] is empty, the reference will point to the root of the
   /// storage bucket.
-  Reference ref([String path]) {
+  Reference ref([String/*?*/ path]) {
     path ??= '/';
     path = path.isEmpty ? '/' : path;
     return Reference._(this, _delegate.ref(path));

--- a/packages/firebase_storage/firebase_storage/lib/src/list_result.dart
+++ b/packages/firebase_storage/firebase_storage/lib/src/list_result.dart
@@ -29,7 +29,7 @@ class ListResult {
   /// If set, there might be more results for this list.
   ///
   /// Use this token to resume the list with [ListOptions].
-  String/*?*/ get nextPageToken => _delegate.nextPageToken;
+  String /*?*/ get nextPageToken => _delegate.nextPageToken;
 
   /// References to prefixes (sub-folders). You can call list() on them to get
   /// its contents.

--- a/packages/firebase_storage/firebase_storage/lib/src/list_result.dart
+++ b/packages/firebase_storage/firebase_storage/lib/src/list_result.dart
@@ -29,7 +29,7 @@ class ListResult {
   /// If set, there might be more results for this list.
   ///
   /// Use this token to resume the list with [ListOptions].
-  String get nextPageToken => _delegate.nextPageToken;
+  String/*?*/ get nextPageToken => _delegate.nextPageToken;
 
   /// References to prefixes (sub-folders). You can call list() on them to get
   /// its contents.

--- a/packages/firebase_storage/firebase_storage/lib/src/reference.dart
+++ b/packages/firebase_storage/firebase_storage/lib/src/reference.dart
@@ -54,7 +54,7 @@ class Reference {
   /// A reference pointing to the parent location of this reference, or `null`
   /// if this reference is the root.
   Reference get parent {
-    ReferencePlatform referenceParentPlatform = _delegate.parent;
+    ReferencePlatform/*?*/ referenceParentPlatform = _delegate.parent;
 
     if (referenceParentPlatform == null) {
       return null;
@@ -107,12 +107,13 @@ class Reference {
   /// objects whose paths end with "/" or contain two consecutive "/"s. Firebase
   /// Storage List API will filter these unsupported objects. [list] may fail
   /// if there are too many unsupported objects in the bucket.
-  Future<ListResult> list(ListOptions options) async {
+  Future<ListResult> list([ListOptions/*?*/ options]) async {
     if (options?.maxResults != null) {
       assert(options.maxResults > 0);
       assert(options.maxResults <= 1000);
     }
 
+    // TODO(ehesp): options should be nullable post platform migration
     return ListResult._(storage, await _delegate.list(options));
   }
 
@@ -219,6 +220,8 @@ class Reference {
         );
       }
     }
+
+    // TODO(ehesp): Check metadata is nullable post platform migration
     return UploadTask._(storage, _delegate.putString(data, format, metadata));
   }
 

--- a/packages/firebase_storage/firebase_storage/lib/src/reference.dart
+++ b/packages/firebase_storage/firebase_storage/lib/src/reference.dart
@@ -137,7 +137,7 @@ class Reference {
   ///
   /// If the [maxSize] (in bytes) is exceeded, the operation will be canceled. By
   /// default the [maxSize] is 10mb (10485760 bytes).
-  Future<Uint8List> getData([int maxSize]) async {
+  Future<Uint8List /*?*/ > getData([int maxSize]) async {
     maxSize ??= 10485760;
     assert(maxSize > 0);
     return _delegate.getData(maxSize);

--- a/packages/firebase_storage/firebase_storage/lib/src/reference.dart
+++ b/packages/firebase_storage/firebase_storage/lib/src/reference.dart
@@ -54,7 +54,7 @@ class Reference {
   /// A reference pointing to the parent location of this reference, or `null`
   /// if this reference is the root.
   Reference get parent {
-    ReferencePlatform/*?*/ referenceParentPlatform = _delegate.parent;
+    ReferencePlatform /*?*/ referenceParentPlatform = _delegate.parent;
 
     if (referenceParentPlatform == null) {
       return null;
@@ -107,7 +107,7 @@ class Reference {
   /// objects whose paths end with "/" or contain two consecutive "/"s. Firebase
   /// Storage List API will filter these unsupported objects. [list] may fail
   /// if there are too many unsupported objects in the bucket.
-  Future<ListResult> list([ListOptions/*?*/ options]) async {
+  Future<ListResult> list([ListOptions /*?*/ options]) async {
     if (options?.maxResults != null) {
       assert(options.maxResults > 0);
       assert(options.maxResults <= 1000);

--- a/packages/firebase_storage/firebase_storage/test/firebase_storage_test.dart
+++ b/packages/firebase_storage/firebase_storage/test/firebase_storage_test.dart
@@ -14,10 +14,10 @@ import 'package:mockito/mockito.dart';
 
 void main() {
   setupFirebaseStorageMocks();
-  FirebaseApp app;
-  FirebaseStorage storage;
-  FirebaseStorage storageSecondary;
-  FirebaseApp secondaryApp;
+  /*late*/ FirebaseApp app;
+  /*late*/ FirebaseStorage storage;
+  /*late*/ FirebaseStorage storageSecondary;
+  /*late*/ FirebaseApp secondaryApp;
 
   group('$FirebaseStorage', () {
     setUpAll(() async {

--- a/packages/firebase_storage/firebase_storage/test/list_result_test.dart
+++ b/packages/firebase_storage/firebase_storage/test/list_result_test.dart
@@ -16,8 +16,8 @@ void main() {
 
   const String kNextPageToken = 'next-page-token';
 
-  FirebaseStorage storage;
-  ListResult listResult;
+  /*late*/ FirebaseStorage storage;
+  /*late*/ ListResult listResult;
   MockReferencePlatform mockReference = MockReferencePlatform();
   MockListResultPlatform mockList = MockListResultPlatform();
 

--- a/packages/firebase_storage/firebase_storage/test/reference_test.dart
+++ b/packages/firebase_storage/firebase_storage/test/reference_test.dart
@@ -35,8 +35,8 @@ MockDownloadTaskPlatform mockDownloadTaskPlatform = MockDownloadTaskPlatform();
 
 void main() async {
   setupFirebaseStorageMocks();
-  FirebaseStorage storage;
-  Reference testRef;
+  /*late*/ FirebaseStorage storage;
+  /*late*/ Reference testRef;
   FullMetadata testFullMetadata = FullMetadata(testMetadataMap);
   ListOptions testListOptions =
       ListOptions(maxResults: testMaxResults, pageToken: testPageToken);

--- a/packages/firebase_storage/firebase_storage/test/task_snapshot_test.dart
+++ b/packages/firebase_storage/firebase_storage/test/task_snapshot_test.dart
@@ -24,8 +24,8 @@ MockTaskSnapshotPlatform mockTaskSnapshotPlatform = MockTaskSnapshotPlatform();
 
 void main() {
   setupFirebaseStorageMocks();
-  FirebaseStorage storage;
-  TaskSnapshot taskSnapshot;
+  /*late*/ FirebaseStorage storage;
+  /*late*/ TaskSnapshot taskSnapshot;
   FullMetadata fullMetadata = FullMetadata(testMetadata);
 
   group('$TaskSnapshot', () {

--- a/packages/firebase_storage/firebase_storage/test/task_test.dart
+++ b/packages/firebase_storage/firebase_storage/test/task_test.dart
@@ -20,8 +20,8 @@ MockTaskSnapshotPlatform mockTaskSnapshotPlatform = MockTaskSnapshotPlatform();
 void main() {
   setupFirebaseStorageMocks();
 
-  FirebaseStorage storage;
-  UploadTask uploadTask;
+  /*late*/ FirebaseStorage storage;
+  /*late*/ UploadTask uploadTask;
 
   group('Task', () {
     setUpAll(() async {

--- a/packages/firebase_storage/firebase_storage_platform_interface/lib/src/full_metadata.dart
+++ b/packages/firebase_storage/firebase_storage_platform_interface/lib/src/full_metadata.dart
@@ -10,7 +10,7 @@ class FullMetadata {
   @protected
   FullMetadata(this._metadata);
 
-  final Map<String, dynamic>/*!*/ _metadata;
+  final Map<String, dynamic> /*!*/ _metadata;
 
   /// The bucket this object is contained in.
   String get bucket {

--- a/packages/firebase_storage/firebase_storage_platform_interface/lib/src/full_metadata.dart
+++ b/packages/firebase_storage/firebase_storage_platform_interface/lib/src/full_metadata.dart
@@ -10,7 +10,7 @@ class FullMetadata {
   @protected
   FullMetadata(this._metadata);
 
-  final Map<String, dynamic> _metadata;
+  final Map<String, dynamic>/*!*/ _metadata;
 
   /// The bucket this object is contained in.
   String get bucket {

--- a/packages/firebase_storage/firebase_storage_platform_interface/lib/src/internal/pointer.dart
+++ b/packages/firebase_storage/firebase_storage_platform_interface/lib/src/internal/pointer.dart
@@ -25,7 +25,7 @@ class Pointer {
     }
   }
 
-  String _path;
+  String/*!*/ _path;
 
   /// Returns whether the path points to the root of a bucket.
   bool get isRoot {

--- a/packages/firebase_storage/firebase_storage_platform_interface/lib/src/internal/pointer.dart
+++ b/packages/firebase_storage/firebase_storage_platform_interface/lib/src/internal/pointer.dart
@@ -25,7 +25,7 @@ class Pointer {
     }
   }
 
-  String/*!*/ _path;
+  String /*!*/ _path;
 
   /// Returns whether the path points to the root of a bucket.
   bool get isRoot {

--- a/packages/firebase_storage/firebase_storage_platform_interface/lib/src/method_channel/method_channel_firebase_storage.dart
+++ b/packages/firebase_storage/firebase_storage_platform_interface/lib/src/method_channel/method_channel_firebase_storage.dart
@@ -19,7 +19,8 @@ class MethodChannelFirebaseStorage extends FirebaseStoragePlatform {
 
   /// Returns a unique key to identify the instance by [FirebaseApp] name and
   /// any custom storage buckets.
-  static String _getInstanceKey(String/*!*//*!*/ appName, String/*!*/ bucket) {
+  static String _getInstanceKey(
+      String /*!*/ /*!*/ appName, String /*!*/ bucket) {
     return '${appName}|${bucket ?? ''}';
   }
 
@@ -55,14 +56,14 @@ class MethodChannelFirebaseStorage extends FirebaseStoragePlatform {
 
   /// Creates a new [MethodChannelFirebaseStorage] instance with an [app] and/or
   /// [bucket].
-  MethodChannelFirebaseStorage({FirebaseApp/*!*/ app, String bucket})
+  MethodChannelFirebaseStorage({FirebaseApp /*!*/ app, String bucket})
       : super(appInstance: app, bucket: bucket) {
     // The channel setMethodCallHandler callback is not app specific, so there
     // is no need to register the caller more than once.
     if (_initialized) return;
 
     channel.setMethodCallHandler((MethodCall call) async {
-      Map<dynamic, dynamic>/*!*/ arguments = call.arguments;
+      Map<dynamic, dynamic> /*!*/ arguments = call.arguments;
 
       switch (call.method) {
         case 'Task#onProgress':
@@ -117,7 +118,7 @@ class MethodChannelFirebaseStorage extends FirebaseStoragePlatform {
     taskObservers[arguments['handle']].add(snapshot);
   }
 
-  void _sendTaskException(int/*!*/ handle, FirebaseException exception) {
+  void _sendTaskException(int /*!*/ handle, FirebaseException exception) {
     taskObservers[handle].addError(exception);
   }
 

--- a/packages/firebase_storage/firebase_storage_platform_interface/lib/src/method_channel/method_channel_firebase_storage.dart
+++ b/packages/firebase_storage/firebase_storage_platform_interface/lib/src/method_channel/method_channel_firebase_storage.dart
@@ -19,7 +19,7 @@ class MethodChannelFirebaseStorage extends FirebaseStoragePlatform {
 
   /// Returns a unique key to identify the instance by [FirebaseApp] name and
   /// any custom storage buckets.
-  static String _getInstanceKey(String appName, String bucket) {
+  static String _getInstanceKey(String/*!*//*!*/ appName, String/*!*/ bucket) {
     return '${appName}|${bucket ?? ''}';
   }
 
@@ -55,14 +55,14 @@ class MethodChannelFirebaseStorage extends FirebaseStoragePlatform {
 
   /// Creates a new [MethodChannelFirebaseStorage] instance with an [app] and/or
   /// [bucket].
-  MethodChannelFirebaseStorage({FirebaseApp app, String bucket})
+  MethodChannelFirebaseStorage({FirebaseApp/*!*/ app, String bucket})
       : super(appInstance: app, bucket: bucket) {
     // The channel setMethodCallHandler callback is not app specific, so there
     // is no need to register the caller more than once.
     if (_initialized) return;
 
     channel.setMethodCallHandler((MethodCall call) async {
-      Map<dynamic, dynamic> arguments = call.arguments;
+      Map<dynamic, dynamic>/*!*/ arguments = call.arguments;
 
       switch (call.method) {
         case 'Task#onProgress':
@@ -117,7 +117,7 @@ class MethodChannelFirebaseStorage extends FirebaseStoragePlatform {
     taskObservers[arguments['handle']].add(snapshot);
   }
 
-  void _sendTaskException(int handle, FirebaseException exception) {
+  void _sendTaskException(int/*!*/ handle, FirebaseException exception) {
     taskObservers[handle].addError(exception);
   }
 

--- a/packages/firebase_storage/firebase_storage_platform_interface/lib/src/method_channel/method_channel_reference.dart
+++ b/packages/firebase_storage/firebase_storage_platform_interface/lib/src/method_channel/method_channel_reference.dart
@@ -79,7 +79,7 @@ class MethodChannelReference extends ReferencePlatform {
   }
 
   @override
-  Future<ListResultPlatform> list(ListOptions options) async {
+  Future<ListResultPlatform> list([ListOptions /*?*/ options]) async {
     try {
       Map<String, dynamic> data = await MethodChannelFirebaseStorage.channel
           .invokeMapMethod<String, dynamic>('Reference#list', <String, dynamic>{

--- a/packages/firebase_storage/firebase_storage_platform_interface/lib/src/method_channel/method_channel_reference.dart
+++ b/packages/firebase_storage/firebase_storage_platform_interface/lib/src/method_channel/method_channel_reference.dart
@@ -131,7 +131,7 @@ class MethodChannelReference extends ReferencePlatform {
   }
 
   @override
-  Future<Uint8List /*!*/ > getData(int maxSize) {
+  Future<Uint8List /*?*/ > getData(int maxSize) {
     try {
       return MethodChannelFirebaseStorage.channel
           .invokeMethod<Uint8List>('Reference#getData', <String, dynamic>{

--- a/packages/firebase_storage/firebase_storage_platform_interface/lib/src/method_channel/method_channel_reference.dart
+++ b/packages/firebase_storage/firebase_storage_platform_interface/lib/src/method_channel/method_channel_reference.dart
@@ -39,7 +39,7 @@ class MethodChannelReference extends ReferencePlatform {
   }
 
   @override
-  Future<String> getDownloadURL() async {
+  Future<String/*!*/> getDownloadURL() async {
     try {
       Map<String, dynamic> data = await MethodChannelFirebaseStorage.channel
           .invokeMapMethod<String, dynamic>(
@@ -131,7 +131,7 @@ class MethodChannelReference extends ReferencePlatform {
   }
 
   @override
-  Future<Uint8List> getData(int maxSize) {
+  Future<Uint8List/*!*/> getData(int maxSize) {
     try {
       return MethodChannelFirebaseStorage.channel
           .invokeMethod<Uint8List>('Reference#getData', <String, dynamic>{
@@ -149,7 +149,7 @@ class MethodChannelReference extends ReferencePlatform {
   }
 
   @override
-  TaskPlatform putData(Uint8List data, [SettableMetadata metadata]) {
+  TaskPlatform putData(Uint8List data, [SettableMetadata/*?*/ metadata]) {
     int handle = MethodChannelFirebaseStorage.nextMethodChannelHandleId;
     MethodChannelFirebaseStorage.taskObservers[handle] =
         StreamController<TaskSnapshotPlatform>.broadcast();
@@ -157,13 +157,13 @@ class MethodChannelReference extends ReferencePlatform {
   }
 
   @override
-  TaskPlatform putBlob(dynamic data, [SettableMetadata metadata]) {
+  TaskPlatform putBlob(dynamic data, [SettableMetadata/*?*/ metadata]) {
     throw UnimplementedError(
         'putBlob() is not supported on native platforms. Use [put], [putFile] or [putString] instead.');
   }
 
   @override
-  TaskPlatform putFile(File file, [SettableMetadata metadata]) {
+  TaskPlatform putFile(File file, [SettableMetadata/*?*/ metadata]) {
     int handle = MethodChannelFirebaseStorage.nextMethodChannelHandleId;
     MethodChannelFirebaseStorage.taskObservers[handle] =
         StreamController<TaskSnapshotPlatform>.broadcast();
@@ -171,7 +171,7 @@ class MethodChannelReference extends ReferencePlatform {
   }
 
   TaskPlatform putString(String data, PutStringFormat format,
-      [SettableMetadata metadata]) {
+      [SettableMetadata/*?*/ metadata]) {
     int handle = MethodChannelFirebaseStorage.nextMethodChannelHandleId;
     MethodChannelFirebaseStorage.taskObservers[handle] =
         StreamController<TaskSnapshotPlatform>.broadcast();

--- a/packages/firebase_storage/firebase_storage_platform_interface/lib/src/method_channel/method_channel_reference.dart
+++ b/packages/firebase_storage/firebase_storage_platform_interface/lib/src/method_channel/method_channel_reference.dart
@@ -39,7 +39,7 @@ class MethodChannelReference extends ReferencePlatform {
   }
 
   @override
-  Future<String/*!*/> getDownloadURL() async {
+  Future<String /*!*/ > getDownloadURL() async {
     try {
       Map<String, dynamic> data = await MethodChannelFirebaseStorage.channel
           .invokeMapMethod<String, dynamic>(
@@ -131,7 +131,7 @@ class MethodChannelReference extends ReferencePlatform {
   }
 
   @override
-  Future<Uint8List/*!*/> getData(int maxSize) {
+  Future<Uint8List /*!*/ > getData(int maxSize) {
     try {
       return MethodChannelFirebaseStorage.channel
           .invokeMethod<Uint8List>('Reference#getData', <String, dynamic>{
@@ -149,7 +149,7 @@ class MethodChannelReference extends ReferencePlatform {
   }
 
   @override
-  TaskPlatform putData(Uint8List data, [SettableMetadata/*?*/ metadata]) {
+  TaskPlatform putData(Uint8List data, [SettableMetadata /*?*/ metadata]) {
     int handle = MethodChannelFirebaseStorage.nextMethodChannelHandleId;
     MethodChannelFirebaseStorage.taskObservers[handle] =
         StreamController<TaskSnapshotPlatform>.broadcast();
@@ -157,13 +157,13 @@ class MethodChannelReference extends ReferencePlatform {
   }
 
   @override
-  TaskPlatform putBlob(dynamic data, [SettableMetadata/*?*/ metadata]) {
+  TaskPlatform putBlob(dynamic data, [SettableMetadata /*?*/ metadata]) {
     throw UnimplementedError(
         'putBlob() is not supported on native platforms. Use [put], [putFile] or [putString] instead.');
   }
 
   @override
-  TaskPlatform putFile(File file, [SettableMetadata/*?*/ metadata]) {
+  TaskPlatform putFile(File file, [SettableMetadata /*?*/ metadata]) {
     int handle = MethodChannelFirebaseStorage.nextMethodChannelHandleId;
     MethodChannelFirebaseStorage.taskObservers[handle] =
         StreamController<TaskSnapshotPlatform>.broadcast();
@@ -171,7 +171,7 @@ class MethodChannelReference extends ReferencePlatform {
   }
 
   TaskPlatform putString(String data, PutStringFormat format,
-      [SettableMetadata/*?*/ metadata]) {
+      [SettableMetadata /*?*/ metadata]) {
     int handle = MethodChannelFirebaseStorage.nextMethodChannelHandleId;
     MethodChannelFirebaseStorage.taskObservers[handle] =
         StreamController<TaskSnapshotPlatform>.broadcast();

--- a/packages/firebase_storage/firebase_storage_platform_interface/lib/src/method_channel/method_channel_task.dart
+++ b/packages/firebase_storage/firebase_storage_platform_interface/lib/src/method_channel/method_channel_task.dart
@@ -212,7 +212,7 @@ class MethodChannelPutFileTask extends MethodChannelTask {
       FirebaseStoragePlatform storage,
       String path,
       File file,
-      SettableMetadata/*?*/ metadata) {
+      SettableMetadata /*?*/ metadata) {
     return () => MethodChannelFirebaseStorage.channel
             .invokeMethod<void>('Task#startPutFile', <String, dynamic>{
           'appName': storage.app.name,
@@ -237,7 +237,7 @@ class MethodChannelPutStringTask extends MethodChannelTask {
       String path,
       String data,
       PutStringFormat format,
-      SettableMetadata/*?*/ metadata)
+      SettableMetadata /*?*/ metadata)
       : super(handle, storage, path,
             _getTask(handle, storage, path, data, format, metadata));
 
@@ -247,7 +247,7 @@ class MethodChannelPutStringTask extends MethodChannelTask {
       String path,
       String data,
       PutStringFormat format,
-      SettableMetadata/*?*/ metadata) {
+      SettableMetadata /*?*/ metadata) {
     return () => MethodChannelFirebaseStorage.channel
             .invokeMethod<void>('Task#startPutString', <String, dynamic>{
           'appName': storage.app.name,
@@ -268,7 +268,7 @@ class MethodChannelPutStringTask extends MethodChannelTask {
 class MethodChannelPutTask extends MethodChannelTask {
   // ignore: public_member_api_docs
   MethodChannelPutTask(int handle, FirebaseStoragePlatform storage, String path,
-      Uint8List data, SettableMetadata/*?*/ metadata)
+      Uint8List data, SettableMetadata /*?*/ metadata)
       : super(handle, storage, path,
             _getTask(handle, storage, path, data, metadata));
 

--- a/packages/firebase_storage/firebase_storage_platform_interface/lib/src/method_channel/method_channel_task.dart
+++ b/packages/firebase_storage/firebase_storage_platform_interface/lib/src/method_channel/method_channel_task.dart
@@ -46,7 +46,7 @@ abstract class MethodChannelTask extends TaskPlatform {
 
     // Get the task stream.
     _stream = MethodChannelFirebaseStorage.taskObservers[_handle].stream;
-    StreamSubscription _subscription;
+    /*late*/ StreamSubscription _subscription;
 
     // Listen for stream events.
     _subscription = _stream.listen((TaskSnapshotPlatform snapshot) async {
@@ -212,7 +212,7 @@ class MethodChannelPutFileTask extends MethodChannelTask {
       FirebaseStoragePlatform storage,
       String path,
       File file,
-      SettableMetadata metadata) {
+      SettableMetadata/*?*/ metadata) {
     return () => MethodChannelFirebaseStorage.channel
             .invokeMethod<void>('Task#startPutFile', <String, dynamic>{
           'appName': storage.app.name,
@@ -237,7 +237,7 @@ class MethodChannelPutStringTask extends MethodChannelTask {
       String path,
       String data,
       PutStringFormat format,
-      SettableMetadata metadata)
+      SettableMetadata/*?*/ metadata)
       : super(handle, storage, path,
             _getTask(handle, storage, path, data, format, metadata));
 
@@ -247,7 +247,7 @@ class MethodChannelPutStringTask extends MethodChannelTask {
       String path,
       String data,
       PutStringFormat format,
-      SettableMetadata metadata) {
+      SettableMetadata/*?*/ metadata) {
     return () => MethodChannelFirebaseStorage.channel
             .invokeMethod<void>('Task#startPutString', <String, dynamic>{
           'appName': storage.app.name,
@@ -268,7 +268,7 @@ class MethodChannelPutStringTask extends MethodChannelTask {
 class MethodChannelPutTask extends MethodChannelTask {
   // ignore: public_member_api_docs
   MethodChannelPutTask(int handle, FirebaseStoragePlatform storage, String path,
-      Uint8List data, SettableMetadata metadata)
+      Uint8List data, SettableMetadata/*?*/ metadata)
       : super(handle, storage, path,
             _getTask(handle, storage, path, data, metadata));
 

--- a/packages/firebase_storage/firebase_storage_platform_interface/lib/src/method_channel/method_channel_task_snapshot.dart
+++ b/packages/firebase_storage/firebase_storage_platform_interface/lib/src/method_channel/method_channel_task_snapshot.dart
@@ -13,7 +13,7 @@ class MethodChannelTaskSnapshot extends TaskSnapshotPlatform {
       : super(state, _data);
 
   /// The [FirebaseStoragePlatform] used to create the task.
-  final FirebaseStoragePlatform storage;
+  final FirebaseStoragePlatform/*!*/ storage;
 
   final Map<String, dynamic> _data;
 

--- a/packages/firebase_storage/firebase_storage_platform_interface/lib/src/method_channel/method_channel_task_snapshot.dart
+++ b/packages/firebase_storage/firebase_storage_platform_interface/lib/src/method_channel/method_channel_task_snapshot.dart
@@ -13,7 +13,7 @@ class MethodChannelTaskSnapshot extends TaskSnapshotPlatform {
       : super(state, _data);
 
   /// The [FirebaseStoragePlatform] used to create the task.
-  final FirebaseStoragePlatform/*!*/ storage;
+  final FirebaseStoragePlatform /*!*/ storage;
 
   final Map<String, dynamic> _data;
 

--- a/packages/firebase_storage/firebase_storage_platform_interface/lib/src/method_channel/utils/exception.dart
+++ b/packages/firebase_storage/firebase_storage_platform_interface/lib/src/method_channel/utils/exception.dart
@@ -10,7 +10,7 @@ import 'package:flutter/services.dart';
 /// Catches a [PlatformException] and returns an [Exception].
 ///
 /// If the [Exception] is a [PlatformException], a [FirebaseException] is returned.
-Exception convertPlatformException(Object exception, [StackTrace stackTrace]) {
+Exception convertPlatformException(Object exception, [StackTrace/*?*/ stackTrace]) {
   if (exception is! Exception || exception is! PlatformException) {
     return exception;
   }
@@ -21,7 +21,7 @@ Exception convertPlatformException(Object exception, [StackTrace stackTrace]) {
 
 /// Catches a [PlatformException] and converts it into a [FirebaseException] if
 /// it was intentionally caught on the native platform.
-Future<T> catchFuturePlatformException<T>(Object exception,
+Future<T> catchFuturePlatformException<T>(Object/*!*/ exception,
     [StackTrace stackTrace]) {
   if (exception is! Exception || exception is! PlatformException) {
     return Future.error(exception, stackTrace);
@@ -38,13 +38,13 @@ Future<T> catchFuturePlatformException<T>(Object exception,
 /// which can be converted into user friendly exceptions.
 FirebaseException platformExceptionToFirebaseException(
     PlatformException platformException,
-    [StackTrace stackTrace]) {
+    [StackTrace/*?*/ stackTrace]) {
   Map<String, String> details = platformException.details != null
       ? Map<String, String>.from(platformException.details)
       : null;
 
   String code = 'unknown';
-  String message = platformException.message;
+  String message = platformException.message ?? '';
 
   if (details != null) {
     code = details['code'] ?? code;

--- a/packages/firebase_storage/firebase_storage_platform_interface/lib/src/method_channel/utils/exception.dart
+++ b/packages/firebase_storage/firebase_storage_platform_interface/lib/src/method_channel/utils/exception.dart
@@ -10,7 +10,8 @@ import 'package:flutter/services.dart';
 /// Catches a [PlatformException] and returns an [Exception].
 ///
 /// If the [Exception] is a [PlatformException], a [FirebaseException] is returned.
-Exception convertPlatformException(Object exception, [StackTrace/*?*/ stackTrace]) {
+Exception convertPlatformException(Object exception,
+    [StackTrace /*?*/ stackTrace]) {
   if (exception is! Exception || exception is! PlatformException) {
     return exception;
   }
@@ -21,7 +22,7 @@ Exception convertPlatformException(Object exception, [StackTrace/*?*/ stackTrace
 
 /// Catches a [PlatformException] and converts it into a [FirebaseException] if
 /// it was intentionally caught on the native platform.
-Future<T> catchFuturePlatformException<T>(Object/*!*/ exception,
+Future<T> catchFuturePlatformException<T>(Object /*!*/ exception,
     [StackTrace stackTrace]) {
   if (exception is! Exception || exception is! PlatformException) {
     return Future.error(exception, stackTrace);
@@ -38,7 +39,7 @@ Future<T> catchFuturePlatformException<T>(Object/*!*/ exception,
 /// which can be converted into user friendly exceptions.
 FirebaseException platformExceptionToFirebaseException(
     PlatformException platformException,
-    [StackTrace/*?*/ stackTrace]) {
+    [StackTrace /*?*/ stackTrace]) {
   Map<String, String> details = platformException.details != null
       ? Map<String, String>.from(platformException.details)
       : null;

--- a/packages/firebase_storage/firebase_storage_platform_interface/lib/src/platform_interface/platform_interface_firebase_storage.dart
+++ b/packages/firebase_storage/firebase_storage_platform_interface/lib/src/platform_interface/platform_interface_firebase_storage.dart
@@ -19,7 +19,7 @@ abstract class FirebaseStoragePlatform extends PlatformInterface {
   final FirebaseApp appInstance;
 
   /// The storage bucket of this instance.
-  final String/*!*/ bucket;
+  final String /*!*/ bucket;
 
   /// Create an instance using [app]
   FirebaseStoragePlatform({this.appInstance, this.bucket})
@@ -29,13 +29,13 @@ abstract class FirebaseStoragePlatform extends PlatformInterface {
 
   /// Returns a [FirebaseStoragePlatform] with the provided arguments.
   factory FirebaseStoragePlatform.instanceFor(
-      {FirebaseApp/*!*/ app, String/*!*/ bucket}) {
+      {FirebaseApp /*!*/ app, String /*!*/ bucket}) {
     return FirebaseStoragePlatform.instance
         .delegateFor(app: app, bucket: bucket);
   }
 
   /// Returns the [FirebaseApp] for the current instance.
-  FirebaseApp/*!*/ get app {
+  FirebaseApp /*!*/ get app {
     if (appInstance == null) {
       return Firebase.app();
     }
@@ -81,7 +81,8 @@ abstract class FirebaseStoragePlatform extends PlatformInterface {
   /// Enables delegates to create new instances of themselves if a none default
   /// [FirebaseApp] instance is required by the user.
   @protected
-  FirebaseStoragePlatform/*!*/ delegateFor({FirebaseApp/*!*/ app, String/*!*/ bucket}) {
+  FirebaseStoragePlatform /*!*/ delegateFor(
+      {FirebaseApp /*!*/ app, String /*!*/ bucket}) {
     throw UnimplementedError('delegateFor() is not implemented');
   }
 

--- a/packages/firebase_storage/firebase_storage_platform_interface/lib/src/platform_interface/platform_interface_firebase_storage.dart
+++ b/packages/firebase_storage/firebase_storage_platform_interface/lib/src/platform_interface/platform_interface_firebase_storage.dart
@@ -19,7 +19,7 @@ abstract class FirebaseStoragePlatform extends PlatformInterface {
   final FirebaseApp appInstance;
 
   /// The storage bucket of this instance.
-  final String bucket;
+  final String/*!*/ bucket;
 
   /// Create an instance using [app]
   FirebaseStoragePlatform({this.appInstance, this.bucket})
@@ -29,13 +29,13 @@ abstract class FirebaseStoragePlatform extends PlatformInterface {
 
   /// Returns a [FirebaseStoragePlatform] with the provided arguments.
   factory FirebaseStoragePlatform.instanceFor(
-      {FirebaseApp app, String bucket}) {
+      {FirebaseApp/*!*/ app, String/*!*/ bucket}) {
     return FirebaseStoragePlatform.instance
         .delegateFor(app: app, bucket: bucket);
   }
 
   /// Returns the [FirebaseApp] for the current instance.
-  FirebaseApp get app {
+  FirebaseApp/*!*/ get app {
     if (appInstance == null) {
       return Firebase.app();
     }
@@ -81,7 +81,7 @@ abstract class FirebaseStoragePlatform extends PlatformInterface {
   /// Enables delegates to create new instances of themselves if a none default
   /// [FirebaseApp] instance is required by the user.
   @protected
-  FirebaseStoragePlatform delegateFor({FirebaseApp app, String bucket}) {
+  FirebaseStoragePlatform/*!*/ delegateFor({FirebaseApp/*!*/ app, String/*!*/ bucket}) {
     throw UnimplementedError('delegateFor() is not implemented');
   }
 

--- a/packages/firebase_storage/firebase_storage_platform_interface/lib/src/platform_interface/platform_interface_list_result.dart
+++ b/packages/firebase_storage/firebase_storage_platform_interface/lib/src/platform_interface/platform_interface_list_result.dart
@@ -32,7 +32,7 @@ abstract class ListResultPlatform extends PlatformInterface {
   }
 
   /// If set, there might be more results for this list. Use this token to resume the list.
-  final String nextPageToken;
+  final String /*?*/ nextPageToken;
 
   /// References to prefixes (sub-folders). You can call [list] on them to get its contents.
   ///

--- a/packages/firebase_storage/firebase_storage_platform_interface/lib/src/platform_interface/platform_interface_reference.dart
+++ b/packages/firebase_storage/firebase_storage_platform_interface/lib/src/platform_interface/platform_interface_reference.dart
@@ -121,7 +121,7 @@ abstract class ReferencePlatform extends PlatformInterface {
   ///
   /// Returns a [Uint8List] of the data. If the [maxSize] (in bytes) is exceeded,
   /// the operation will be canceled.
-  Future<Uint8List /*!*/ > getData(int maxSize) async {
+  Future<Uint8List /*?*/ > getData(int maxSize) async {
     throw UnimplementedError('getData() is not implemented');
   }
 

--- a/packages/firebase_storage/firebase_storage_platform_interface/lib/src/platform_interface/platform_interface_reference.dart
+++ b/packages/firebase_storage/firebase_storage_platform_interface/lib/src/platform_interface/platform_interface_reference.dart
@@ -13,7 +13,7 @@ import '../internal/pointer.dart';
 /// The interface a reference must implement.
 abstract class ReferencePlatform extends PlatformInterface {
   // ignore: public_member_api_docs
-  ReferencePlatform(this.storage, String/*!*/ path)
+  ReferencePlatform(this.storage, String /*!*/ path)
       : _pointer = Pointer(path),
         super(token: _token);
 
@@ -33,7 +33,7 @@ abstract class ReferencePlatform extends PlatformInterface {
   }
 
   /// The storage service associated with this reference.
-  final FirebaseStoragePlatform/*!*/ storage;
+  final FirebaseStoragePlatform /*!*/ storage;
 
   /// The name of the bucket containing this reference's object.
   String get bucket {
@@ -41,7 +41,7 @@ abstract class ReferencePlatform extends PlatformInterface {
   }
 
   /// The full path of this object.
-  String/*!*/ get fullPath => _pointer.path;
+  String /*!*/ get fullPath => _pointer.path;
 
   /// The short name of this object, which is the last component of the full path.
   ///
@@ -79,7 +79,7 @@ abstract class ReferencePlatform extends PlatformInterface {
   }
 
   /// Fetches a long lived download URL for this object.
-  Future<String/*!*/> getDownloadURL() {
+  Future<String /*!*/ > getDownloadURL() {
     throw UnimplementedError('getDownloadURL() is not implemented');
   }
 
@@ -121,7 +121,7 @@ abstract class ReferencePlatform extends PlatformInterface {
   ///
   /// Returns a [Uint8List] of the data. If the [maxSize] (in bytes) is exceeded,
   /// the operation will be canceled.
-  Future<Uint8List/*!*/> getData(int maxSize) async {
+  Future<Uint8List /*!*/ > getData(int maxSize) async {
     throw UnimplementedError('getData() is not implemented');
   }
 
@@ -130,21 +130,22 @@ abstract class ReferencePlatform extends PlatformInterface {
   /// Use this method to upload fixed sized data as a [Uint8List].
   ///
   /// Optionally, you can also set metadata onto the uploaded object.
-  TaskPlatform putData(Uint8List/*!*/ data, [SettableMetadata/*?*/ metadata]) {
+  TaskPlatform putData(Uint8List /*!*/ data,
+      [SettableMetadata /*?*/ metadata]) {
     throw UnimplementedError('putData() is not implemented');
   }
 
   /// Upload a [Blob]. Note; this is only supported on web platforms.
   ///
   /// Optionally, you can also set metadata onto the uploaded object.
-  TaskPlatform putBlob(dynamic data, [SettableMetadata/*?*/ metadata]) {
+  TaskPlatform putBlob(dynamic data, [SettableMetadata /*?*/ metadata]) {
     throw UnimplementedError('putBlob() is not implemented');
   }
 
   /// Upload a [File] from the filesystem. The file must exist.
   ///
   /// Optionally, you can also set metadata onto the uploaded object.
-  TaskPlatform putFile(File/*!*/ file, [SettableMetadata/*?*/ metadata]) {
+  TaskPlatform putFile(File /*!*/ file, [SettableMetadata /*?*/ metadata]) {
     throw UnimplementedError('putFile() is not implemented');
   }
 
@@ -159,19 +160,19 @@ abstract class ReferencePlatform extends PlatformInterface {
   ///   - [PutStringFormat.base64] will be encoded as a Base64 string.
   ///   - [PutStringFormat.base64Url] will be encoded as a Base64 string safe URL.
   TaskPlatform putString(String data, PutStringFormat format,
-      [SettableMetadata/*?*/ metadata]) {
+      [SettableMetadata /*?*/ metadata]) {
     throw UnimplementedError('putString() is not implemented');
   }
 
   /// Updates the metadata on a storage object.
-  Future<FullMetadata> updateMetadata(SettableMetadata/*!*/ metadata) {
+  Future<FullMetadata> updateMetadata(SettableMetadata /*!*/ metadata) {
     throw UnimplementedError('updateMetadata() is not implemented');
   }
 
   /// Writes a remote storage object to the local filesystem.
   ///
   /// If a file already exists at the given location, it will be overwritten.
-  TaskPlatform writeToFile(File/*!*/ file) {
+  TaskPlatform writeToFile(File /*!*/ file) {
     throw UnimplementedError('writeToFile() is not implemented');
   }
 }

--- a/packages/firebase_storage/firebase_storage_platform_interface/lib/src/platform_interface/platform_interface_reference.dart
+++ b/packages/firebase_storage/firebase_storage_platform_interface/lib/src/platform_interface/platform_interface_reference.dart
@@ -13,7 +13,7 @@ import '../internal/pointer.dart';
 /// The interface a reference must implement.
 abstract class ReferencePlatform extends PlatformInterface {
   // ignore: public_member_api_docs
-  ReferencePlatform(this.storage, String path)
+  ReferencePlatform(this.storage, String/*!*/ path)
       : _pointer = Pointer(path),
         super(token: _token);
 
@@ -33,7 +33,7 @@ abstract class ReferencePlatform extends PlatformInterface {
   }
 
   /// The storage service associated with this reference.
-  final FirebaseStoragePlatform storage;
+  final FirebaseStoragePlatform/*!*/ storage;
 
   /// The name of the bucket containing this reference's object.
   String get bucket {
@@ -41,7 +41,7 @@ abstract class ReferencePlatform extends PlatformInterface {
   }
 
   /// The full path of this object.
-  String get fullPath => _pointer.path;
+  String/*!*/ get fullPath => _pointer.path;
 
   /// The short name of this object, which is the last component of the full path.
   ///
@@ -79,7 +79,7 @@ abstract class ReferencePlatform extends PlatformInterface {
   }
 
   /// Fetches a long lived download URL for this object.
-  Future<String> getDownloadURL() {
+  Future<String/*!*/> getDownloadURL() {
     throw UnimplementedError('getDownloadURL() is not implemented');
   }
 
@@ -121,7 +121,7 @@ abstract class ReferencePlatform extends PlatformInterface {
   ///
   /// Returns a [Uint8List] of the data. If the [maxSize] (in bytes) is exceeded,
   /// the operation will be canceled.
-  Future<Uint8List> getData(int maxSize) async {
+  Future<Uint8List/*!*/> getData(int maxSize) async {
     throw UnimplementedError('getData() is not implemented');
   }
 
@@ -130,21 +130,21 @@ abstract class ReferencePlatform extends PlatformInterface {
   /// Use this method to upload fixed sized data as a [Uint8List].
   ///
   /// Optionally, you can also set metadata onto the uploaded object.
-  TaskPlatform putData(Uint8List data, [SettableMetadata metadata]) {
+  TaskPlatform putData(Uint8List/*!*/ data, [SettableMetadata/*?*/ metadata]) {
     throw UnimplementedError('putData() is not implemented');
   }
 
   /// Upload a [Blob]. Note; this is only supported on web platforms.
   ///
   /// Optionally, you can also set metadata onto the uploaded object.
-  TaskPlatform putBlob(dynamic data, [SettableMetadata metadata]) {
+  TaskPlatform putBlob(dynamic data, [SettableMetadata/*?*/ metadata]) {
     throw UnimplementedError('putBlob() is not implemented');
   }
 
   /// Upload a [File] from the filesystem. The file must exist.
   ///
   /// Optionally, you can also set metadata onto the uploaded object.
-  TaskPlatform putFile(File file, [SettableMetadata metadata]) {
+  TaskPlatform putFile(File/*!*/ file, [SettableMetadata/*?*/ metadata]) {
     throw UnimplementedError('putFile() is not implemented');
   }
 
@@ -159,19 +159,19 @@ abstract class ReferencePlatform extends PlatformInterface {
   ///   - [PutStringFormat.base64] will be encoded as a Base64 string.
   ///   - [PutStringFormat.base64Url] will be encoded as a Base64 string safe URL.
   TaskPlatform putString(String data, PutStringFormat format,
-      [SettableMetadata metadata]) {
+      [SettableMetadata/*?*/ metadata]) {
     throw UnimplementedError('putString() is not implemented');
   }
 
   /// Updates the metadata on a storage object.
-  Future<FullMetadata> updateMetadata(SettableMetadata metadata) {
+  Future<FullMetadata> updateMetadata(SettableMetadata/*!*/ metadata) {
     throw UnimplementedError('updateMetadata() is not implemented');
   }
 
   /// Writes a remote storage object to the local filesystem.
   ///
   /// If a file already exists at the given location, it will be overwritten.
-  TaskPlatform writeToFile(File file) {
+  TaskPlatform writeToFile(File/*!*/ file) {
     throw UnimplementedError('writeToFile() is not implemented');
   }
 }

--- a/packages/firebase_storage/firebase_storage_platform_interface/lib/src/platform_interface/platform_interface_reference.dart
+++ b/packages/firebase_storage/firebase_storage_platform_interface/lib/src/platform_interface/platform_interface_reference.dart
@@ -50,7 +50,7 @@ abstract class ReferencePlatform extends PlatformInterface {
 
   /// A reference pointing to the parent location of this reference, or `null`
   /// if this reference is the root.
-  ReferencePlatform get parent {
+  ReferencePlatform /*?*/ get parent {
     String parentPath = _pointer.parent;
 
     if (parentPath == null) {
@@ -99,7 +99,7 @@ abstract class ReferencePlatform extends PlatformInterface {
   /// objects whose paths end with "/" or contain two consecutive "/"s. Firebase
   /// Storage List API will filter these unsupported objects. [list] may fail
   /// if there are too many unsupported objects in the bucket.
-  Future<ListResultPlatform> list(ListOptions options) {
+  Future<ListResultPlatform> list([ListOptions /*?*/ options]) {
     throw UnimplementedError('list() is not implemented');
   }
 

--- a/packages/firebase_storage/firebase_storage_platform_interface/lib/src/platform_interface/platform_interface_task.dart
+++ b/packages/firebase_storage/firebase_storage_platform_interface/lib/src/platform_interface/platform_interface_task.dart
@@ -37,7 +37,7 @@ abstract class TaskPlatform extends PlatformInterface {
   }
 
   /// The latest [TaskSnapshot] for this task.
-  TaskSnapshotPlatform/*!*/ get snapshot {
+  TaskSnapshotPlatform /*!*/ get snapshot {
     throw UnimplementedError('snapshot is not implemented');
   }
 

--- a/packages/firebase_storage/firebase_storage_platform_interface/lib/src/platform_interface/platform_interface_task.dart
+++ b/packages/firebase_storage/firebase_storage_platform_interface/lib/src/platform_interface/platform_interface_task.dart
@@ -37,7 +37,7 @@ abstract class TaskPlatform extends PlatformInterface {
   }
 
   /// The latest [TaskSnapshot] for this task.
-  TaskSnapshotPlatform get snapshot {
+  TaskSnapshotPlatform/*!*/ get snapshot {
     throw UnimplementedError('snapshot is not implemented');
   }
 

--- a/packages/firebase_storage/firebase_storage_platform_interface/lib/src/platform_interface/platform_interface_task_snapshot.dart
+++ b/packages/firebase_storage/firebase_storage_platform_interface/lib/src/platform_interface/platform_interface_task_snapshot.dart
@@ -28,7 +28,7 @@ abstract class TaskSnapshotPlatform extends PlatformInterface {
   }
 
   /// The current transferred bytes of this task.
-  int get bytesTransferred => _data['bytesTransferred'];
+  int/*!*/ get bytesTransferred => _data['bytesTransferred'];
 
   /// The [FullMetadata] associated with this task.
   ///
@@ -51,5 +51,5 @@ abstract class TaskSnapshotPlatform extends PlatformInterface {
   }
 
   /// The total bytes of the task.
-  int get totalBytes => _data['totalBytes'];
+  int/*!*/ get totalBytes => _data['totalBytes'];
 }

--- a/packages/firebase_storage/firebase_storage_platform_interface/lib/src/platform_interface/platform_interface_task_snapshot.dart
+++ b/packages/firebase_storage/firebase_storage_platform_interface/lib/src/platform_interface/platform_interface_task_snapshot.dart
@@ -28,7 +28,7 @@ abstract class TaskSnapshotPlatform extends PlatformInterface {
   }
 
   /// The current transferred bytes of this task.
-  int/*!*/ get bytesTransferred => _data['bytesTransferred'];
+  int /*!*/ get bytesTransferred => _data['bytesTransferred'];
 
   /// The [FullMetadata] associated with this task.
   ///
@@ -51,5 +51,5 @@ abstract class TaskSnapshotPlatform extends PlatformInterface {
   }
 
   /// The total bytes of the task.
-  int/*!*/ get totalBytes => _data['totalBytes'];
+  int /*!*/ get totalBytes => _data['totalBytes'];
 }

--- a/packages/firebase_storage/firebase_storage_platform_interface/test/method_channel_tests/method_channel_firebase_storage_test.dart
+++ b/packages/firebase_storage/firebase_storage_platform_interface/test/method_channel_tests/method_channel_firebase_storage_test.dart
@@ -14,9 +14,9 @@ import '../mock.dart';
 void main() {
   setupFirebaseStorageMocks();
 
-  FirebaseStoragePlatform storage;
-  FirebaseApp app;
-  FirebaseApp secondaryApp;
+  /*late*/ FirebaseStoragePlatform storage;
+  /*late*/ FirebaseApp app;
+  /*late*/ FirebaseApp secondaryApp;
 
   String kBucket = 'foo';
 

--- a/packages/firebase_storage/firebase_storage_platform_interface/test/method_channel_tests/method_channel_list_result_test.dart
+++ b/packages/firebase_storage/firebase_storage_platform_interface/test/method_channel_tests/method_channel_list_result_test.dart
@@ -13,7 +13,7 @@ import '../mock.dart';
 void main() {
   setupFirebaseStorageMocks();
 
-  MethodChannelListResult testListResult;
+  /*late*/ MethodChannelListResult testListResult;
 
   group('$MethodChannelListResult', () {
     setUpAll(() async {

--- a/packages/firebase_storage/firebase_storage_platform_interface/test/method_channel_tests/method_channel_reference_test.dart
+++ b/packages/firebase_storage/firebase_storage_platform_interface/test/method_channel_tests/method_channel_reference_test.dart
@@ -17,13 +17,13 @@ import 'package:flutter/services.dart';
 void main() {
   setupFirebaseStorageMocks();
 
-  FirebaseStoragePlatform storage;
-  ReferencePlatform ref;
+  /*late*/ FirebaseStoragePlatform storage;
+  /*late*/ ReferencePlatform ref;
   final List<MethodCall> log = <MethodCall>[];
 
   // mock props
   bool mockPlatformExceptionThrown = false;
-  File kFile;
+  /*late*/ File kFile;
   final kMetadata = SettableMetadata(
       contentLanguage: 'en',
       customMetadata: <String, String>{'activity': 'test'});

--- a/packages/firebase_storage/firebase_storage_platform_interface/test/method_channel_tests/method_channel_task_test.dart
+++ b/packages/firebase_storage/firebase_storage_platform_interface/test/method_channel_tests/method_channel_task_test.dart
@@ -17,16 +17,16 @@ import '../mock.dart';
 void main() {
   setupFirebaseStorageMocks();
 
-  FirebaseStoragePlatform storage;
-  MethodChannelReference ref;
-  FirebaseApp app;
+  /*late*/ FirebaseStoragePlatform storage;
+  /*late*/ MethodChannelReference ref;
+  /*late*/ FirebaseApp app;
   final List<MethodCall> log = <MethodCall>[];
 
   // mock props
   bool mockPlatformExceptionThrown = false;
 
   final kMockData = 'Hello World';
-  MethodChannelPutStringTask kMockTask;
+  /*late*/ MethodChannelPutStringTask kMockTask;
 
   final kMockExceptionMessage = 'a mock exception message';
 

--- a/packages/firebase_storage/firebase_storage_platform_interface/test/mock.dart
+++ b/packages/firebase_storage/firebase_storage_platform_interface/test/mock.dart
@@ -14,7 +14,7 @@ typedef Callback(MethodCall call);
 int mockHandleId = 0;
 int get nextMockHandleId => mockHandleId++;
 
-setupFirebaseStorageMocks([Callback customHandlers]) {
+setupFirebaseStorageMocks([Callback/*?*/ customHandlers]) {
   TestWidgetsFlutterBinding.ensureInitialized();
 
   MethodChannelFirebase.channel.setMockMethodCallHandler((call) async {

--- a/packages/firebase_storage/firebase_storage_platform_interface/test/mock.dart
+++ b/packages/firebase_storage/firebase_storage_platform_interface/test/mock.dart
@@ -14,7 +14,7 @@ typedef Callback(MethodCall call);
 int mockHandleId = 0;
 int get nextMockHandleId => mockHandleId++;
 
-setupFirebaseStorageMocks([Callback/*?*/ customHandlers]) {
+setupFirebaseStorageMocks([Callback /*?*/ customHandlers]) {
   TestWidgetsFlutterBinding.ensureInitialized();
 
   MethodChannelFirebase.channel.setMockMethodCallHandler((call) async {

--- a/packages/firebase_storage/firebase_storage_platform_interface/test/platform_interface_tests/platform_interface_firebase_storage_test.dart
+++ b/packages/firebase_storage/firebase_storage_platform_interface/test/platform_interface_tests/platform_interface_firebase_storage_test.dart
@@ -12,9 +12,9 @@ import '../mock.dart';
 void main() {
   setupFirebaseStorageMocks();
 
-  TestFirebaseStoragePlatform firebaseStoragePlatform;
-  FirebaseApp app;
-  FirebaseApp secondaryApp;
+  /*late*/ TestFirebaseStoragePlatform firebaseStoragePlatform;
+  /*late*/ FirebaseApp app;
+  /*late*/ FirebaseApp secondaryApp;
 
   group('$FirebaseStoragePlatform()', () {
     setUpAll(() async {

--- a/packages/firebase_storage/firebase_storage_platform_interface/test/platform_interface_tests/platform_interface_list_result_test.dart
+++ b/packages/firebase_storage/firebase_storage_platform_interface/test/platform_interface_tests/platform_interface_list_result_test.dart
@@ -12,9 +12,9 @@ import '../mock.dart';
 void main() {
   setupFirebaseStorageMocks();
 
-  FirebaseStoragePlatform firebaseStoragePlatform;
-  FirebaseApp app;
-  TestListResultPlatform listResultPlatform;
+  /*late*/ FirebaseStoragePlatform firebaseStoragePlatform;
+  /*late*/ FirebaseApp app;
+  /*late*/ TestListResultPlatform listResultPlatform;
 
   group('$ListResultPlatform()', () {
     setUpAll(() async {

--- a/packages/firebase_storage/firebase_storage_platform_interface/test/platform_interface_tests/platform_interface_reference_test.dart
+++ b/packages/firebase_storage/firebase_storage_platform_interface/test/platform_interface_tests/platform_interface_reference_test.dart
@@ -12,9 +12,9 @@ import '../mock.dart';
 void main() {
   setupFirebaseStorageMocks();
 
-  TestReferencePlatform referencePlatform;
-  FirebaseApp app;
-  FirebaseStoragePlatform firebaseStoragePlatform;
+  /*late*/ TestReferencePlatform referencePlatform;
+  /*late*/ FirebaseApp app;
+  /*late*/ FirebaseStoragePlatform firebaseStoragePlatform;
 
   group('$ReferencePlatform()', () {
     setUpAll(() async {

--- a/packages/firebase_storage/firebase_storage_platform_interface/test/platform_interface_tests/platform_interface_task_test.dart
+++ b/packages/firebase_storage/firebase_storage_platform_interface/test/platform_interface_tests/platform_interface_task_test.dart
@@ -12,7 +12,7 @@ import '../mock.dart';
 void main() {
   setupFirebaseStorageMocks();
 
-  TestTaskPlatform taskPlatform;
+  /*late*/ TestTaskPlatform taskPlatform;
 
   group('$TaskPlatform()', () {
     setUpAll(() async {

--- a/packages/firebase_storage/firebase_storage_web/lib/src/firebase_storage_web.dart
+++ b/packages/firebase_storage/firebase_storage_web/lib/src/firebase_storage_web.dart
@@ -50,7 +50,7 @@ class FirebaseStorageWeb extends FirebaseStoragePlatform {
 
   /// Returns a [FirebaseStorageWeb] with the provided arguments.
   @override
-  FirebaseStoragePlatform delegateFor({FirebaseApp app, String bucket}) {
+  FirebaseStoragePlatform delegateFor({FirebaseApp app, String/*!*/ bucket}) {
     if (bucket == null) {
       throw FirebaseException(
           message:

--- a/packages/firebase_storage/firebase_storage_web/lib/src/firebase_storage_web.dart
+++ b/packages/firebase_storage/firebase_storage_web/lib/src/firebase_storage_web.dart
@@ -50,7 +50,7 @@ class FirebaseStorageWeb extends FirebaseStoragePlatform {
 
   /// Returns a [FirebaseStorageWeb] with the provided arguments.
   @override
-  FirebaseStoragePlatform delegateFor({FirebaseApp app, String/*!*/ bucket}) {
+  FirebaseStoragePlatform delegateFor({FirebaseApp app, String /*!*/ bucket}) {
     if (bucket == null) {
       throw FirebaseException(
           message:

--- a/packages/firebase_storage/firebase_storage_web/lib/src/interop/firebase_interop.dart
+++ b/packages/firebase_storage/firebase_storage_web/lib/src/interop/firebase_interop.dart
@@ -13,4 +13,4 @@ import 'package:js/js.dart';
 import 'storage_interop.dart';
 
 @JS()
-external StorageJsImpl storage([AppJsImpl app]);
+external StorageJsImpl storage([AppJsImpl/*?*/ app]);

--- a/packages/firebase_storage/firebase_storage_web/lib/src/interop/firebase_interop.dart
+++ b/packages/firebase_storage/firebase_storage_web/lib/src/interop/firebase_interop.dart
@@ -13,4 +13,4 @@ import 'package:js/js.dart';
 import 'storage_interop.dart';
 
 @JS()
-external StorageJsImpl storage([AppJsImpl/*?*/ app]);
+external StorageJsImpl storage([AppJsImpl /*?*/ app]);

--- a/packages/firebase_storage/firebase_storage_web/lib/src/interop/storage.dart
+++ b/packages/firebase_storage/firebase_storage_web/lib/src/interop/storage.dart
@@ -159,7 +159,7 @@ class StorageReference
   /// Uploads data [blob] to the actual location with optional [metadata].
   /// Returns the [UploadTask] which can be used to monitor and manage
   /// the upload.
-  UploadTask put(blob, [UploadMetadata metadata]) {
+  UploadTask put(blob, [UploadMetadata/*?*/ metadata]) {
     storage_interop.UploadTaskJsImpl taskImpl;
     if (metadata != null) {
       taskImpl = jsObject.put(blob, metadata.jsObject);
@@ -176,7 +176,7 @@ class StorageReference
   ///
   /// Returns the [UploadTask] which can be used to monitor and manage
   /// the upload.
-  UploadTask putString(String data, [String format, UploadMetadata metadata]) {
+  UploadTask putString(String data, [String/*?*/ format, UploadMetadata/*?*/ metadata]) {
     storage_interop.UploadTaskJsImpl taskImpl;
     if (metadata != null) {
       taskImpl = jsObject.putString(data, format, metadata.jsObject);

--- a/packages/firebase_storage/firebase_storage_web/lib/src/interop/storage.dart
+++ b/packages/firebase_storage/firebase_storage_web/lib/src/interop/storage.dart
@@ -159,7 +159,7 @@ class StorageReference
   /// Uploads data [blob] to the actual location with optional [metadata].
   /// Returns the [UploadTask] which can be used to monitor and manage
   /// the upload.
-  UploadTask put(blob, [UploadMetadata/*?*/ metadata]) {
+  UploadTask put(blob, [UploadMetadata /*?*/ metadata]) {
     storage_interop.UploadTaskJsImpl taskImpl;
     if (metadata != null) {
       taskImpl = jsObject.put(blob, metadata.jsObject);
@@ -176,7 +176,8 @@ class StorageReference
   ///
   /// Returns the [UploadTask] which can be used to monitor and manage
   /// the upload.
-  UploadTask putString(String data, [String/*?*/ format, UploadMetadata/*?*/ metadata]) {
+  UploadTask putString(String data,
+      [String /*?*/ format, UploadMetadata /*?*/ metadata]) {
     storage_interop.UploadTaskJsImpl taskImpl;
     if (metadata != null) {
       taskImpl = jsObject.putString(data, format, metadata.jsObject);

--- a/packages/firebase_storage/firebase_storage_web/lib/src/interop/storage_interop.dart
+++ b/packages/firebase_storage/firebase_storage_web/lib/src/interop/storage_interop.dart
@@ -57,14 +57,14 @@ abstract class ReferenceJsImpl {
 @JS()
 @anonymous
 class FullMetadataJsImpl extends UploadMetadataJsImpl {
-  external String/*?*/ get bucket;
-  external String/*?*/ get fullPath;
-  external String/*?*/ get generation;
-  external String/*?*/ get metageneration;
-  external String/*?*/ get name;
-  external int/*?*/ get size;
-  external String/*?*/ get timeCreated;
-  external String/*?*/ get updated;
+  external String /*?*/ get bucket;
+  external String /*?*/ get fullPath;
+  external String /*?*/ get generation;
+  external String /*?*/ get metageneration;
+  external String /*?*/ get name;
+  external int /*?*/ get size;
+  external String /*?*/ get timeCreated;
+  external String /*?*/ get updated;
 
   external factory FullMetadataJsImpl(
       {String md5Hash,
@@ -79,7 +79,7 @@ class FullMetadataJsImpl extends UploadMetadataJsImpl {
 @JS()
 @anonymous
 class UploadMetadataJsImpl extends SettableMetadataJsImpl {
-  external String/*?*/ get md5Hash;
+  external String /*?*/ get md5Hash;
   external set md5Hash(String s);
 
   external factory UploadMetadataJsImpl(

--- a/packages/firebase_storage/firebase_storage_web/lib/src/interop/storage_interop.dart
+++ b/packages/firebase_storage/firebase_storage_web/lib/src/interop/storage_interop.dart
@@ -57,14 +57,14 @@ abstract class ReferenceJsImpl {
 @JS()
 @anonymous
 class FullMetadataJsImpl extends UploadMetadataJsImpl {
-  external String get bucket;
-  external String get fullPath;
-  external String get generation;
-  external String get metageneration;
-  external String get name;
-  external int get size;
-  external String get timeCreated;
-  external String get updated;
+  external String/*?*/ get bucket;
+  external String/*?*/ get fullPath;
+  external String/*?*/ get generation;
+  external String/*?*/ get metageneration;
+  external String/*?*/ get name;
+  external int/*?*/ get size;
+  external String/*?*/ get timeCreated;
+  external String/*?*/ get updated;
 
   external factory FullMetadataJsImpl(
       {String md5Hash,
@@ -79,7 +79,7 @@ class FullMetadataJsImpl extends UploadMetadataJsImpl {
 @JS()
 @anonymous
 class UploadMetadataJsImpl extends SettableMetadataJsImpl {
-  external String get md5Hash;
+  external String/*?*/ get md5Hash;
   external set md5Hash(String s);
 
   external factory UploadMetadataJsImpl(

--- a/packages/firebase_storage/firebase_storage_web/lib/src/list_result_web.dart
+++ b/packages/firebase_storage/firebase_storage_web/lib/src/list_result_web.dart
@@ -9,11 +9,12 @@ class ListResultWeb extends ListResultPlatform {
   /// Build a ListResultWeb instance from a list of items and prefixes.
   ListResultWeb(
     FirebaseStoragePlatform storage, {
-    String nextPageToken,
+    String/*?*/ nextPageToken,
     List<String> items,
     List<String> prefixes,
   })  : _items = items ?? [],
         _prefixes = prefixes ?? [],
+        // TODO(ehesp): This should be nullable after platform NS migration
         super(storage, nextPageToken);
 
   List<String> _items;

--- a/packages/firebase_storage/firebase_storage_web/lib/src/list_result_web.dart
+++ b/packages/firebase_storage/firebase_storage_web/lib/src/list_result_web.dart
@@ -9,7 +9,7 @@ class ListResultWeb extends ListResultPlatform {
   /// Build a ListResultWeb instance from a list of items and prefixes.
   ListResultWeb(
     FirebaseStoragePlatform storage, {
-    String/*?*/ nextPageToken,
+    String /*?*/ nextPageToken,
     List<String> items,
     List<String> prefixes,
   })  : _items = items ?? [],

--- a/packages/firebase_storage/firebase_storage_web/lib/src/reference_web.dart
+++ b/packages/firebase_storage/firebase_storage_web/lib/src/reference_web.dart
@@ -151,7 +151,7 @@ class ReferenceWeb extends ReferencePlatform {
   ///
   /// Optionally, you can also set metadata onto the uploaded object.
   @override
-  TaskPlatform putData(Uint8List data, [SettableMetadata metadata]) {
+  TaskPlatform putData(Uint8List data, [SettableMetadata/*?*/ metadata]) {
     return TaskWeb(
       this,
       _ref.put(
@@ -168,7 +168,7 @@ class ReferenceWeb extends ReferencePlatform {
   ///
   /// Optionally, you can also set metadata onto the uploaded object.
   @override
-  TaskPlatform putBlob(dynamic data, [SettableMetadata metadata]) {
+  TaskPlatform putBlob(dynamic data, [SettableMetadata/*?*/ metadata]) {
     assert(data is html.Blob, 'data must be a dart:html Blob object.');
 
     return TaskWeb(
@@ -197,7 +197,7 @@ class ReferenceWeb extends ReferencePlatform {
   TaskPlatform putString(
     String data,
     PutStringFormat format, [
-    SettableMetadata metadata,
+    SettableMetadata/*?*/ metadata,
   ]) {
     return TaskWeb(
       this,

--- a/packages/firebase_storage/firebase_storage_web/lib/src/reference_web.dart
+++ b/packages/firebase_storage/firebase_storage_web/lib/src/reference_web.dart
@@ -125,7 +125,7 @@ class ReferenceWeb extends ReferencePlatform {
   /// Returns a [Uint8List] of the data. If the [maxSize] (in bytes) is exceeded,
   /// the operation will be canceled.
   @override
-  Future<Uint8List> getData(
+  Future<Uint8List /*?*/ > getData(
     int maxSize, {
     @visibleForTesting
         Future<Uint8List> Function(dynamic url) readBytes = http.readBytes,

--- a/packages/firebase_storage/firebase_storage_web/lib/src/reference_web.dart
+++ b/packages/firebase_storage/firebase_storage_web/lib/src/reference_web.dart
@@ -90,7 +90,7 @@ class ReferenceWeb extends ReferencePlatform {
   /// Storage List API will filter these unsupported objects. [list] may fail
   /// if there are too many unsupported objects in the bucket.
   @override
-  Future<ListResultPlatform> list(ListOptions options) async {
+  Future<ListResultPlatform> list([ListOptions /*?*/ options]) async {
     try {
       storage_interop.ListResult listResult =
           await _ref.list(listOptionsToFbListOptions(options));

--- a/packages/firebase_storage/firebase_storage_web/lib/src/reference_web.dart
+++ b/packages/firebase_storage/firebase_storage_web/lib/src/reference_web.dart
@@ -151,7 +151,7 @@ class ReferenceWeb extends ReferencePlatform {
   ///
   /// Optionally, you can also set metadata onto the uploaded object.
   @override
-  TaskPlatform putData(Uint8List data, [SettableMetadata/*?*/ metadata]) {
+  TaskPlatform putData(Uint8List data, [SettableMetadata /*?*/ metadata]) {
     return TaskWeb(
       this,
       _ref.put(
@@ -168,7 +168,7 @@ class ReferenceWeb extends ReferencePlatform {
   ///
   /// Optionally, you can also set metadata onto the uploaded object.
   @override
-  TaskPlatform putBlob(dynamic data, [SettableMetadata/*?*/ metadata]) {
+  TaskPlatform putBlob(dynamic data, [SettableMetadata /*?*/ metadata]) {
     assert(data is html.Blob, 'data must be a dart:html Blob object.');
 
     return TaskWeb(
@@ -197,7 +197,7 @@ class ReferenceWeb extends ReferencePlatform {
   TaskPlatform putString(
     String data,
     PutStringFormat format, [
-    SettableMetadata/*?*/ metadata,
+    SettableMetadata /*?*/ metadata,
   ]) {
     return TaskWeb(
       this,

--- a/packages/firebase_storage/firebase_storage_web/test/metadata_cache_test.dart
+++ b/packages/firebase_storage/firebase_storage_web/test/metadata_cache_test.dart
@@ -21,7 +21,7 @@ void main() {
 
   TestWidgetsFlutterBinding.ensureInitialized();
 
-  SettableMetadataCache cache;
+  /*late*/ SettableMetadataCache cache;
 
   setUp(() {
     cache = SettableMetadataCache();


### PR DESCRIPTION
## Description

Adds null safety hints to the storage packages.

Note; this does not allow null safety, it's a precursor to a larger migration

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
