### PR TITLE
docs(firebase_auth): Facebook Auth Example Code Fix

### DIFF
--- a/docs/auth/social.mdx
+++ b/docs/auth/social.mdx
@@ -138,11 +138,11 @@ import 'package:flutter_facebook_auth/flutter_facebook_auth.dart';
 
 Future<UserCredential> signInWithFacebook() async {
   // Trigger the sign-in flow
-  final LoginResult result = await FacebookAuth.instance.login();
+  final AccessToken result = await FacebookAuth.instance.login();
 
   // Create a credential from the access token
   final FacebookAuthCredential facebookAuthCredential =
-    FacebookAuthProvider.credential(result.accessToken.token);
+    FacebookAuthProvider.credential(result.token);
 
   // Once signed in, return the UserCredential
   return await FirebaseAuth.instance.signInWithCredential(facebookAuthCredential);


### PR DESCRIPTION
FacebookAuth instance's login method is returning AccessToken but in the example code result was of type LoginResult which was causing error. Just changes it to AccessToken and made changes accordingly while creating credential also.