### PR TITLE
refactor(firestore_auth)!: remove deprecated APIs

### DIFF
--- a/packages/firebase_auth/firebase_auth/lib/src/firebase_auth.dart
+++ b/packages/firebase_auth/firebase_auth/lib/src/firebase_auth.dart
@@ -58,18 +58,6 @@ class FirebaseAuth extends FirebasePluginPlatform {
     return _firebaseAuthInstances[app.name];
   }
 
-  @Deprecated('Deprecated in favor of `FirebaseAuth.instanceFor`')
-  // ignore: public_member_api_docs
-  factory FirebaseAuth.fromApp(FirebaseApp app) {
-    return FirebaseAuth.instanceFor(app: app);
-  }
-
-  @Deprecated('Deprecated in favor of `authStateChanges`')
-  // ignore: public_member_api_docs
-  Stream<User /*?*/ > get onAuthStateChanged {
-    return authStateChanges();
-  }
-
   /// Returns the current [User] if they are currently signed-in, or `null` if
   /// not.
   ///

--- a/packages/firebase_auth/firebase_auth/lib/src/user.dart
+++ b/packages/firebase_auth/firebase_auth/lib/src/user.dart
@@ -64,15 +64,6 @@ class User {
     return _delegate.photoURL;
   }
 
-  /// Returns a photo URL for the user.
-  ///
-  /// This property will be populated if the user has signed in or been linked
-  /// with a 3rd party OAuth provider (such as Google).
-  @Deprecated("Deprecated in favor of 'photoURL'.")
-  String /*?*/ get photoUrl {
-    return _delegate.photoURL;
-  }
-
   /// Returns a list of user information for each linked provider.
   List<UserInfo> get providerData {
     return _delegate.providerData;
@@ -365,11 +356,4 @@ class User {
   String toString() {
     return '$User(displayName: $displayName, email: $email, emailVerified: $emailVerified, isAnonymous: $isAnonymous, metadata: ${metadata.toString()}, phoneNumber: $phoneNumber, photoURL: $photoURL, providerData, ${providerData.toString()}, refreshToken: $refreshToken, tenantId: $tenantId, uid: $uid)';
   }
-}
-
-@Deprecated(
-    "Deprecated in favor of `User`. When updating your code it is recommended to namespace your 'firebase_auth' import to avoid class naming conflicts if you already have a 'User' class in your project e.g. `import 'package:firebase_auth/firebase_auth.dart' as auth;`, `User` then becomes `auth.User`.")
-// ignore: public_member_api_docs
-class FirebaseUser extends User {
-  FirebaseUser._(FirebaseAuth auth, UserPlatform user) : super._(auth, user);
 }

--- a/packages/firebase_auth/firebase_auth_platform_interface/lib/src/action_code_settings.dart
+++ b/packages/firebase_auth/firebase_auth_platform_interface/lib/src/action_code_settings.dart
@@ -10,26 +10,14 @@ class ActionCodeSettings {
   // ignore: public_member_api_docs
   @protected
   ActionCodeSettings({
-    @Deprecated("Deprecated in favor of using named args instead ([androidPackageName], [androidMinimumVersion], [androidInstallApp])")
-        // ignore: deprecated_member_use_from_same_package
-        this.android,
     this.androidPackageName,
     this.androidMinimumVersion,
     this.androidInstallApp,
     this.dynamicLinkDomain,
     this.handleCodeInApp,
-    @Deprecated("Deprecated in favor of using named args instead ([iOSBundleId])")
-        // ignore: deprecated_member_use_from_same_package
-        this.iOS,
     this.iOSBundleId,
-    /*required*/ @required
-        this.url,
+    /*required*/ @required this.url,
   }) : assert(url != null);
-
-  @Deprecated(
-      "Deprecated in favor of using named args instead ([androidPackageName], [androidMinimumVersion], [androidInstallApp])")
-  // ignore: public_member_api_docs
-  Map<String, dynamic> /*?*/ android;
 
   /// The Android package name of the application to open when the URL is pressed.
   final String androidPackageName;
@@ -56,54 +44,19 @@ class ActionCodeSettings {
   /// app if installed.
   final bool handleCodeInApp;
 
-  @Deprecated("Deprecated in favor of using named args instead ([iOSBundleId])")
-  // ignore: public_member_api_docs
-  Map<String, dynamic> iOS;
-
   /// Sets the link continue/state URL
   final String url;
 
   /// Returns the current instance as a [Map].
   Map<String, dynamic> asMap() {
-    // ignore: deprecated_member_use_from_same_package
-    android ??= {};
-    // ignore: deprecated_member_use_from_same_package
-    iOS ??= {};
-
-    Map<String, dynamic> androidMap;
-    Map<String, dynamic> iOSMap;
-
-    // ignore: deprecated_member_use_from_same_package
-    if (androidPackageName != null || android['packageName'] != null) {
-      androidMap = {};
-      androidMap['packageName'] =
-          // ignore: deprecated_member_use_from_same_package
-          androidPackageName ?? android['packageName'].toString();
-      androidMap['minimumVersion'] =
-          // ignore: deprecated_member_use_from_same_package
-          androidMinimumVersion ?? android['minimumVersion']?.toString();
-      androidMap['installApp'] = androidInstallApp;
-
-      // ignore: deprecated_member_use_from_same_package
-      if (androidMap['installApp'] == null && android['installApp'] is bool) {
-        // ignore: deprecated_member_use_from_same_package
-        androidMap['installApp'] = android['installApp'];
-      }
-    }
-
-    // ignore: deprecated_member_use_from_same_package
-    if (iOSBundleId != null || iOS['bundleId'] != null) {
-      iOSMap = {};
-      // ignore: deprecated_member_use_from_same_package
-      iOSMap['bundleId'] = iOSBundleId ?? iOS['bundleId'].toString();
-    }
-
     return <String, dynamic>{
       'url': url,
       'dynamicLinkDomain': dynamicLinkDomain,
       'handleCodeInApp': handleCodeInApp,
-      'android': androidMap,
-      'iOS': iOSMap,
+      'androidPackageName': androidPackageName,
+      'androidMinimumVersion': androidMinimumVersion,
+      'androidInstallApp': androidInstallApp,
+      'iOSBundleId': iOSBundleId,
     };
   }
 

--- a/packages/firebase_auth/firebase_auth_platform_interface/lib/src/providers/email_auth.dart
+++ b/packages/firebase_auth/firebase_auth_platform_interface/lib/src/providers/email_auth.dart
@@ -49,24 +49,6 @@ abstract class EmailAuthProvider extends AuthProvider {
     assert(emailLink != null);
     return EmailAuthCredential._credentialWithLink(email, emailLink);
   }
-
-  @Deprecated('Deprecated in favor of `EmailAuthProvider.credential()`')
-  // ignore: public_member_api_docs
-  static AuthCredential getCredential({
-    @required String email,
-    @required String password,
-  }) {
-    return EmailAuthProvider.credential(email: email, password: password);
-  }
-
-  @Deprecated('Deprecated in favor of `EmailAuthProvider.credentialWithLink()`')
-  // ignore: public_member_api_docs
-  static AuthCredential getCredentialWithLink({
-    @required String email,
-    @required String link,
-  }) {
-    return EmailAuthProvider.credentialWithLink(email: email, emailLink: link);
-  }
 }
 
 /// The auth credential returned from calling

--- a/packages/firebase_auth/firebase_auth_platform_interface/lib/src/providers/facebook_auth.dart
+++ b/packages/firebase_auth/firebase_auth_platform_interface/lib/src/providers/facebook_auth.dart
@@ -86,12 +86,6 @@ class FacebookAuthProvider extends AuthProvider {
       accessToken,
     );
   }
-
-  @Deprecated('Deprecated in favor of `FacebookAuthProvider.credential()`')
-  // ignore: public_member_api_docs
-  static AuthCredential getCredential(String token) {
-    return FacebookAuthProvider.credential(token);
-  }
 }
 
 /// The auth credential returned from calling

--- a/packages/firebase_auth/firebase_auth_platform_interface/lib/src/providers/github_auth.dart
+++ b/packages/firebase_auth/firebase_auth_platform_interface/lib/src/providers/github_auth.dart
@@ -86,12 +86,6 @@ class GithubAuthProvider extends AuthProvider {
       accessToken,
     );
   }
-
-  @Deprecated('Deprecated in favor of `GithubAuthProvider.credential()`')
-  // ignore: public_member_api_docs
-  static AuthCredential getCredential(String token) {
-    return GithubAuthProvider.credential(token);
-  }
 }
 
 /// The auth credential returned from calling

--- a/packages/firebase_auth/firebase_auth_platform_interface/lib/src/providers/google_auth.dart
+++ b/packages/firebase_auth/firebase_auth_platform_interface/lib/src/providers/google_auth.dart
@@ -85,13 +85,6 @@ class GoogleAuthProvider extends AuthProvider {
       accessToken: accessToken,
     );
   }
-
-  @Deprecated('Deprecated in favor of `GoogleAuthProvider.credential()`')
-  // ignore: public_member_api_docs
-  static AuthCredential getCredential({String idToken, String accessToken}) {
-    return GoogleAuthProvider.credential(
-        idToken: idToken, accessToken: accessToken);
-  }
 }
 
 /// The auth credential returned from calling

--- a/packages/firebase_auth/firebase_auth_platform_interface/lib/src/providers/oauth.dart
+++ b/packages/firebase_auth/firebase_auth_platform_interface/lib/src/providers/oauth.dart
@@ -62,14 +62,6 @@ class OAuthProvider extends AuthProvider {
       rawNonce: rawNonce,
     );
   }
-
-  @Deprecated('Deprecated in favor of `OAuthProvider.credential()`')
-  // ignore: public_member_api_docs
-  OAuthCredential getCredential(
-      {@required String accessToken, String idToken, String rawNonce}) {
-    return credential(
-        accessToken: accessToken, idToken: idToken, rawNonce: rawNonce);
-  }
 }
 
 /// A generic OAuth credential.

--- a/packages/firebase_auth/firebase_auth_platform_interface/lib/src/providers/phone_auth.dart
+++ b/packages/firebase_auth/firebase_auth_platform_interface/lib/src/providers/phone_auth.dart
@@ -41,16 +41,6 @@ class PhoneAuthProvider extends AuthProvider {
     assert(token != null);
     return PhoneAuthCredential._credentialFromToken(token, smsCode: smsCode);
   }
-
-  @Deprecated('Deprecated in favor of `PhoneAuthProvider.credential()`')
-  // ignore: public_member_api_docs
-  static AuthCredential getCredential({
-    @required String verificationId,
-    @required String smsCode,
-  }) {
-    return PhoneAuthProvider.credential(
-        verificationId: verificationId, smsCode: smsCode);
-  }
 }
 
 /// The auth credential returned from calling

--- a/packages/firebase_auth/firebase_auth_platform_interface/lib/src/providers/twitter_auth.dart
+++ b/packages/firebase_auth/firebase_auth_platform_interface/lib/src/providers/twitter_auth.dart
@@ -77,14 +77,6 @@ class TwitterAuthProvider extends AuthProvider {
       secret: secret,
     );
   }
-
-  @Deprecated('Deprecated in favor of `TwitterAuthProvider.credential()`')
-  // ignore: public_member_api_docs
-  static AuthCredential getCredential(
-      {@required String accessToken, @required String secret}) {
-    return TwitterAuthProvider.credential(
-        accessToken: accessToken, secret: secret);
-  }
 }
 
 /// The auth credential returned from calling

--- a/packages/firebase_auth/firebase_auth_platform_interface/test/action_code_settings_test.dart
+++ b/packages/firebase_auth/firebase_auth_platform_interface/test/action_code_settings_test.dart
@@ -52,94 +52,10 @@ void main() {
           expect(result['url'], equals(kMockUrl));
           expect(result['dynamicLinkDomain'], equals(kMockDynamicLinkDomain));
           expect(result['handleCodeInApp'], equals(kMockHandleCodeInApp));
-
-          expect(result['android'], isNotNull);
-          expect(result['iOS'], isNotNull);
-
-          expect(result['android']['packageName'], equals(kMockPackageName));
-          expect(result['android']['installApp'], equals(kMockInstallApp));
-          expect(
-              result['android']['minimumVersion'], equals(kMockMinimumVersion));
-          expect(result['iOS']['bundleId'], equals(kMockBundleId));
-        });
-
-        test('handles deprecated properties', () {
-          ActionCodeSettings deprecatedSettings = ActionCodeSettings(
-              // ignore: deprecated_member_use_from_same_package
-              android: <String, dynamic>{
-                'packageName': kMockPackageName,
-                'minimumVersion': kMockMinimumVersion,
-                'installApp': true,
-              },
-              // ignore: deprecated_member_use_from_same_package
-              iOS: <String, dynamic>{
-                'bundleId': kMockBundleId,
-              },
-              dynamicLinkDomain: kMockDynamicLinkDomain,
-              handleCodeInApp: kMockHandleCodeInApp,
-              url: kMockUrl);
-
-          final result = deprecatedSettings.asMap();
-          expect(result, isA<Map<String, dynamic>>());
-
-          expect(result['url'], equals(kMockUrl));
-          expect(result['dynamicLinkDomain'], equals(kMockDynamicLinkDomain));
-          expect(result['handleCodeInApp'], equals(kMockHandleCodeInApp));
-
-          expect(result['android'], isNotNull);
-          expect(result['iOS'], isNotNull);
-
-          expect(result['android']['packageName'], equals(kMockPackageName));
-          expect(result['android']['installApp'], equals(kMockInstallApp));
-          expect(
-              result['android']['minimumVersion'], equals(kMockMinimumVersion));
-          expect(result['iOS']['bundleId'], equals(kMockBundleId));
-        });
-
-        test('handles mixed deprecated properties', () {
-          ActionCodeSettings deprecatedSettings = ActionCodeSettings(
-              // ignore: deprecated_member_use_from_same_package
-              android: <String, dynamic>{
-                'packageName': kMockPackageName,
-                'minimumVersion': kMockMinimumVersion,
-                'installApp': true,
-              },
-              androidPackageName: kMockPackageName + '!',
-              // ignore: deprecated_member_use_from_same_package
-              iOS: <String, dynamic>{
-                'bundleId': kMockBundleId,
-              },
-              iOSBundleId: kMockBundleId + '!',
-              dynamicLinkDomain: kMockDynamicLinkDomain,
-              handleCodeInApp: kMockHandleCodeInApp,
-              url: kMockUrl);
-
-          final result = deprecatedSettings.asMap();
-          expect(result, isA<Map<String, dynamic>>());
-
-          expect(result['url'], equals(kMockUrl));
-          expect(result['dynamicLinkDomain'], equals(kMockDynamicLinkDomain));
-          expect(result['handleCodeInApp'], equals(kMockHandleCodeInApp));
-
-          expect(result['android'], isNotNull);
-          expect(result['iOS'], isNotNull);
-
-          expect(
-              result['android']['packageName'], equals(kMockPackageName + '!'));
-          expect(result['android']['installApp'], equals(kMockInstallApp));
-          expect(
-              result['android']['minimumVersion'], equals(kMockMinimumVersion));
-          expect(result['iOS']['bundleId'], equals(kMockBundleId + '!'));
-        });
-
-        test('expects android/iOS Maps to be null', () {
-          ActionCodeSettings testActionCodeSettings =
-              ActionCodeSettings(url: kMockUrl);
-
-          final result = testActionCodeSettings.asMap();
-          expect(result, isA<Map<String, dynamic>>());
-          expect(result['android'], isNull);
-          expect(result['iOS'], isNull);
+          expect(result['androidPackageName'], equals(kMockPackageName));
+          expect(result['androidInstallApp'], equals(kMockInstallApp));
+          expect(result['androidMinimumVersion'], equals(kMockMinimumVersion));
+          expect(result['iOSBundleId'], equals(kMockBundleId));
         });
       });
 


### PR DESCRIPTION
## Description

Remove deprecated `firestore_auth` API ahead of the next major release.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [x] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [ ] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
