### PR TITLE
refactor(firebase_storage)!: remove deprecated APIs

### DIFF
--- a/packages/firebase_storage/firebase_storage/lib/src/firebase_storage.dart
+++ b/packages/firebase_storage/firebase_storage/lib/src/firebase_storage.dart
@@ -98,13 +98,6 @@ class FirebaseStorage extends FirebasePluginPlatform {
     return newInstance;
   }
 
-  // ignore: public_member_api_docs
-  @Deprecated(
-      "Constructing Storage is deprecated, use 'FirebaseStorage.instance' or 'FirebaseStorage.instanceFor' instead")
-  factory FirebaseStorage({FirebaseApp app, String storageBucket}) {
-    return FirebaseStorage.instanceFor(app: app, bucket: storageBucket);
-  }
-
   /// Returns a new [Reference].
   ///
   /// If the [path] is empty, the reference will point to the root of the
@@ -146,41 +139,11 @@ class FirebaseStorage extends FirebasePluginPlatform {
         .ref(path);
   }
 
-  @Deprecated("Deprecated in favor of refFromURL")
-  // ignore: public_member_api_docs
-  Future<Reference> getReferenceFromUrl(String url) async {
-    return refFromURL(url);
-  }
-
-  @Deprecated("Deprecated in favor of get.maxOperationRetryTime")
-  // ignore: public_member_api_docs
-  Future<int> getMaxOperationRetryTimeMillis() async {
-    return maxOperationRetryTime.inMilliseconds;
-  }
-
-  @Deprecated("Deprecated in favor of get.maxUploadRetryTime")
-  // ignore: public_member_api_docs
-  Future<int> getMaxUploadRetryTimeMillis() async {
-    return maxUploadRetryTime.inMilliseconds;
-  }
-
-  @Deprecated("Deprecated in favor of get.maxDownloadRetryTime")
-  // ignore: public_member_api_docs
-  Future<int> getMaxDownloadRetryTimeMillis() async {
-    return maxDownloadRetryTime.inMilliseconds;
-  }
-
   /// Sets the new maximum operation retry time.
   void setMaxOperationRetryTime(Duration time) {
     assert(time != null);
     assert(!time.isNegative);
     return _delegate.setMaxOperationRetryTime(time.inMilliseconds);
-  }
-
-  /// Sets the new maximum operation retry time in milliseconds.
-  @Deprecated("Deprecated in favor of setMaxUploadRetryTime()")
-  Future<void> setMaxOperationRetryTimeMillis(int time) async {
-    return setMaxOperationRetryTime(Duration(milliseconds: time));
   }
 
   /// Sets the new maximum upload retry time.
@@ -190,23 +153,11 @@ class FirebaseStorage extends FirebasePluginPlatform {
     return _delegate.setMaxUploadRetryTime(time.inMilliseconds);
   }
 
-  /// Sets the new maximum upload retry time in milliseconds.
-  @Deprecated("Deprecated in favor of setMaxUploadRetryTime()")
-  Future<void> setMaxUploadRetryTimeMillis(int time) async {
-    return setMaxUploadRetryTime(Duration(milliseconds: time));
-  }
-
   /// Sets the new maximum download retry time.
   void setMaxDownloadRetryTime(Duration time) {
     assert(time != null);
     assert(!time.isNegative);
     return _delegate.setMaxDownloadRetryTime(time.inMilliseconds);
-  }
-
-  /// Sets the new maximum download retry time in milliseconds.
-  @Deprecated("Deprecated in favor of setMaxDownloadRetryTime()")
-  Future<void> setMaxDownloadRetryTimeMillis(int time) async {
-    return setMaxDownloadRetryTime(Duration(milliseconds: time));
   }
 
   @override

--- a/packages/firebase_storage/firebase_storage/lib/src/reference.dart
+++ b/packages/firebase_storage/firebase_storage/lib/src/reference.dart
@@ -12,12 +12,6 @@ class Reference {
   /// The storage service associated with this reference.
   final FirebaseStorage storage;
 
-  @Deprecated("Deprecated in favor of get.storage")
-  // ignore: public_member_api_docs
-  FirebaseStorage getStorage() {
-    return storage;
-  }
-
   Reference._(this.storage, this._delegate) {
     ReferencePlatform.verifyExtends(_delegate);
   }
@@ -25,31 +19,13 @@ class Reference {
   /// The name of the bucket containing this reference's object.
   String get bucket => _delegate.bucket;
 
-  @Deprecated("Deprecated in favor of get.bucket")
-  // ignore: public_member_api_docs
-  Future<String> getBucket() async {
-    return bucket;
-  }
-
   /// The full path of this object.
   String get fullPath => _delegate.fullPath;
-
-  @Deprecated("Deprecated in favor of get.fullPath")
-  // ignore: public_member_api_docs
-  Future<String> getPath() async {
-    return fullPath;
-  }
 
   /// The short name of this object, which is the last component of the full path.
   ///
   /// For example, if fullPath is 'full/path/image.png', name is 'image.png'.
   String get name => _delegate.name;
-
-  @Deprecated("Deprecated in favor of get.name")
-  // ignore: public_member_api_docs
-  Future<String> getName() async {
-    return name;
-  }
 
   /// A reference pointing to the parent location of this reference, or `null`
   /// if this reference is the root.
@@ -63,20 +39,8 @@ class Reference {
     return Reference._(storage, referenceParentPlatform);
   }
 
-  @Deprecated("Deprecated in favor of get.parent")
-  // ignore: public_member_api_docs
-  Reference getParent() {
-    return parent;
-  }
-
   /// A reference to the root of this reference's bucket.
   Reference get root => Reference._(storage, _delegate.root);
-
-  @Deprecated("Deprecated in favor of get.root")
-  // ignore: public_member_api_docs
-  Reference getRoot() {
-    return root;
-  }
 
   /// Returns a reference to a relative path from this reference.
   ///

--- a/packages/firebase_storage/firebase_storage/lib/src/task.dart
+++ b/packages/firebase_storage/firebase_storage/lib/src/task.dart
@@ -15,12 +15,6 @@ abstract class Task implements Future<TaskSnapshot> {
     TaskPlatform.verifyExtends(_delegate);
   }
 
-  @Deprecated('events has been deprecated in favor of snapshotEvents')
-  // ignore: public_member_api_docs
-  Stream<dynamic> get events {
-    return snapshotEvents;
-  }
-
   /// Returns a [Stream] of [TaskSnapshot] events.
   ///
   /// If the task is canceled or fails, the stream will send an error event.
@@ -32,10 +26,6 @@ abstract class Task implements Future<TaskSnapshot> {
     return _delegate.snapshotEvents
         .map((snapshotDelegate) => TaskSnapshot._(storage, snapshotDelegate));
   }
-
-  @Deprecated("Deprecated in favor of [snapshot]")
-  // ignore: public_member_api_docs
-  TaskSnapshot get lastSnapshot => snapshot;
 
   /// The latest [TaskSnapshot] for this task.
   TaskSnapshot get snapshot {


### PR DESCRIPTION
## Description
Remove deprecated `firestore_storage` API ahead of the next major release.

## Related Issues

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [x] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [ ] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
