### PR TITLE
refactor(cloud_firestore)!: remove deprecated APIs

### DIFF
--- a/packages/cloud_firestore/cloud_firestore/lib/src/collection_reference.dart
+++ b/packages/cloud_firestore/cloud_firestore/lib/src/collection_reference.dart
@@ -63,10 +63,6 @@ class CollectionReference extends Query {
     return DocumentReference._(firestore, _delegate.doc(path));
   }
 
-  @Deprecated("Deprecated in favor of `.doc()`")
-  // ignore: public_member_api_docs
-  DocumentReference document([String path]) => doc(path);
-
   @override
   bool operator ==(dynamic o) =>
       o is CollectionReference && o.firestore == firestore && o.path == path;

--- a/packages/cloud_firestore/cloud_firestore/lib/src/document_change.dart
+++ b/packages/cloud_firestore/cloud_firestore/lib/src/document_change.dart
@@ -36,8 +36,4 @@ class DocumentChange {
   /// Returns the [DocumentSnapshot] for this instance.
   DocumentSnapshot get doc =>
       DocumentSnapshot._(_firestore, _delegate.document);
-
-  @Deprecated("Deprecated in favor of .doc")
-  // ignore: public_member_api_docs
-  DocumentSnapshot get document => doc;
 }

--- a/packages/cloud_firestore/cloud_firestore/lib/src/document_reference.dart
+++ b/packages/cloud_firestore/cloud_firestore/lib/src/document_reference.dart
@@ -23,10 +23,6 @@ class DocumentReference {
   /// This document's given ID within the collection.
   String get id => _delegate.id;
 
-  @Deprecated("Deprecated in favor of `.id`")
-  // ignore: public_member_api_docs
-  String get documentID => id;
-
   /// The parent [CollectionReference] of this document.
   CollectionReference get parent =>
       CollectionReference._(firestore, _delegate.parent);
@@ -85,12 +81,6 @@ class DocumentReference {
         options);
   }
 
-  @Deprecated("Deprecated in favor of `.set()`")
-  // ignore: public_member_api_docs
-  Future<void> setData(Map<String, dynamic> data, [SetOptions /*?*/ options]) {
-    return set(data, options);
-  }
-
   /// Updates data on the document. Data will be merged with any existing
   /// document data.
   ///
@@ -99,12 +89,6 @@ class DocumentReference {
     assert(data != null);
     return _delegate
         .update(_CodecUtility.replaceValueWithDelegatesInMap(data) /*!*/);
-  }
-
-  @Deprecated("Deprecated in favor of `.update()`")
-  // ignore: public_member_api_docs
-  Future<void> updateData(Map<String, dynamic> data) {
-    return update(data);
   }
 
   @override

--- a/packages/cloud_firestore/cloud_firestore/lib/src/document_snapshot.dart
+++ b/packages/cloud_firestore/cloud_firestore/lib/src/document_snapshot.dart
@@ -20,10 +20,6 @@ class DocumentSnapshot {
   /// This document's given ID for this snapshot.
   String get id => _delegate.id;
 
-  @Deprecated("Deprecated in favor of `.id`")
-  // ignore: public_member_api_docs
-  String get documentID => id;
-
   /// Returns the [DocumentReference] of this snapshot.
   DocumentReference get reference => _firestore.doc(_delegate.reference.path);
 

--- a/packages/cloud_firestore/cloud_firestore/lib/src/firestore.dart
+++ b/packages/cloud_firestore/cloud_firestore/lib/src/firestore.dart
@@ -57,13 +57,6 @@ class FirebaseFirestore extends FirebasePluginPlatform {
     return newInstance;
   }
 
-  // ignore: public_member_api_docs
-  @Deprecated(
-      "Constructing Firestore is deprecated, use 'FirebaseFirestore.instance' or 'FirebaseFirestore.instanceFor' instead")
-  factory FirebaseFirestore({/*required*/ FirebaseApp app}) {
-    return FirebaseFirestore.instanceFor(app: app);
-  }
-
   /// Gets a [CollectionReference] for the specified Firestore path.
   CollectionReference collection(String collectionPath) {
     assert(collectionPath != null, "a collection path cannot be null");
@@ -131,10 +124,6 @@ class FirebaseFirestore extends FirebasePluginPlatform {
 
     return DocumentReference._(this, _delegate.doc(documentPath));
   }
-
-  @Deprecated("Deprecated in favor of `.doc()`")
-  // ignore: public_member_api_docs
-  DocumentReference document(String documentPath) => doc(documentPath);
 
   /// Enables the network for this instance. Any pending local-only writes
   /// will be written to the remote servers.
@@ -234,26 +223,4 @@ class FirebaseFirestore extends FirebasePluginPlatform {
 
   @override
   String toString() => '$FirebaseFirestore(app: ${app.name})';
-}
-
-/// Extends the [FirebaseFirestore] class to allow for deprecated usage of
-/// using [Firebase] directly.
-@Deprecated("Class Firestore is deprecated, use 'FirebaseFirestore' instead.")
-class Firestore extends FirebaseFirestore {
-  // ignore: public_member_api_docs
-  @Deprecated(
-      "Constructing Firestore is deprecated, use 'FirebaseFirestore.instance' or 'FirebaseFirestore.instanceFor' instead")
-  factory Firestore({/*required*/ FirebaseApp app}) {
-    return FirebaseFirestore.instanceFor(app: app);
-  }
-
-  /// Returns an instance using the default [FirebaseApp].
-  static FirebaseFirestore get instance {
-    return FirebaseFirestore.instance;
-  }
-
-  /// Returns an instance using a specified [FirebaseApp].
-  static FirebaseFirestore instanceFor({/*required*/ FirebaseApp app}) {
-    return FirebaseFirestore.instanceFor(app: app);
-  }
 }

--- a/packages/cloud_firestore/cloud_firestore/lib/src/query.dart
+++ b/packages/cloud_firestore/cloud_firestore/lib/src/query.dart
@@ -180,10 +180,6 @@ class Query {
     return QuerySnapshot._(firestore, snapshotDelegate);
   }
 
-  @Deprecated("Deprecated in favor of `.get()`")
-  // ignore: public_member_api_docs
-  Future<QuerySnapshot> getDocuments([GetOptions options]) => get(options);
-
   /// Creates and returns a new Query that's additionally limited to only return up
   /// to the specified number of documents.
   Query limit(int limit) {

--- a/packages/cloud_firestore/cloud_firestore/lib/src/query_snapshot.dart
+++ b/packages/cloud_firestore/cloud_firestore/lib/src/query_snapshot.dart
@@ -20,19 +20,11 @@ class QuerySnapshot {
           QueryDocumentSnapshot._(_firestore, documentDelegate))
       .toList();
 
-  @Deprecated("Deprecated in favor of `.docs`")
-  // ignore: public_member_api_docs
-  List<QueryDocumentSnapshot> get documents => docs;
-
   /// An array of the documents that changed since the last snapshot. If this
   /// is the first snapshot, all documents will be in the list as Added changes.
   List<DocumentChange> get docChanges => _delegate.docChanges
       .map((documentDelegate) => DocumentChange._(_firestore, documentDelegate))
       .toList();
-
-  @Deprecated("Deprecated in favor of `docChanges`")
-  // ignore: public_member_api_docs
-  List<DocumentChange> get documentChanges => docChanges;
 
   /// Returns the [SnapshotMetadata] for this snapshot.
   SnapshotMetadata get metadata => SnapshotMetadata._(_delegate.metadata);

--- a/packages/cloud_firestore/cloud_firestore/lib/src/write_batch.dart
+++ b/packages/cloud_firestore/cloud_firestore/lib/src/write_batch.dart
@@ -50,13 +50,6 @@ class WriteBatch {
         options);
   }
 
-  @Deprecated("Deprecated in favor of `.set`")
-  // ignore: public_member_api_docs
-  void setData(DocumentReference document, Map<String, dynamic> data,
-      [SetOptions /*?*/ options]) {
-    return set(document, data, options);
-  }
-
   /// Updates a given [document].
   ///
   /// If the document does not yet exist, an exception will be thrown.
@@ -67,11 +60,5 @@ class WriteBatch {
         "the document provided is from a different Firestore instance");
     return _delegate.update(
         document.path, _CodecUtility.replaceValueWithDelegatesInMap(data));
-  }
-
-  @Deprecated("Deprecated in favor of `.update`")
-  // ignore: public_member_api_docs
-  void updateData(DocumentReference document, Map<String, dynamic> data) {
-    return update(document, data);
   }
 }

--- a/packages/cloud_firestore/cloud_firestore_platform_interface/lib/src/platform_interface/platform_interface_field_value.dart
+++ b/packages/cloud_firestore/cloud_firestore_platform_interface/lib/src/platform_interface/platform_interface_field_value.dart
@@ -17,8 +17,4 @@ class FieldValuePlatform {
   /// through to the underlying implementation.
   static dynamic getDelegate(FieldValuePlatform fieldValue) =>
       fieldValue._delegate;
-
-  /// No-op method kept in place to avoid a breaking change.
-  @Deprecated('It is no longer necessary to call this method.')
-  static void verifyExtends(FieldValuePlatform instance) {}
 }

--- a/packages/cloud_firestore/cloud_firestore_web/lib/src/interop/firestore_interop.dart
+++ b/packages/cloud_firestore/cloud_firestore_web/lib/src/interop/firestore_interop.dart
@@ -459,23 +459,10 @@ abstract class Settings {
 
   external set ssl(bool v);
 
-  @Deprecated(
-    'This setting will be removed in a future release. You should update '
-    'your code to expect Timestamp objects and stop using the '
-    'timestampsInSnapshots setting.',
-  )
-  external set timestampsInSnapshots(bool v);
-
   external factory Settings({
     int cacheSizeBytes,
     String host,
     bool ssl,
-    @Deprecated(
-      'This setting will be removed in a future release. You should update '
-      'your code to expect Timestamp objects and stop using the '
-      'timestampsInSnapshots setting.',
-    )
-        bool timestampsInSnapshots,
   });
 }
 


### PR DESCRIPTION
## Description

Remove deprecated `cloud_firestore` API ahead of the next major release.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [x] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [ ] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
