### PR TITLE
feat(crashlytics): Move iOS deployment target from 10 to 9

### DIFF
--- a/packages/firebase_crashlytics/firebase_crashlytics/ios/firebase_crashlytics.podspec
+++ b/packages/firebase_crashlytics/firebase_crashlytics/ios/firebase_crashlytics.podspec
@@ -28,7 +28,7 @@ Pod::Spec.new do |s|
   s.source_files = 'Classes/**/*'
   s.public_header_files = 'Classes/**/*.h'
 
-  s.ios.deployment_target = '10.0'
+  s.ios.deployment_target = '9.0'
 
   s.dependency 'firebase_core'
   s.dependency 'Firebase/Crashlytics', firebase_sdk_version


### PR DESCRIPTION
## Description

Since firebase-ios-sdk 7.3.0 bumps down crashlytics minimum deployment target to **9.0** . This plugin can also support iOS 9+. 

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
https://github.com/firebase/firebase-ios-sdk/pull/7053