### PR TITLE
docs(firebase_auth): Add UserInfoCard widget in auth example SignInPage

### DIFF
--- a/packages/firebase_auth/firebase_auth/example/lib/signin_page.dart
+++ b/packages/firebase_auth/firebase_auth/example/lib/signin_page.dart
@@ -22,6 +22,14 @@ class SignInPage extends StatefulWidget {
 }
 
 class _SignInPageState extends State<SignInPage> {
+  User user;
+
+  @override
+  void initState() {
+    _auth.userChanges().listen((event) => setState(() => user = event));
+    super.initState();
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -55,6 +63,7 @@ class _SignInPageState extends State<SignInPage> {
           padding: EdgeInsets.all(8),
           scrollDirection: Axis.vertical,
           children: <Widget>[
+            _UserInfoCard(user),
             _EmailPasswordForm(),
             _EmailLinkSignInSection(),
             _AnonymouslySignInSection(),
@@ -69,6 +78,76 @@ class _SignInPageState extends State<SignInPage> {
   // Example code for sign out.
   void _signOut() async {
     await _auth.signOut();
+  }
+}
+
+class _UserInfoCard extends StatefulWidget {
+  final User user;
+
+  _UserInfoCard(this.user);
+
+  @override
+  _UserInfoCardState createState() => _UserInfoCardState();
+}
+
+class _UserInfoCardState extends State<_UserInfoCard> {
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Container(
+              child: const Text(
+                "User info",
+                style: TextStyle(fontWeight: FontWeight.bold),
+              ),
+              padding: EdgeInsets.only(bottom: 8.0),
+              alignment: Alignment.center,
+            ),
+                () {
+              if (widget.user != null) {
+                if (widget.user.photoURL != null) {
+                  return Container(
+                    child: Image.network(widget.user.photoURL),
+                    alignment: Alignment.center,
+                    margin: EdgeInsets.only(bottom: 8.0),
+                  );
+                }
+                return Align(
+                  alignment: Alignment.center,
+                  child: Container(
+                    child: Text(
+                      "No image",
+                      textAlign: TextAlign.center,
+                    ),
+                    width: 50,
+                    height: 50,
+                    padding: EdgeInsets.all(8.0),
+                    margin: EdgeInsets.only(bottom: 8.0),
+                    color: Colors.black,
+                  ),
+                );
+              }
+              return Container();
+            }(),
+            Text(
+              widget.user == null
+                  ? 'Not signed in'
+                  : 'Email: ${widget.user.email}\n\n'
+                  'Phone number: ${widget.user.phoneNumber}\n\n'
+                  'Name: ${widget.user.displayName}\n\n'
+                  'ID: ${widget.user.uid}\n\n'
+                  'Created: ${widget.user.metadata.creationTime.toString()}\n\n'
+                  'Last login: ${widget.user.metadata.lastSignInTime}\n\n\n'
+                  'Providers: ${widget.user.providerData.fold('', (previousValue, element) => previousValue += '\n${element.providerId} ${element.uid}')}',
+            ),
+          ],
+        ),
+      ),
+    );
   }
 }
 

--- a/packages/firebase_auth/firebase_auth/example/lib/signin_page.dart
+++ b/packages/firebase_auth/firebase_auth/example/lib/signin_page.dart
@@ -165,7 +165,10 @@ class _UserInfoCardState extends State<_UserInfoCard> {
                               : Image.network(provider.photoURL),
                           title: Text(provider.providerId),
                           subtitle: Text(
-                              "${provider.displayName == null ? "" : "${provider.displayName}\n"}${provider.uid}"),
+                              "${provider.uid == null ? "" : "ID: ${provider.uid}\n"}"
+                              "${provider.email == null ? "" : "Email: ${provider.email}\n"}"
+                              "${provider.phoneNumber == null ? "" : "Phone number: ${provider.phoneNumber}\n"}"
+                              "${provider.displayName == null ? "" : "Name: ${provider.displayName}\n"}"),
                         ),
                       ),
                       onDismissed: (action) =>

--- a/packages/firebase_auth/firebase_auth/example/lib/signin_page.dart
+++ b/packages/firebase_auth/firebase_auth/example/lib/signin_page.dart
@@ -84,7 +84,7 @@ class _SignInPageState extends State<SignInPage> {
 class _UserInfoCard extends StatefulWidget {
   final User user;
 
-  _UserInfoCard(this.user);
+  const _UserInfoCard(this.user);
 
   @override
   _UserInfoCardState createState() => _UserInfoCardState();
@@ -122,8 +122,6 @@ class _UserInfoCardState extends State<_UserInfoCard> {
                       "No image",
                       textAlign: TextAlign.center,
                     ),
-                    width: 50,
-                    height: 50,
                     padding: EdgeInsets.all(8.0),
                     margin: EdgeInsets.only(bottom: 8.0),
                     color: Colors.black,
@@ -189,6 +187,13 @@ class _UserInfoCardState extends State<_UserInfoCard> {
                       icon: const Icon(Icons.refresh),
                     ),
                     IconButton(
+                      onPressed: () => showDialog(
+                        context: context,
+                        builder: (context) => UpdateUserDialog(widget.user),
+                      ),
+                      icon: const Icon(Icons.text_snippet),
+                    ),
+                    IconButton(
                       onPressed: () => widget.user.delete(),
                       icon: const Icon(Icons.delete_forever),
                     ),
@@ -200,6 +205,80 @@ class _UserInfoCardState extends State<_UserInfoCard> {
         ),
       ),
     );
+  }
+}
+
+class UpdateUserDialog extends StatefulWidget {
+  final User user;
+
+  const UpdateUserDialog(this.user);
+
+  @override
+  _UpdateUserDialogState createState() => _UpdateUserDialogState();
+}
+
+class _UpdateUserDialogState extends State<UpdateUserDialog> {
+  TextEditingController _nameController;
+  TextEditingController _urlController;
+
+  @override
+  void initState() {
+    _nameController = TextEditingController(text: widget.user.displayName);
+    _urlController = TextEditingController(text: widget.user.photoURL);
+    super.initState();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      title: const Text("Update profile"),
+      content: SingleChildScrollView(
+        child: ListBody(
+          children: [
+            TextFormField(
+              controller: _nameController,
+              autocorrect: false,
+              decoration: const InputDecoration(labelText: 'displayName'),
+            ),
+            TextFormField(
+              controller: _urlController,
+              decoration: const InputDecoration(labelText: 'photoURL'),
+              autovalidateMode: AutovalidateMode.onUserInteraction,
+              autocorrect: false,
+              validator: (String value) {
+                if (value.isNotEmpty) {
+                  var uri = Uri.parse(value);
+                  if (uri.isAbsolute) {
+                    //You can get the data with dart:io or http and check it here
+                    return null;
+                  }
+                  return "Faulty URL!";
+                }
+                return null;
+              },
+            ),
+          ],
+        ),
+      ),
+      actions: [
+        TextButton(
+          onPressed: () {
+            widget.user.updateProfile(
+                displayName: _nameController.text,
+                photoURL: _urlController.text);
+            Navigator.of(context).pop();
+          },
+          child: const Text("Update"),
+        )
+      ],
+    );
+  }
+
+  @override
+  void dispose() {
+    _nameController.dispose();
+    _urlController.dispose();
+    super.dispose();
   }
 }
 

--- a/packages/firebase_auth/firebase_auth/example/lib/signin_page.dart
+++ b/packages/firebase_auth/firebase_auth/example/lib/signin_page.dart
@@ -107,7 +107,7 @@ class _UserInfoCardState extends State<_UserInfoCard> {
               padding: EdgeInsets.only(bottom: 8.0),
               alignment: Alignment.center,
             ),
-                () {
+            () {
               if (widget.user != null) {
                 if (widget.user.photoURL != null) {
                   return Container(
@@ -137,12 +137,12 @@ class _UserInfoCardState extends State<_UserInfoCard> {
               widget.user == null
                   ? 'Not signed in'
                   : 'Email: ${widget.user.email}\n\n'
-                  'Phone number: ${widget.user.phoneNumber}\n\n'
-                  'Name: ${widget.user.displayName}\n\n'
-                  'ID: ${widget.user.uid}\n\n'
-                  'Created: ${widget.user.metadata.creationTime.toString()}\n\n'
-                  'Last login: ${widget.user.metadata.lastSignInTime}\n\n\n'
-                  'Providers: ${widget.user.providerData.fold('', (previousValue, element) => previousValue += '\n${element.providerId} ${element.uid}')}',
+                      'Phone number: ${widget.user.phoneNumber}\n\n'
+                      'Name: ${widget.user.displayName}\n\n'
+                      'ID: ${widget.user.uid}\n\n'
+                      'Created: ${widget.user.metadata.creationTime.toString()}\n\n'
+                      'Last login: ${widget.user.metadata.lastSignInTime}\n\n\n'
+                      'Providers: ${widget.user.providerData.fold('', (previousValue, element) => previousValue += '\n${element.providerId} ${element.uid}')}',
             ),
           ],
         ),

--- a/packages/firebase_auth/firebase_auth/example/lib/signin_page.dart
+++ b/packages/firebase_auth/firebase_auth/example/lib/signin_page.dart
@@ -107,16 +107,15 @@ class _UserInfoCardState extends State<_UserInfoCard> {
               padding: EdgeInsets.only(bottom: 8.0),
               alignment: Alignment.center,
             ),
-            () {
-              if (widget.user != null) {
-                if (widget.user.photoURL != null) {
-                  return Container(
-                    child: Image.network(widget.user.photoURL),
-                    alignment: Alignment.center,
-                    margin: EdgeInsets.only(bottom: 8.0),
-                  );
-                }
-                return Align(
+            if (widget.user != null)
+              if (widget.user.photoURL != null)
+                Container(
+                  child: Image.network(widget.user.photoURL),
+                  alignment: Alignment.center,
+                  margin: EdgeInsets.only(bottom: 8.0),
+                )
+              else
+                Align(
                   alignment: Alignment.center,
                   child: Container(
                     child: Text(
@@ -129,20 +128,70 @@ class _UserInfoCardState extends State<_UserInfoCard> {
                     margin: EdgeInsets.only(bottom: 8.0),
                     color: Colors.black,
                   ),
-                );
-              }
-              return Container();
-            }(),
-            Text(
-              widget.user == null
-                  ? 'Not signed in'
-                  : 'Email: ${widget.user.email}\n\n'
-                      'Phone number: ${widget.user.phoneNumber}\n\n'
-                      'Name: ${widget.user.displayName}\n\n'
-                      'ID: ${widget.user.uid}\n\n'
-                      'Created: ${widget.user.metadata.creationTime.toString()}\n\n'
-                      'Last login: ${widget.user.metadata.lastSignInTime}\n\n\n'
-                      'Providers: ${widget.user.providerData.fold('', (previousValue, element) => previousValue += '\n${element.providerId} ${element.uid}')}',
+                ),
+            Text(widget.user == null
+                ? 'Not signed in'
+                : '${widget.user.isAnonymous ? 'User is anonymous\n\n' : ''}'
+                    'Email: ${widget.user.email} (verified: ${widget.user.emailVerified})\n\n'
+                    'Phone number: ${widget.user.phoneNumber}\n\n'
+                    'Name: ${widget.user.displayName}\n\n\n'
+                    'ID: ${widget.user.uid}\n\n'
+                    'Tenant ID: ${widget.user.tenantId}\n\n'
+                    'Refresh token: ${widget.user.refreshToken}\n\n\n'
+                    'Created: ${widget.user.metadata.creationTime.toString()}\n\n'
+                    'Last login: ${widget.user.metadata.lastSignInTime}\n\n'),
+            if (widget.user != null)
+              Column(
+                crossAxisAlignment: CrossAxisAlignment.stretch,
+                children: [
+                  Text(
+                    widget.user.providerData.isEmpty
+                        ? 'No providers'
+                        : 'Providers:',
+                    style: TextStyle(fontWeight: FontWeight.bold),
+                    textAlign: TextAlign.center,
+                  ),
+                  for (var provider in widget.user.providerData)
+                    Dismissible(
+                      key: Key(provider.uid),
+                      child: Card(
+                        color: Colors.grey[700],
+                        child: ListTile(
+                          leading: provider.photoURL == null
+                              ? IconButton(
+                                  icon: const Icon(Icons.remove),
+                                  onPressed: () =>
+                                      widget.user.unlink(provider.providerId))
+                              : Image.network(provider.photoURL),
+                          title: Text(provider.providerId),
+                          subtitle: Text(
+                              "${provider.displayName == null ? "" : "${provider.displayName}\n"}${provider.uid}"),
+                        ),
+                      ),
+                      onDismissed: (action) =>
+                          widget.user.unlink(provider.providerId),
+                    ),
+                ],
+              ),
+            Visibility(
+              visible: widget.user != null,
+              child: Container(
+                margin: EdgeInsets.only(top: 8.0),
+                alignment: Alignment.center,
+                child: Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceEvenly,
+                  children: [
+                    IconButton(
+                      onPressed: () => widget.user.reload(),
+                      icon: const Icon(Icons.refresh),
+                    ),
+                    IconButton(
+                      onPressed: () => widget.user.delete(),
+                      icon: const Icon(Icons.delete_forever),
+                    ),
+                  ],
+                ),
+              ),
             ),
           ],
         ),


### PR DESCRIPTION
## Description

The auth example sign-in page could use some feedback for when the user is signed in plus an example of how to display user info.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
