### PR TITLE
fix(storage,android): handle ArrayIndexOutOfBoundsException (fixes #4334)

### DIFF
--- a/packages/firebase_storage/firebase_storage/android/src/main/java/io/flutter/plugins/firebase/storage/FlutterFirebaseStorageTask.java
+++ b/packages/firebase_storage/firebase_storage/android/src/main/java/io/flutter/plugins/firebase/storage/FlutterFirebaseStorageTask.java
@@ -65,7 +65,13 @@ class FlutterFirebaseStorageTask {
   static void cancelInProgressTasks() {
     synchronized (inProgressTasks) {
       for (int i = 0; i < inProgressTasks.size(); i++) {
-        FlutterFirebaseStorageTask task = inProgressTasks.valueAt(i);
+        FlutterFirebaseStorageTask task = null;
+        try {
+          task = inProgressTasks.valueAt(i);
+        } catch (ArrayIndexOutOfBoundsException e) {
+          // TODO(Salakar): Why does this happen? Race condition / multiple destroy calls?
+          // Can safely ignore exception for now, see https://github.com/FirebaseExtended/flutterfire/issues/4334
+        }
         if (task != null) {
           task.destroy();
         }
@@ -138,8 +144,11 @@ class FlutterFirebaseStorageTask {
       if (storageTask.isInProgress() || storageTask.isPaused()) {
         storageTask.cancel();
       }
-      if (inProgressTasks.get(handle) != null) {
+      try {
         inProgressTasks.remove(handle);
+      } catch (ArrayIndexOutOfBoundsException e) {
+        // TODO(Salakar): Why does this happen? Race condition / multiple destroy calls?
+        // Can safely ignore exception for now, see https://github.com/FirebaseExtended/flutterfire/issues/4334
       }
     }
 

--- a/packages/firebase_storage/firebase_storage/android/src/main/java/io/flutter/plugins/firebase/storage/FlutterFirebaseStorageTask.java
+++ b/packages/firebase_storage/firebase_storage/android/src/main/java/io/flutter/plugins/firebase/storage/FlutterFirebaseStorageTask.java
@@ -65,8 +65,7 @@ class FlutterFirebaseStorageTask {
   static void cancelInProgressTasks() {
     synchronized (inProgressTasks) {
       for (int i = 0; i < inProgressTasks.size(); i++) {
-        int key = inProgressTasks.keyAt(i);
-        FlutterFirebaseStorageTask task = inProgressTasks.get(key);
+        FlutterFirebaseStorageTask task = inProgressTasks.valueAt(i);
         if (task != null) {
           task.destroy();
         }
@@ -139,7 +138,9 @@ class FlutterFirebaseStorageTask {
       if (storageTask.isInProgress() || storageTask.isPaused()) {
         storageTask.cancel();
       }
-      inProgressTasks.remove(handle);
+      if (inProgressTasks.get(handle) != null) {
+        inProgressTasks.remove(handle);
+      }
     }
 
     synchronized (cancelSyncObject) {


### PR DESCRIPTION
## Description

Additionally simplified `cancelInProgressTasks` to use `valueAt` rather than 2 calls of `keyAt` & `get`.

## Related Issues

Fixes #4334.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
