### PR TITLE
docs: fix messaging regex examples

### DIFF
--- a/packages/firebase_messaging/firebase_messaging/lib/src/messaging.dart
+++ b/packages/firebase_messaging/firebase_messaging/lib/src/messaging.dart
@@ -322,7 +322,7 @@ class FirebaseMessaging extends FirebasePluginPlatform {
   /// Subscribe to topic in background.
   ///
   /// [topic] must match the following regular expression:
-  /// "[a-zA-Z0-9-_.~%]{1,900}".
+  /// `[a-zA-Z0-9-_.~%]{1,900}`.
   Future<void> subscribeToTopic(String topic) {
     _assertTopicName(topic);
     return _delegate.subscribeToTopic(topic);

--- a/packages/firebase_messaging/firebase_messaging_platform_interface/lib/src/platform_interface/platform_interface_messaging.dart
+++ b/packages/firebase_messaging/firebase_messaging_platform_interface/lib/src/platform_interface/platform_interface_messaging.dart
@@ -297,7 +297,7 @@ abstract class FirebaseMessagingPlatform extends PlatformInterface {
   /// Subscribe to topic in background.
   ///
   /// [topic] must match the following regular expression:
-  /// "[a-zA-Z0-9-_.~%]{1,900}".
+  /// `[a-zA-Z0-9-_.~%]{1,900}`.
   Future<void> subscribeToTopic(String topic) {
     throw UnimplementedError('subscribeToTopic() is not implemented');
   }


### PR DESCRIPTION
## Description

Updates the documentation currently displayed on https://pub.dev/documentation/firebase_messaging/8.0.0-dev.11/firebase_messaging/FirebaseMessaging/subscribeToTopic.html. 

Changing quotations to backticks will allow the brackets to be displayed in the example provided.

## Related Issues

Fixes https://github.com/FirebaseExtended/flutterfire/issues/4578

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
