### PR TITLE
fix(crashlytics): didCrashOnPreviousExecution

### DIFF
--- a/packages/firebase_crashlytics/firebase_crashlytics/example/android/app/src/main/java/io/flutter/plugins/firebasecrashlyticsexample/EmbeddingV1Activity.java
+++ b/packages/firebase_crashlytics/firebase_crashlytics/example/android/app/src/main/java/io/flutter/plugins/firebasecrashlyticsexample/EmbeddingV1Activity.java
@@ -1,7 +1,6 @@
 package io.flutter.plugins.firebasecrashlyticsexample;
 
 import android.os.Bundle;
-import dev.flutter.plugins.e2e.E2EPlugin;
 import io.flutter.app.FlutterActivity;
 import io.flutter.plugins.firebase.core.FlutterFirebaseCorePlugin;
 import io.flutter.plugins.firebase.crashlytics.FlutterFirebaseCrashlyticsPlugin;
@@ -14,6 +13,5 @@ public class EmbeddingV1Activity extends FlutterActivity {
         registrarFor("io.flutter.plugins.firebase.core.FlutterFirebaseCorePlugin"));
     FlutterFirebaseCrashlyticsPlugin.registerWith(
         registrarFor("io.flutter.plugins.firebase.crashlytics.FlutterFirebaseCrashlyticsPlugin"));
-    E2EPlugin.registerWith(registrarFor("dev.flutter.plugins.e2e.E2EPlugin"));
   }
 }

--- a/packages/firebase_crashlytics/firebase_crashlytics/example/test_driver/firebase_crashlytics_e2e.dart
+++ b/packages/firebase_crashlytics/firebase_crashlytics/example/test_driver/firebase_crashlytics_e2e.dart
@@ -2,15 +2,13 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:e2e/e2e.dart';
+import 'package:drive/drive.dart' as drive;
 import 'package:flutter/widgets.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:firebase_crashlytics/firebase_crashlytics.dart';
 
-void main() {
-  E2EWidgetsFlutterBinding.ensureInitialized();
-
+void testsMain() {
   group('$FirebaseCrashlytics', () {
     /*late*/ FirebaseCrashlytics crashlytics;
 
@@ -138,3 +136,5 @@ void main() {
     });
   });
 }
+
+void main() => drive.main(testsMain);

--- a/packages/firebase_crashlytics/firebase_crashlytics/example/test_driver/firebase_crashlytics_e2e_test.dart
+++ b/packages/firebase_crashlytics/firebase_crashlytics/example/test_driver/firebase_crashlytics_e2e_test.dart
@@ -2,6 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:e2e/e2e_driver.dart' as e2e;
+import 'package:drive/drive_driver.dart' as drive;
 
-void main() => e2e.main();
+void main() => drive.main();

--- a/packages/firebase_crashlytics/firebase_crashlytics/ios/Classes/FLTFirebaseCrashlyticsPlugin.m
+++ b/packages/firebase_crashlytics/firebase_crashlytics/ios/Classes/FLTFirebaseCrashlyticsPlugin.m
@@ -90,7 +90,7 @@ NSString *const kCrashlyticsArgumentDidCrashOnPreviousExecution = @"didCrashOnPr
     [self sendUnsentReportsWithMethodCallResult:methodCallResult];
   } else if ([@"Crashlytics#deleteUnsentReports" isEqualToString:call.method]) {
     [self deleteUnsentReportsWithMethodCallResult:methodCallResult];
-  } else if ([@"Crashlytics#didCrashDuringPreviousExecution" isEqualToString:call.method]) {
+  } else if ([@"Crashlytics#didCrashOnPreviousExecution" isEqualToString:call.method]) {
     [self didCrashOnPreviousExecutionWithMethodCallResult:methodCallResult];
   } else {
     methodCallResult.success(FlutterMethodNotImplemented);


### PR DESCRIPTION
## Description

Bug fix for didCrashOnPOreviousExecution.

Testing library switched to drive (matches other plugins) on Crashlytics as e2e was exiting as 'successful' despite test failures.

## Related Issues

Fixes https://github.com/FirebaseExtended/flutterfire/issues/4658

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
