### PR TITLE
docs(firebase-auth,apple): uninstallation warning for logged in users

### DIFF
--- a/docs/auth/usage.mdx
+++ b/docs/auth/usage.mdx
@@ -163,8 +163,7 @@ try {
 ```
 
 :::caution
-Uninstalling Applications on `iOS` will leave Users logged into the platform.
-As the underlying Firebase iOS SDK persists authentication to the keychain, a user will remain logged in but a token will no longer be available when an app in re-installed.
+Note: uninstalling applications on `iOS` or macOS can still preserve your users authentication state between app re-installs as the underlying Firebase iOS SDK persists authentication to keychain.
 :::
 
 Once successful, if you are listening to changes in [authentication state](#authentication-state), a new event will be sent to your

--- a/docs/auth/usage.mdx
+++ b/docs/auth/usage.mdx
@@ -163,7 +163,7 @@ try {
 ```
 
 :::caution
-Note: uninstalling applications on `iOS` or macOS can still preserve your users authentication state between app re-installs as the underlying Firebase iOS SDK persists authentication to keychain.
+Note: uninstalling your application on iOS or macOS can still preserve your users authentication state between app re-installs as the underlying Firebase iOS SDK persists authentication state to keychain. See [#4661](https://github.com/FirebaseExtended/flutterfire/issues/4661) for more information.
 :::
 
 Once successful, if you are listening to changes in [authentication state](#authentication-state), a new event will be sent to your

--- a/docs/auth/usage.mdx
+++ b/docs/auth/usage.mdx
@@ -162,6 +162,11 @@ try {
 }
 ```
 
+:::caution
+Uninstalling Applications on `iOS` will leave Users logged into the platform.
+As the underlying Firebase iOS SDK persists authentication to the keychain, a user will remain logged in but a token will no longer be available when an app in re-installed.
+:::
+
 Once successful, if you are listening to changes in [authentication state](#authentication-state), a new event will be sent to your
 listeners.
 


### PR DESCRIPTION
## Description

When a user uninstalls an application, the user will remain logged in but an auth token will no longer be available. This is because of the underlying Firebase iOS SDK persisting on a keychain.

This PR updates the documentation to warn developers of this issue until a resolution can be found.

## Related Issues

Fixes https://github.com/FirebaseExtended/flutterfire/issues/4661

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
