### PR TITLE
chore(macos,firestore): use precompiled frameworks in example app

### DIFF
--- a/packages/cloud_firestore/cloud_firestore/example/macos/Podfile
+++ b/packages/cloud_firestore/cloud_firestore/example/macos/Podfile
@@ -1,4 +1,9 @@
 platform :osx, '10.12'
+$FirebaseSDKVersion = '7.4.0'
+
+require 'yaml'
+
+pubspec = YAML.load_file(File.join('..', File.join('..', 'pubspec.yaml')))
 
 # CocoaPods analytics sends network stats synchronously affecting flutter build latency.
 ENV['COCOAPODS_DISABLE_STATS'] = 'true'
@@ -76,8 +81,22 @@ target 'Runner' do
       pod p[:name], :path => File.join(symlink, 'macos')
     end
   }
-  # not supported on MacOS
-  # pod 'FirebaseFirestore', :git => 'https://github.com/invertase/firestore-ios-sdk-frameworks.git', :tag => '6.26.0'
+
+  if defined?($FirebaseSDKVersion)
+    Pod::UI.puts "#{pubspec['name']}: Using user specified Firebase SDK version for FirebaseFirestore framework: '#{$FirebaseSDKVersion}'"
+    firebase_sdk_version = $FirebaseSDKVersion
+  else
+    firebase_core_script = File.join(File.expand_path('..', File.expand_path('..', File.expand_path('..', File.expand_path('..', File.dirname(__FILE__))))), 'firebase_core/firebase_core/ios/firebase_sdk_version.rb')
+    if File.exist?(firebase_core_script)
+      require firebase_core_script
+      firebase_sdk_version = firebase_sdk_version!
+      Pod::UI.puts "#{pubspec['name']}: Using Firebase SDK version '#{firebase_sdk_version}' defined in 'firebase_core for FirebaseFirestore framework'"
+    else
+      raise "Error - unable to locate firebase_ios_sdk.rb script in firebase_core, and no FirebaseSDKVersion specified"
+    end
+  end
+
+  pod 'FirebaseFirestore', :git => 'https://github.com/invertase/firestore-ios-sdk-frameworks.git', :tag => "#{firebase_sdk_version}"
 end
 
 # Prevent Cocoapods from embedding a second Flutter framework and causing an error with the new Xcode build system.


### PR DESCRIPTION
## Description

https://github.com/invertase/firestore-ios-sdk-frameworks should now be compatible with macOS, this PR adds it back in to improve build times on CI.

## Related Issues

https://github.com/FirebaseExtended/flutterfire/issues/2751
https://github.com/invertase/firestore-ios-sdk-frameworks/issues/11

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
