### PR TITLE
docs: removed semicolon on single line return statement

### DIFF
--- a/docs/firestore/usage.mdx
+++ b/docs/firestore/usage.mdx
@@ -194,7 +194,7 @@ FirebaseFirestore.instance
     .then((QuerySnapshot querySnapshot) => {
         querySnapshot.docs.forEach((doc) {
             print(doc["first_name"]);
-        });
+        })
     });
 ```
 

--- a/docs/firestore/usage.mdx
+++ b/docs/firestore/usage.mdx
@@ -191,10 +191,10 @@ which returns a `List` containing [`DocumentSnapshot`](!cloud_firestore.Document
 FirebaseFirestore.instance
     .collection('users')
     .get()
-    .then((QuerySnapshot querySnapshot) => {
+    .then((QuerySnapshot querySnapshot) {
         querySnapshot.docs.forEach((doc) {
             print(doc["first_name"]);
-        })
+        });
     });
 ```
 

--- a/packages/firebase_database/example/lib/main.dart
+++ b/packages/firebase_database/example/lib/main.dart
@@ -97,7 +97,7 @@ class _MyHomePageState extends State<MyHomePage> {
     _counterSubscription.cancel();
   }
 
-  Future<void> _increment() async {
+  Future<void> _incrementWithTransaction() async {
     // Increment counter in transaction.
     final TransactionResult transactionResult =
         await _counterRef.runTransaction((MutableData mutableData) async {
@@ -116,6 +116,18 @@ class _MyHomePageState extends State<MyHomePage> {
       }
     }
   }
+  
+  Future<void> _increment() async {
+
+    try{
+      final result = await _counterRef.update(ServerValue.increment(1));
+      _messagesRef.push().set(<String, String>{
+        _kTestKey: '$_kTestValue ${result.dataSnapshot.value}'
+      });
+    }catch(error){
+        print(error.message);  
+    }
+ }
 
   @override
   Widget build(BuildContext context) {

--- a/packages/firebase_database/example/lib/main.dart
+++ b/packages/firebase_database/example/lib/main.dart
@@ -97,7 +97,7 @@ class _MyHomePageState extends State<MyHomePage> {
     _counterSubscription.cancel();
   }
 
-  Future<void> _incrementWithTransaction() async {
+  Future<void> _increment() async {
     // Increment counter in transaction.
     final TransactionResult transactionResult =
         await _counterRef.runTransaction((MutableData mutableData) async {
@@ -116,18 +116,6 @@ class _MyHomePageState extends State<MyHomePage> {
       }
     }
   }
-  
-  Future<void> _increment() async {
-
-    try{
-      final result = await _counterRef.update(ServerValue.increment(1));
-      _messagesRef.push().set(<String, String>{
-        _kTestKey: '$_kTestValue ${result.dataSnapshot.value}'
-      });
-    }catch(error){
-        print(error.message);  
-    }
- }
 
   @override
   Widget build(BuildContext context) {


### PR DESCRIPTION
## Description

While executing a single line return statement the body should remain without a semicolon indicating the end of it.
With the semicolon added, it doesn't compile!

## Related Issues

 firebaseextended/flutterfire#3711

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] If the pull request affects only one plugin, the PR title starts with the name of the plugin in brackets (e.g. [cloud_firestore])
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.


## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
