### PR TITLE
chore: bump firebase_core and firebase_core_web

### DIFF
--- a/packages/cloud_firestore/cloud_firestore/example/pubspec.yaml
+++ b/packages/cloud_firestore/cloud_firestore/example/pubspec.yaml
@@ -18,6 +18,8 @@ dependency_overrides:
     path: ../../../firebase_core/firebase_core
   firebase_core_platform_interface:
     path: ../../../firebase_core/firebase_core_platform_interface
+  firebase_core_web:
+    path: ../../../firebase_core/firebase_core_web
   cloud_firestore_platform_interface:
     path: ../../cloud_firestore_platform_interface
   http_parser: ^4.0.0-nullsafety

--- a/packages/cloud_functions/cloud_functions/example/pubspec.yaml
+++ b/packages/cloud_functions/cloud_functions/example/pubspec.yaml
@@ -23,6 +23,8 @@ dependency_overrides:
     path: ../../../firebase_core/firebase_core
   firebase_core_platform_interface:
     path: ../../../firebase_core/firebase_core_platform_interface
+  firebase_core_web:
+    path: ../../../firebase_core/firebase_core_web
 
 dev_dependencies:
   drive: 0.0.1-6.0.pre

--- a/packages/cloud_functions/cloud_functions/pubspec.yaml
+++ b/packages/cloud_functions/cloud_functions/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   cloud_functions_platform_interface: ^4.0.2-nullsafety.1
   cloud_functions_web: ^3.1.4-nullsafety.1
   firebase_core: ^0.8.0-nullsafety.0
-  firebase_core_platform_interface: ^3.0.2-nullsafety.0
+  firebase_core_platform_interface: ^4.0.0-nullsafety.0
   flutter:
     sdk: flutter
 

--- a/packages/cloud_functions/cloud_functions_platform_interface/pubspec.yaml
+++ b/packages/cloud_functions/cloud_functions_platform_interface/pubspec.yaml
@@ -17,7 +17,7 @@ dependencies:
   plugin_platform_interface: ^1.1.0-nullsafety.1
 
 dev_dependencies:
-  firebase_core_platform_interface: ^3.0.2-nullsafety.0
+  firebase_core_platform_interface: ^4.0.0-nullsafety.0
   flutter_test:
     sdk: flutter
   mockito: ^5.0.0-nullsafety.2

--- a/packages/cloud_functions/cloud_functions_web/pubspec.yaml
+++ b/packages/cloud_functions/cloud_functions_web/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 dependencies:
   cloud_functions_platform_interface: ^4.0.2-nullsafety.1
   firebase_core: ^0.8.0-nullsafety.0
-  firebase_core_web: ^0.2.2-nullsafety.1
+  firebase_core_web: ^0.3.0-nullsafety.0
   flutter:
     sdk: flutter
   flutter_web_plugins:
@@ -18,7 +18,7 @@ dependencies:
   js: ^0.6.3-nullsafety.3
 
 dev_dependencies:
-  firebase_core_platform_interface: ^3.0.2-nullsafety.0
+  firebase_core_platform_interface: ^4.0.0-nullsafety.0
   flutter_test:
     sdk: flutter
   mockito: ^5.0.0-nullsafety.2

--- a/packages/firebase_admob/example/pubspec.yaml
+++ b/packages/firebase_admob/example/pubspec.yaml
@@ -18,7 +18,7 @@ dependency_overrides:
   firebase_core_platform_interface:
     path: ../../firebase_core/firebase_core_platform_interface
   firebase_core_web:
-    path: ../../../firebase_core/firebase_core_web
+    path: ../../firebase_core/firebase_core_web
   quiver: ">=3.0.0-nullsafety.2 <4.0.0"
 
 dev_dependencies:

--- a/packages/firebase_admob/example/pubspec.yaml
+++ b/packages/firebase_admob/example/pubspec.yaml
@@ -17,6 +17,8 @@ dependency_overrides:
     path: ../../firebase_core/firebase_core
   firebase_core_platform_interface:
     path: ../../firebase_core/firebase_core_platform_interface
+  firebase_core_web:
+    path: ../../../firebase_core/firebase_core_web
   quiver: ">=3.0.0-nullsafety.2 <4.0.0"
 
 dev_dependencies:

--- a/packages/firebase_analytics/firebase_analytics/example/pubspec.yaml
+++ b/packages/firebase_analytics/firebase_analytics/example/pubspec.yaml
@@ -19,6 +19,8 @@ dependency_overrides:
     path: ../../../firebase_core/firebase_core
   firebase_core_platform_interface:
     path: ../../../firebase_core/firebase_core_platform_interface
+  firebase_core_web:
+    path: ../../../firebase_core/firebase_core_web
 
 dev_dependencies:
   pedantic: ^1.8.0

--- a/packages/firebase_auth/firebase_auth_platform_interface/pubspec.yaml
+++ b/packages/firebase_auth/firebase_auth_platform_interface/pubspec.yaml
@@ -17,7 +17,7 @@ dependencies:
   plugin_platform_interface: ^1.1.0-nullsafety.1
 
 dev_dependencies:
-  firebase_core_platform_interface: ^3.0.2-nullsafety.0
+  firebase_core_platform_interface: ^4.0.0-nullsafety.0
   flutter_test:
     sdk: flutter
   mockito: ^5.0.0-nullsafety.2

--- a/packages/firebase_core/firebase_core/example/pubspec.yaml
+++ b/packages/firebase_core/firebase_core/example/pubspec.yaml
@@ -13,6 +13,8 @@ dependencies:
 dependency_overrides:
   firebase_core_platform_interface:
     path: ../../firebase_core_platform_interface
+  firebase_core_web:
+    path: ../../firebase_core_web
   quiver: ">=3.0.0-nullsafety.2 <4.0.0"
 
 dev_dependencies:

--- a/packages/firebase_core/firebase_core/pubspec.yaml
+++ b/packages/firebase_core/firebase_core/pubspec.yaml
@@ -9,8 +9,8 @@ environment:
   flutter: ">=1.12.13+hotfix.5 <2.0.0"
 
 dependencies:
-  firebase_core_platform_interface: ^3.0.2-nullsafety.0
-  firebase_core_web: ^0.2.2-nullsafety.1
+  firebase_core_platform_interface: ^4.0.0-nullsafety.0
+  firebase_core_web: ^0.3.0-nullsafety.0
   flutter:
     sdk: flutter
   meta: ^1.3.0-nullsafety.0
@@ -21,7 +21,6 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
   mockito: ^5.0.0-nullsafety.2
-  pedantic: 1.10.0-nullsafety.3
   plugin_platform_interface: ^1.1.0-nullsafety.1
 
 flutter:

--- a/packages/firebase_core/firebase_core_platform_interface/CHANGELOG.md
+++ b/packages/firebase_core/firebase_core_platform_interface/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 4.0.0-nullsafety.0
+
+Major bump for the null-safety version to respect the versioning convention.
+
 ## 3.0.2-nullsafety.0
 
  - **REFACTOR**: Migrate to non-nullable types (#4656).

--- a/packages/firebase_core/firebase_core_platform_interface/pubspec.yaml
+++ b/packages/firebase_core/firebase_core_platform_interface/pubspec.yaml
@@ -3,7 +3,7 @@ description: A common platform interface for the firebase_core plugin.
 homepage: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/firebase_core/firebase_core_platform_interface
 # NOTE: We strongly prefer non-breaking changes, even at the expense of a
 # less-clean API. See https://flutter.dev/go/platform-interface-breaking-changes
-version: 3.0.2-nullsafety.0
+version: 4.0.0-nullsafety.0
 
 environment:
   sdk: '>=2.12.0-0 <3.0.0'
@@ -19,4 +19,3 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
   mockito: ^5.0.0-nullsafety.2
-  pedantic: 1.10.0-nullsafety.3

--- a/packages/firebase_core/firebase_core_web/CHANGELOG.md
+++ b/packages/firebase_core/firebase_core_web/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.0-nullsafety.0
+
+Major bump for the null-safety version to respect the versioning convention.
+
 ## 0.2.2-nullsafety.1
 
  - Bump `firebase_core` dependency version.

--- a/packages/firebase_core/firebase_core_web/pubspec.yaml
+++ b/packages/firebase_core/firebase_core_web/pubspec.yaml
@@ -1,14 +1,14 @@
 name: firebase_core_web
 description: The web implementation of firebase_core
 homepage: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/firebase_core/firebase_core_web
-version: 0.2.2-nullsafety.1
+version: 0.3.0-nullsafety.0
 
 environment:
   sdk: ">=2.12.0-0 <3.0.0"
   flutter: ">=1.12.13+hotfix.5 <2.0.0"
 
 dependencies:
-  firebase_core_platform_interface: ^3.0.2-nullsafety.0
+  firebase_core_platform_interface: ^4.0.0-nullsafety.0
   flutter:
     sdk: flutter
   flutter_web_plugins:
@@ -20,7 +20,6 @@ dev_dependencies:
   firebase_core: ^0.8.0-nullsafety.0
   flutter_test:
     sdk: flutter
-  pedantic: ^1.10.0-nullsafety.3
 
 flutter:
   plugin:

--- a/packages/firebase_crashlytics/firebase_crashlytics/example/pubspec.yaml
+++ b/packages/firebase_crashlytics/firebase_crashlytics/example/pubspec.yaml
@@ -23,6 +23,8 @@ dependency_overrides:
     path: ../../../firebase_core/firebase_core
   firebase_core_platform_interface:
     path: ../../../firebase_core/firebase_core_platform_interface
+  firebase_core_web:
+    path: ../../../firebase_core/firebase_core_web
   quiver: ">=3.0.0-nullsafety.2 <4.0.0"
 
 dev_dependencies:

--- a/packages/firebase_database/example/pubspec.yaml
+++ b/packages/firebase_database/example/pubspec.yaml
@@ -19,6 +19,8 @@ dependency_overrides:
     path: ../../firebase_core/firebase_core
   firebase_core_platform_interface:
     path: ../../firebase_core/firebase_core_platform_interface
+  firebase_core_web:
+    path: ../../../firebase_core/firebase_core_web
 
 dev_dependencies:
   pedantic: ^1.8.0

--- a/packages/firebase_database/example/pubspec.yaml
+++ b/packages/firebase_database/example/pubspec.yaml
@@ -20,7 +20,7 @@ dependency_overrides:
   firebase_core_platform_interface:
     path: ../../firebase_core/firebase_core_platform_interface
   firebase_core_web:
-    path: ../../../firebase_core/firebase_core_web
+    path: ../../firebase_core/firebase_core_web
 
 dev_dependencies:
   pedantic: ^1.8.0

--- a/packages/firebase_dynamic_links/example/pubspec.yaml
+++ b/packages/firebase_dynamic_links/example/pubspec.yaml
@@ -19,6 +19,8 @@ dependency_overrides:
     path: ../../firebase_core/firebase_core
   firebase_core_platform_interface:
     path: ../../firebase_core/firebase_core_platform_interface
+  firebase_core_web:
+    path: ../../../firebase_core/firebase_core_web
 
 dev_dependencies:
   pedantic: ^1.8.0

--- a/packages/firebase_dynamic_links/example/pubspec.yaml
+++ b/packages/firebase_dynamic_links/example/pubspec.yaml
@@ -20,7 +20,7 @@ dependency_overrides:
   firebase_core_platform_interface:
     path: ../../firebase_core/firebase_core_platform_interface
   firebase_core_web:
-    path: ../../../firebase_core/firebase_core_web
+    path: ../../firebase_core/firebase_core_web
 
 dev_dependencies:
   pedantic: ^1.8.0

--- a/packages/firebase_in_app_messaging/example/pubspec.yaml
+++ b/packages/firebase_in_app_messaging/example/pubspec.yaml
@@ -22,7 +22,7 @@ dependency_overrides:
   firebase_core_platform_interface:
     path: ../../firebase_core/firebase_core_platform_interface
   firebase_core_web:
-    path: ../../../firebase_core/firebase_core_web
+    path: ../../firebase_core/firebase_core_web
 
 dev_dependencies:
   pedantic: ^1.8.0

--- a/packages/firebase_in_app_messaging/example/pubspec.yaml
+++ b/packages/firebase_in_app_messaging/example/pubspec.yaml
@@ -21,6 +21,8 @@ dependency_overrides:
     path: ../../firebase_core/firebase_core
   firebase_core_platform_interface:
     path: ../../firebase_core/firebase_core_platform_interface
+  firebase_core_web:
+    path: ../../../firebase_core/firebase_core_web
 
 dev_dependencies:
   pedantic: ^1.8.0

--- a/packages/firebase_messaging/firebase_messaging/example/pubspec.yaml
+++ b/packages/firebase_messaging/firebase_messaging/example/pubspec.yaml
@@ -20,6 +20,8 @@ dependency_overrides:
     path: ../../../firebase_core/firebase_core
   firebase_core_platform_interface:
     path: ../../../firebase_core/firebase_core_platform_interface
+  firebase_core_web:
+    path: ../../../firebase_core/firebase_core_web
   firebase_messaging:
     path: ../
   firebase_messaging_platform_interface:

--- a/packages/firebase_ml_custom/example/pubspec.yaml
+++ b/packages/firebase_ml_custom/example/pubspec.yaml
@@ -24,6 +24,8 @@ dependency_overrides:
     path: ../../firebase_core/firebase_core
   firebase_core_platform_interface:
     path: ../../firebase_core/firebase_core_platform_interface
+  firebase_core_web:
+    path: ../../firebase_core/firebase_core_web
   http: ^0.12.2
   http_parser: ^4.0.0-nullsafety
 

--- a/packages/firebase_ml_vision/example/pubspec.yaml
+++ b/packages/firebase_ml_vision/example/pubspec.yaml
@@ -23,7 +23,7 @@ dependency_overrides:
   firebase_core_platform_interface:
     path: ../../firebase_core/firebase_core_platform_interface
   firebase_core_web:
-    path: ../../../firebase_core/firebase_core_web
+    path: ../../firebase_core/firebase_core_web
   http: ^0.12.2
   http_parser: ^4.0.0-nullsafety
 

--- a/packages/firebase_ml_vision/example/pubspec.yaml
+++ b/packages/firebase_ml_vision/example/pubspec.yaml
@@ -22,6 +22,8 @@ dependency_overrides:
     path: ../../firebase_core/firebase_core
   firebase_core_platform_interface:
     path: ../../firebase_core/firebase_core_platform_interface
+  firebase_core_web:
+    path: ../../../firebase_core/firebase_core_web
   http: ^0.12.2
   http_parser: ^4.0.0-nullsafety
 

--- a/packages/firebase_performance/example/pubspec.yaml
+++ b/packages/firebase_performance/example/pubspec.yaml
@@ -19,6 +19,8 @@ dependency_overrides:
     path: ../../firebase_core/firebase_core
   firebase_core_platform_interface:
     path: ../../firebase_core/firebase_core_platform_interface
+  firebase_core_web:
+    path: ../../../firebase_core/firebase_core_web
 
 dev_dependencies:
   pedantic: ^1.8.0

--- a/packages/firebase_performance/example/pubspec.yaml
+++ b/packages/firebase_performance/example/pubspec.yaml
@@ -20,7 +20,7 @@ dependency_overrides:
   firebase_core_platform_interface:
     path: ../../firebase_core/firebase_core_platform_interface
   firebase_core_web:
-    path: ../../../firebase_core/firebase_core_web
+    path: ../../firebase_core/firebase_core_web
 
 dev_dependencies:
   pedantic: ^1.8.0

--- a/packages/firebase_remote_config/firebase_remote_config/example/pubspec.yaml
+++ b/packages/firebase_remote_config/firebase_remote_config/example/pubspec.yaml
@@ -19,6 +19,8 @@ dependencies:
 dependency_overrides:
   firebase_core:
     path: ../../../firebase_core/firebase_core
+  firebase_core_web:
+    path: ../../../firebase_core/firebase_core_web
   firebase_core_platform_interface:
     path: ../../../firebase_core/firebase_core_platform_interface
   firebase_remote_config_platform_interface:

--- a/packages/firebase_storage/firebase_storage/example/pubspec.yaml
+++ b/packages/firebase_storage/firebase_storage/example/pubspec.yaml
@@ -20,6 +20,8 @@ dependency_overrides:
     path: ../../../firebase_core/firebase_core
   firebase_core_platform_interface:
     path: ../../../firebase_core/firebase_core_platform_interface
+  firebase_core_web:
+    path: ../../../firebase_core/firebase_core_web
   firebase_storage:
     path: ../
   firebase_storage_platform_interface:


### PR DESCRIPTION
## Description

This bumps firebase_core and firebase_core_web to respect the conventions around null-safety versioning

## Related Issues

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
