### PR TITLE
fix(firebase_remote_config): Consider '1' as boolean on iOS

### DIFF
--- a/packages/firebase_remote_config/firebase_remote_config_platform_interface/lib/src/remote_config_value.dart
+++ b/packages/firebase_remote_config/firebase_remote_config_platform_interface/lib/src/remote_config_value.dart
@@ -74,7 +74,8 @@ class RemoteConfigValue {
   bool asBool() {
     if (_value != null) {
       final String strValue = const Utf8Codec().decode(_value);
-      return strValue.toLowerCase() == 'true';
+      final lowerCase = strValue.toLowerCase();
+      return lowerCase == 'true' || lowerCase == '1';
     } else {
       return defaultValueForBool;
     }


### PR DESCRIPTION
## Description

When parsing booleans from iOS, consider `'1'` as `true`

## Related Issues

Closes https://github.com/FirebaseExtended/flutterfire/issues/2629

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
