### PR TITLE
docs: add missing semicolon

### DIFF
--- a/docs/overview.mdx
+++ b/docs/overview.mdx
@@ -139,7 +139,7 @@ import 'package:flutter/material.dart';
 import 'package:firebase_core/firebase_core.dart';
 
 void main() {
-  WidgetsFlutterBinding.ensureInitialized()
+  WidgetsFlutterBinding.ensureInitialized();
   runApp(App());
 }
 


### PR DESCRIPTION
## Description

Semicolon was missing in overview section of flutterfire doc [website](https://firebase.flutter.dev/docs/overview) .

![fireflutter](https://user-images.githubusercontent.com/57143358/105719657-8c3ca200-5f48-11eb-82af-f22756322793.PNG)

This PR fix the issue.

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [ ] No, this is *not* a breaking change.

