### PR TITLE
fix: Analysis error with firebase_core/web

### DIFF
--- a/packages/firebase_core/firebase_core_web/lib/src/interop/utils/utils.dart
+++ b/packages/firebase_core/firebase_core_web/lib/src/interop/utils/utils.dart
@@ -113,11 +113,11 @@ PromiseJsImpl<S> handleFutureWithMapper<T, S>(
 ) {
   return PromiseJsImpl<S>(allowInterop((
     void Function(S) resolve,
-    Null Function(Object) reject,
+    void Function(Object) reject,
   ) {
     future.then((value) {
       var mappedValue = mapper(value);
       resolve(mappedValue);
-    }).catchError(reject);
+    }).catchError((error) => reject(error));
   }));
 }

--- a/packages/firebase_core/firebase_core_web/lib/src/interop/utils/utils.dart
+++ b/packages/firebase_core/firebase_core_web/lib/src/interop/utils/utils.dart
@@ -113,7 +113,7 @@ PromiseJsImpl<S> handleFutureWithMapper<T, S>(
 ) {
   return PromiseJsImpl<S>(allowInterop((
     void Function(S) resolve,
-    void Function(Object) reject,
+    Null Function(Object) reject,
   ) {
     future.then((value) {
       var mappedValue = mapper(value);


### PR DESCRIPTION

## Description

Fixes the following analysis warning:

```
firebase_core/web/lib/src/interop/utils/utils.dart:121
  The return type 'void' isn't assignable to 'FutureOr<Null>', as required by 'Future.catchError'. #return_type_invalid_for_catch_error
```

`return_type_invalid_for_catch_error` analysis option should probably be enabled to avoid this in the future

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
