### PR TITLE
ci: enable `--fatal-infos` on Dart Analyzer

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -2,3 +2,6 @@ include: package:pedantic/analysis_options.1.8.0.yaml
 linter:
   rules:
     - public_member_api_docs
+analyzer:
+  exclude:
+    - "**/generated_plugin_registrant.dart"

--- a/melos.yaml
+++ b/melos.yaml
@@ -11,7 +11,7 @@ scripts:
   analyze:
     run: |
       melos exec -c 5 -- \
-        dart analyze .
+        dart analyze . --fatal-infos
     description: |
       Run `dart analyze` in all packages.
        - Note: you can also rely on your IDEs Dart Analysis / Issues window.

--- a/packages/firebase_admob/example/lib/main.dart
+++ b/packages/firebase_admob/example/lib/main.dart
@@ -110,7 +110,7 @@ class _MyAppState extends State<MyApp> {
               crossAxisAlignment: CrossAxisAlignment.center,
               mainAxisSize: MainAxisSize.min,
               children: <Widget>[
-                RaisedButton(
+                ElevatedButton(
                     child: const Text('SHOW BANNER'),
                     onPressed: () {
                       _bannerAd ??= createBannerAd();
@@ -118,7 +118,7 @@ class _MyAppState extends State<MyApp> {
                         ..load()
                         ..show();
                     }),
-                RaisedButton(
+                ElevatedButton(
                     child: const Text('SHOW BANNER WITH OFFSET'),
                     onPressed: () {
                       _bannerAd ??= createBannerAd();
@@ -126,26 +126,26 @@ class _MyAppState extends State<MyApp> {
                         ..load()
                         ..show(horizontalCenterOffset: -50, anchorOffset: 100);
                     }),
-                RaisedButton(
+                ElevatedButton(
                     child: const Text('REMOVE BANNER'),
                     onPressed: () {
                       _bannerAd?.dispose();
                       _bannerAd = null;
                     }),
-                RaisedButton(
+                ElevatedButton(
                   child: const Text('LOAD INTERSTITIAL'),
                   onPressed: () {
                     _interstitialAd?.dispose();
                     _interstitialAd = createInterstitialAd()..load();
                   },
                 ),
-                RaisedButton(
+                ElevatedButton(
                   child: const Text('SHOW INTERSTITIAL'),
                   onPressed: () {
                     _interstitialAd?.show();
                   },
                 ),
-                RaisedButton(
+                ElevatedButton(
                   child: const Text('SHOW NATIVE'),
                   onPressed: () {
                     _nativeAd ??= createNativeAd();
@@ -158,14 +158,14 @@ class _MyAppState extends State<MyApp> {
                       );
                   },
                 ),
-                RaisedButton(
+                ElevatedButton(
                   child: const Text('REMOVE NATIVE'),
                   onPressed: () {
                     _nativeAd?.dispose();
                     _nativeAd = null;
                   },
                 ),
-                RaisedButton(
+                ElevatedButton(
                   child: const Text('LOAD REWARDED VIDEO'),
                   onPressed: () {
                     RewardedVideoAd.instance.load(
@@ -173,7 +173,7 @@ class _MyAppState extends State<MyApp> {
                         targetingInfo: targetingInfo);
                   },
                 ),
-                RaisedButton(
+                ElevatedButton(
                   child: const Text('SHOW REWARDED VIDEO'),
                   onPressed: () {
                     RewardedVideoAd.instance.show();

--- a/packages/firebase_core/firebase_core/example/lib/main.dart
+++ b/packages/firebase_core/firebase_core/example/lib/main.dart
@@ -67,16 +67,17 @@ class MyApp extends StatelessWidget {
             mainAxisAlignment: MainAxisAlignment.spaceAround,
             crossAxisAlignment: CrossAxisAlignment.stretch,
             children: <Widget>[
-              RaisedButton(
+              ElevatedButton(
                   onPressed: initializeDefault,
                   child: const Text('Initialize default app')),
-              RaisedButton(
+              ElevatedButton(
                   onPressed: initializeSecondary,
                   child: const Text('Initialize secondary app')),
-              RaisedButton(onPressed: apps, child: const Text('Get apps')),
-              RaisedButton(
+              ElevatedButton(onPressed: apps, child: const Text('Get apps')),
+              ElevatedButton(
                   onPressed: options, child: const Text('List options')),
-              RaisedButton(onPressed: delete, child: const Text('Delete app')),
+              ElevatedButton(
+                  onPressed: delete, child: const Text('Delete app')),
             ],
           ),
         ),

--- a/packages/firebase_core/firebase_core_web/lib/src/interop/utils/utils.dart
+++ b/packages/firebase_core/firebase_core_web/lib/src/interop/utils/utils.dart
@@ -112,8 +112,8 @@ PromiseJsImpl<S> handleFutureWithMapper<T, S>(
   Func1<T, S> mapper,
 ) {
   return PromiseJsImpl<S>(allowInterop((
-    void Function(S) resolve,
-    void Function(Object) reject,
+    Function(S) resolve,
+    Function(Object) reject,
   ) {
     future.then((value) {
       var mappedValue = mapper(value);

--- a/packages/firebase_crashlytics/firebase_crashlytics/example/lib/main.dart
+++ b/packages/firebase_crashlytics/firebase_crashlytics/example/lib/main.dart
@@ -98,7 +98,7 @@ class _MyAppState extends State<MyApp> {
                 return Center(
                   child: Column(
                     children: <Widget>[
-                      RaisedButton(
+                      ElevatedButton(
                         onPressed: () {
                           FirebaseCrashlytics.instance
                               .setCustomKey('example', 'flutterfire');
@@ -112,7 +112,7 @@ class _MyAppState extends State<MyApp> {
                         },
                         child: const Text('Key'),
                       ),
-                      RaisedButton(
+                      ElevatedButton(
                         onPressed: () {
                           FirebaseCrashlytics.instance
                               .log('This is a log example');
@@ -126,7 +126,7 @@ class _MyAppState extends State<MyApp> {
                         },
                         child: const Text('Log'),
                       ),
-                      RaisedButton(
+                      ElevatedButton(
                         onPressed: () async {
                           ScaffoldMessenger.of(context)
                               .showSnackBar(const SnackBar(
@@ -144,7 +144,7 @@ class _MyAppState extends State<MyApp> {
                         },
                         child: const Text('Crash'),
                       ),
-                      RaisedButton(
+                      ElevatedButton(
                         onPressed: () {
                           ScaffoldMessenger.of(context)
                               .showSnackBar(const SnackBar(
@@ -159,7 +159,7 @@ class _MyAppState extends State<MyApp> {
                         },
                         child: const Text('Throw Error'),
                       ),
-                      RaisedButton(
+                      ElevatedButton(
                         onPressed: () {
                           ScaffoldMessenger.of(context)
                               .showSnackBar(const SnackBar(
@@ -182,7 +182,7 @@ class _MyAppState extends State<MyApp> {
                         },
                         child: const Text('Async out of bounds'),
                       ),
-                      RaisedButton(
+                      ElevatedButton(
                         onPressed: () async {
                           try {
                             ScaffoldMessenger.of(context)

--- a/packages/firebase_dynamic_links/example/lib/main.dart
+++ b/packages/firebase_dynamic_links/example/lib/main.dart
@@ -113,13 +113,13 @@ class _MainScreenState extends State<_MainScreen> {
                 ButtonBar(
                   alignment: MainAxisAlignment.center,
                   children: <Widget>[
-                    RaisedButton(
+                    ElevatedButton(
                       onPressed: !_isCreatingLink
                           ? () => _createDynamicLink(false)
                           : null,
                       child: const Text('Get Long Link'),
                     ),
-                    RaisedButton(
+                    ElevatedButton(
                       onPressed: !_isCreatingLink
                           ? () => _createDynamicLink(true)
                           : null,

--- a/packages/firebase_in_app_messaging/example/lib/main.dart
+++ b/packages/firebase_in_app_messaging/example/lib/main.dart
@@ -60,14 +60,14 @@ class ProgrammaticTriggersExample extends StatelessWidget {
             const SizedBox(height: 8),
             const Text("Manually trigger events programmatically "),
             const SizedBox(height: 8),
-            RaisedButton(
+            ElevatedButton(
               onPressed: () {
                 fiam.triggerEvent('chicken_event');
                 ScaffoldMessenger.of(context).showSnackBar(const SnackBar(
                   content: Text("Triggering event: chicken_event"),
                 ));
               },
-              color: Colors.blue,
+              style: ElevatedButton.styleFrom(primary: Colors.blue),
               child: Text(
                 "Programmatic Triggers".toUpperCase(),
                 style: TextStyle(color: Colors.white),
@@ -105,14 +105,14 @@ class AnalyticsEventExample extends StatelessWidget {
             const SizedBox(height: 8),
             const Text("Trigger an analytics event"),
             const SizedBox(height: 8),
-            RaisedButton(
+            ElevatedButton(
               onPressed: () {
                 _sendAnalyticsEvent();
                 ScaffoldMessenger.of(context).showSnackBar(const SnackBar(
                   content: Text("Firing analytics event: awesome_event"),
                 ));
               },
-              color: Colors.blue,
+              style: ElevatedButton.styleFrom(primary: Colors.blue),
               child: Text(
                 "Log event".toUpperCase(),
                 style: TextStyle(color: Colors.white),

--- a/packages/firebase_messaging/firebase_messaging/example/lib/permissions.dart
+++ b/packages/firebase_messaging/firebase_messaging/example/lib/permissions.dart
@@ -58,7 +58,7 @@ class _Permissions extends State<Permissions> {
     }
 
     if (!_requested) {
-      return RaisedButton(
+      return ElevatedButton(
           onPressed: requestPermissions, child: Text("Request Permissions"));
     }
 
@@ -75,7 +75,7 @@ class _Permissions extends State<Permissions> {
         row("Sound", settingsMap[_settings.sound]),
       ],
       Container(
-        child: RaisedButton(
+        child: ElevatedButton(
             onPressed: () => {}, child: Text("Reload Permissions")),
       )
     ]));

--- a/packages/firebase_ml_vision/example/lib/material_barcode_scanner.dart
+++ b/packages/firebase_ml_vision/example/lib/material_barcode_scanner.dart
@@ -8,10 +8,10 @@ import 'dart:async';
 import 'dart:io';
 import 'dart:ui' show lerpDouble;
 
+import 'package:camera/camera.dart';
 import 'package:firebase_ml_vision/firebase_ml_vision.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
-import 'package:camera/camera.dart';
 import 'package:flutter/services.dart';
 import 'package:path_provider/path_provider.dart';
 
@@ -425,17 +425,19 @@ class _MaterialBarcodeScannerState extends State<MaterialBarcodeScanner>
                           child: ButtonTheme(
                             minWidth: 312,
                             height: 48,
-                            child: RaisedButton.icon(
+                            child: ElevatedButton.icon(
                               onPressed: () => Navigator.of(context).pop(),
-                              color: kShrinePink100,
-                              label: const Text('ADD TO CART - \$12.99'),
-                              icon: const Icon(Icons.add_shopping_cart),
-                              elevation: 8.0,
-                              shape: const BeveledRectangleBorder(
-                                borderRadius: BorderRadius.all(
-                                  Radius.circular(7.0),
+                              style: ElevatedButton.styleFrom(
+                                primary: kShrinePink100,
+                                elevation: 8.0,
+                                shape: const BeveledRectangleBorder(
+                                  borderRadius: BorderRadius.all(
+                                    Radius.circular(7.0),
+                                  ),
                                 ),
                               ),
+                              label: const Text('ADD TO CART - \$12.99'),
+                              icon: const Icon(Icons.add_shopping_cart),
                             ),
                           ),
                         ),

--- a/packages/firebase_performance/example/lib/main.dart
+++ b/packages/firebase_performance/example/lib/main.dart
@@ -129,11 +129,11 @@ class _MyAppState extends State<MyApp> {
           child: Column(
             children: <Widget>[
               Text(_performanceCollectionMessage),
-              RaisedButton(
+              ElevatedButton(
                 onPressed: _togglePerformanceCollection,
                 child: const Text('Toggle Data Collection'),
               ),
-              RaisedButton(
+              ElevatedButton(
                 onPressed: _testTrace,
                 child: const Text('Run Trace'),
               ),
@@ -141,7 +141,7 @@ class _MyAppState extends State<MyApp> {
                 _traceHasRan ? 'Trace Ran!' : '',
                 style: textStyle,
               ),
-              RaisedButton(
+              ElevatedButton(
                 onPressed: _testHttpMetric,
                 child: const Text('Run HttpMetric'),
               ),


### PR DESCRIPTION
## Description

This PR enables --fatal-infos for `dart analyze`. Additionally excludes generated plugin files from being analyzed.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
