### PR TITLE
PluginRegistry cannot be converted to FlutterEngine

### DIFF
--- a/docs/messaging/overview.mdx
+++ b/docs/messaging/overview.mdx
@@ -57,7 +57,8 @@ public class Application extends FlutterApplication implements PluginRegistrantC
 
   @Override
   public void registerWith(PluginRegistry registry) {
-    GeneratedPluginRegistrant.registerWith(registry);
+    // GeneratedPluginRegistrant.registerWith(registry); // Removed this line and added line below
+    FirebaseMessagingPlugin.registerWith(registry.registrarFor("io.flutter.plugins.firebasemessaging.FirebaseMessagingPlugin"));
   }
   // ...
 }


### PR DESCRIPTION
## Description

PluginRegistry cannot be converted to FlutterEngine.
