### PR TITLE
refactor: pubspec & dependency updates

### DIFF
--- a/packages/cloud_firestore/cloud_firestore/pubspec.yaml
+++ b/packages/cloud_firestore/cloud_firestore/pubspec.yaml
@@ -7,7 +7,7 @@ version: 0.17.0-1.0.nullsafety.0
 
 environment:
   sdk: ">=2.12.0-0 <3.0.0"
-  flutter: ">=1.12.13+hotfix.4 <2.0.0"
+  flutter: ">=1.12.13+hotfix.4"
 
 dependencies:
   cloud_firestore_platform_interface: ">=4.0.0-1.0.nullsafety.0 <4.0.0-2.0.nullsafety.0"
@@ -25,9 +25,6 @@ dev_dependencies:
     sdk: flutter
   mockito: ^5.0.0-nullsafety.2
   test: any
-
-dependency_overrides:
-  http_parser: ^4.0.0-nullsafety
 
 flutter:
   plugin:

--- a/packages/cloud_firestore/cloud_firestore_platform_interface/pubspec.yaml
+++ b/packages/cloud_firestore/cloud_firestore_platform_interface/pubspec.yaml
@@ -5,7 +5,7 @@ homepage: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/c
 
 environment:
   sdk: ">=2.12.0-0 <3.0.0"
-  flutter: ">=1.9.1+hotfix.5 <2.0.0"
+  flutter: ">=1.9.1+hotfix.5"
 
 dependencies:
   collection: ^1.15.0-nullsafety.5
@@ -13,7 +13,7 @@ dependencies:
   flutter:
     sdk: flutter
   meta: ^1.3.0-nullsafety.6
-  plugin_platform_interface: ^1.1.0-nullsafety.1
+  plugin_platform_interface: ^1.1.0-nullsafety.2
 
 
 dev_dependencies:

--- a/packages/cloud_firestore/cloud_firestore_web/pubspec.yaml
+++ b/packages/cloud_firestore/cloud_firestore_web/pubspec.yaml
@@ -5,7 +5,7 @@ version: 0.4.0-1.0.nullsafety.0
 
 environment:
   sdk: ">=2.12.0-0 <3.0.0"
-  flutter: ">=1.12.13+hotfix.4 <2.0.0"
+  flutter: ">=1.12.13+hotfix.4"
 
 dependencies:
   cloud_firestore_platform_interface: ">=4.0.0-1.0.nullsafety.0 <4.0.0-2.0.nullsafety.0"
@@ -16,9 +16,6 @@ dependencies:
   flutter_web_plugins:
     sdk: flutter
   js: ^0.6.3-nullsafety.3
-
-dependency_overrides:
-  http_parser: ^4.0.0-nullsafety
 
 dev_dependencies:
   firebase_core_platform_interface: ">=4.0.0-1.0.nullsafety.0 <4.0.0-2.0.nullsafety.0"

--- a/packages/cloud_functions/cloud_functions/example/pubspec.yaml
+++ b/packages/cloud_functions/cloud_functions/example/pubspec.yaml
@@ -30,7 +30,6 @@ dev_dependencies:
   drive: 0.0.1-6.0.pre
   flutter_driver:
     sdk: flutter
-  pedantic: ^1.8.0
   test: any
 
 flutter:

--- a/packages/cloud_functions/cloud_functions/pubspec.yaml
+++ b/packages/cloud_functions/cloud_functions/pubspec.yaml
@@ -5,7 +5,7 @@ homepage: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/c
 
 environment:
   sdk: ">=2.12.0-0 <3.0.0"
-  flutter: ">=1.12.13+hotfix.5 <2.0.0"
+  flutter: ">=1.12.13+hotfix.5"
 
 dependencies:
   cloud_functions_platform_interface: ">=4.0.2-1.0.nullsafety.0 <4.0.2-2.0.nullsafety.0"
@@ -21,7 +21,7 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
   pedantic: 1.10.0-nullsafety.3
-  plugin_platform_interface: ^1.1.0-nullsafety.1
+  plugin_platform_interface: ^1.1.0-nullsafety.2
   test: any
 
 flutter:

--- a/packages/cloud_functions/cloud_functions_platform_interface/pubspec.yaml
+++ b/packages/cloud_functions/cloud_functions_platform_interface/pubspec.yaml
@@ -7,19 +7,18 @@ version: 4.0.2-1.0.nullsafety.0
 
 environment:
   sdk: ">=2.12.0-0 <3.0.0"
-  flutter: ">=1.9.1+hotfix.5 <2.0.0"
+  flutter: ">=1.9.1+hotfix.5"
 
 dependencies:
   firebase_core: ">=0.8.0-1.0.nullsafety.0 <0.8.0-2.0.nullsafety.0"
   flutter:
     sdk: flutter
   meta: ^1.3.0-nullsafety.0
-  plugin_platform_interface: ^1.1.0-nullsafety.1
+  plugin_platform_interface: ^1.1.0-nullsafety.2
 
 dev_dependencies:
   firebase_core_platform_interface: ">=4.0.0-1.0.nullsafety.0 <4.0.0-2.0.nullsafety.0"
   flutter_test:
     sdk: flutter
   mockito: ^5.0.0-nullsafety.2
-  pedantic: 1.10.0-nullsafety.3
 

--- a/packages/cloud_functions/cloud_functions_web/pubspec.yaml
+++ b/packages/cloud_functions/cloud_functions_web/pubspec.yaml
@@ -5,7 +5,7 @@ version: 3.1.4-1.0.nullsafety.0
 
 environment:
   sdk: ">=2.12.0-0 <3.0.0"
-  flutter: ">=1.12.13+hotfix.4 <2.0.0"
+  flutter: ">=1.12.13+hotfix.4"
 
 dependencies:
   cloud_functions_platform_interface: ">=4.0.2-1.0.nullsafety.0 <4.0.2-2.0.nullsafety.0"
@@ -22,7 +22,6 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
   mockito: ^5.0.0-nullsafety.2
-  pedantic: 1.10.0-nullsafety.3
 
 flutter:
   plugin:

--- a/packages/firebase_auth/firebase_auth/example/pubspec.yaml
+++ b/packages/firebase_auth/firebase_auth/example/pubspec.yaml
@@ -33,18 +33,12 @@ dependency_overrides:
     path: ../../../firebase_core/firebase_core_web
   firebase_dynamic_links:
     path: ../../../firebase_dynamic_links
-  http:
-    git:
-      url: https://github.com/dart-lang/http
-      ref: d5c678cd63c3e9c1d779a09acfa95b7e3af84665
-  http_parser: ^4.0.0-nullsafety
 
 dev_dependencies:
   drive: 0.0.1-6.0.pre
-  e2e: ^0.6.1
   flutter_driver:
     sdk: flutter
-  pedantic: 1.10.0-nullsafety.3
+  http: ^0.13.0-nullsafety.0
   test: any
 
 flutter:

--- a/packages/firebase_auth/firebase_auth/pubspec.yaml
+++ b/packages/firebase_auth/firebase_auth/pubspec.yaml
@@ -7,7 +7,7 @@ version: 0.21.0-1.1.nullsafety.0
 
 environment:
   sdk: ">=2.12.0-0 <3.0.0"
-  flutter: ">=1.12.13+hotfix.4 <2.0.0"
+  flutter: ">=1.12.13+hotfix.4"
 
 dependencies:
   firebase_auth_platform_interface: ">=4.0.0-1.1.nullsafety.0 <4.0.0-2.0.nullsafety.0"
@@ -23,11 +23,8 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
   mockito: ^5.0.0-nullsafety.2
-  plugin_platform_interface: ^1.0.2
+  plugin_platform_interface: ^1.1.0-nullsafety.2
   test: ^1.16.0-nullsafety.15
-
-dependency_overrides:
-  http_parser: ^4.0.0-nullsafety
 
 flutter:
   plugin:

--- a/packages/firebase_auth/firebase_auth_platform_interface/pubspec.yaml
+++ b/packages/firebase_auth/firebase_auth_platform_interface/pubspec.yaml
@@ -7,14 +7,14 @@ version: 4.0.0-1.1.nullsafety.0
 
 environment:
   sdk: ">=2.12.0-0 <3.0.0"
-  flutter: ">=1.9.1+hotfix.5 <2.0.0"
+  flutter: ">=1.9.1+hotfix.5"
 
 dependencies:
   firebase_core: ">=0.8.0-1.0.nullsafety.0 <0.8.0-2.0.nullsafety.0"
   flutter:
     sdk: flutter
   meta: ^1.3.0-nullsafety.6
-  plugin_platform_interface: ^1.1.0-nullsafety.1
+  plugin_platform_interface: ^1.1.0-nullsafety.2
 
 dev_dependencies:
   firebase_core_platform_interface: ">=4.0.0-1.0.nullsafety.0 <4.0.0-2.0.nullsafety.0"

--- a/packages/firebase_auth/firebase_auth_web/pubspec.yaml
+++ b/packages/firebase_auth/firebase_auth_web/pubspec.yaml
@@ -5,7 +5,7 @@ version: 0.4.0-1.1.nullsafety.0
 
 environment:
   sdk: ">=2.12.0-0 <3.0.0"
-  flutter: ">=1.12.13+hotfix.4 <2.0.0"
+  flutter: ">=1.12.13+hotfix.4"
 
 dependencies:
   firebase_auth_platform_interface: ">=4.0.0-1.1.nullsafety.0 <4.0.0-2.0.nullsafety.0"
@@ -15,6 +15,7 @@ dependencies:
     sdk: flutter
   flutter_web_plugins:
     sdk: flutter
+  http_parser: ^4.0.0-nullsafety
   intl: ^0.17.0-nullsafety.2
   js: ^0.6.3-nullsafety.3
   meta: ^1.3.0-nullsafety.6
@@ -25,9 +26,6 @@ dev_dependencies:
   firebase_core_platform_interface: ">=4.0.0-1.0.nullsafety.0 <4.0.0-2.0.nullsafety.0"
   flutter_test:
     sdk: flutter
-
-dependency_overrides:
-  http_parser: ^4.0.0-nullsafety  
 
 flutter:
   plugin:

--- a/packages/firebase_core/firebase_core/pubspec.yaml
+++ b/packages/firebase_core/firebase_core/pubspec.yaml
@@ -6,7 +6,7 @@ version: 0.8.0-1.0.nullsafety.0
 
 environment:
   sdk: ">=2.12.0-0 <3.0.0"
-  flutter: ">=1.12.13+hotfix.5 <2.0.0"
+  flutter: ">=1.12.13+hotfix.5"
 
 dependencies:
   firebase_core_platform_interface: ">=4.0.0-1.0.nullsafety.0 <4.0.0-2.0.nullsafety.0"
@@ -21,7 +21,7 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
   mockito: ^5.0.0-nullsafety.2
-  plugin_platform_interface: ^1.1.0-nullsafety.1
+  plugin_platform_interface: ^1.1.0-nullsafety.2
 
 flutter:
   plugin:

--- a/packages/firebase_core/firebase_core_platform_interface/pubspec.yaml
+++ b/packages/firebase_core/firebase_core_platform_interface/pubspec.yaml
@@ -7,13 +7,13 @@ version: 4.0.0-1.0.nullsafety.0
 
 environment:
   sdk: '>=2.12.0-0 <3.0.0'
-  flutter: ">=1.12.13+hotfix.5 <2.0.0"
+  flutter: ">=1.12.13+hotfix.5"
 
 dependencies:
   flutter:
     sdk: flutter
   meta: ^1.3.0-nullsafety.0
-  plugin_platform_interface: ^1.1.0-nullsafety.1
+  plugin_platform_interface: ^1.1.0-nullsafety.2
 
 dev_dependencies:
   flutter_test:

--- a/packages/firebase_core/firebase_core_web/pubspec.yaml
+++ b/packages/firebase_core/firebase_core_web/pubspec.yaml
@@ -5,7 +5,7 @@ version: 0.3.0-1.0.nullsafety.0
 
 environment:
   sdk: ">=2.12.0-0 <3.0.0"
-  flutter: ">=1.12.13+hotfix.5 <2.0.0"
+  flutter: ">=1.12.13+hotfix.5"
 
 dependencies:
   firebase_core_platform_interface: ">=4.0.0-1.0.nullsafety.0 <4.0.0-2.0.nullsafety.0"

--- a/packages/firebase_crashlytics/firebase_crashlytics/example/pubspec.yaml
+++ b/packages/firebase_crashlytics/firebase_crashlytics/example/pubspec.yaml
@@ -29,10 +29,8 @@ dependency_overrides:
 
 dev_dependencies:
   drive: 0.0.1-6.0.pre
-  e2e: ^0.6.1
   flutter_driver:
     sdk: flutter
-  pedantic: ^1.10.0-nullsafety.3
   test: any
 
 flutter:

--- a/packages/firebase_crashlytics/firebase_crashlytics/pubspec.yaml
+++ b/packages/firebase_crashlytics/firebase_crashlytics/pubspec.yaml
@@ -7,7 +7,7 @@ homepage: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/f
 
 environment:
   sdk: ">=2.12.0-0 <3.0.0"
-  flutter: ">=1.12.13+hotfix.5 <2.0.0"
+  flutter: ">=1.12.13+hotfix.5"
 
 dependencies:
   firebase_core: ">=0.8.0-1.0.nullsafety.0 <0.8.0-2.0.nullsafety.0"
@@ -20,8 +20,7 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  pedantic: 1.10.0-nullsafety.3
-  test: ^1.5.1
+  test: any
 
 flutter:
   plugin:

--- a/packages/firebase_crashlytics/firebase_crashlytics_platform_interface/pubspec.yaml
+++ b/packages/firebase_crashlytics/firebase_crashlytics_platform_interface/pubspec.yaml
@@ -5,7 +5,7 @@ homepage: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/f
 
 environment:
   sdk: ">=2.12.0-0 <3.0.0"
-  flutter: ">=1.12.13+hotfix.5 <2.0.0"
+  flutter: ">=1.12.13+hotfix.5"
 
 dependencies:
   collection: ^1.15.0-nullsafety.5
@@ -13,11 +13,10 @@ dependencies:
   flutter:
     sdk: flutter
   meta: ^1.3.0-nullsafety.6
-  plugin_platform_interface: ^1.1.0-nullsafety.1
+  plugin_platform_interface: ^1.1.0-nullsafety.2
 
 dev_dependencies:
   firebase_core_platform_interface: ">=4.0.0-1.0.nullsafety.0 <4.0.0-2.0.nullsafety.0"
   flutter_test:
     sdk: flutter
   mockito: ^5.0.0-nullsafety.2
-  pedantic: ^1.10.0-nullsafety.3

--- a/packages/firebase_messaging/firebase_messaging/pubspec.yaml
+++ b/packages/firebase_messaging/firebase_messaging/pubspec.yaml
@@ -6,7 +6,7 @@ version: 9.0.0-1.0.nullsafety.0
 
 environment:
   sdk: '>=2.12.0-0 <3.0.0'
-  flutter: ">=1.12.13+hotfix.5 <2.0.0"
+  flutter: ">=1.12.13+hotfix.5"
 
 dependencies:
   firebase_core: ">=0.8.0-1.0.nullsafety.0 <0.8.0-2.0.nullsafety.0"
@@ -24,7 +24,7 @@ dev_dependencies:
   flutter_test:
     sdk: flutter
   mockito: ^5.0.0-nullsafety.2
-  plugin_platform_interface: ^1.1.0-nullsafety.1
+  plugin_platform_interface: ^1.1.0-nullsafety.2
   test: any
 
 flutter:

--- a/packages/firebase_messaging/firebase_messaging_platform_interface/pubspec.yaml
+++ b/packages/firebase_messaging/firebase_messaging_platform_interface/pubspec.yaml
@@ -5,14 +5,14 @@ homepage: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/f
 
 environment:
   sdk: '>=2.12.0-0 <3.0.0'
-  flutter: ">=1.9.1+hotfix.5 <2.0.0"
+  flutter: ">=1.9.1+hotfix.5"
 
 dependencies:
   firebase_core: ">=0.8.0-1.0.nullsafety.0 <0.8.0-2.0.nullsafety.0"
   flutter:
     sdk: flutter
   meta: ^1.3.0-nullsafety.6
-  plugin_platform_interface: ^1.1.0-nullsafety.1
+  plugin_platform_interface: ^1.1.0-nullsafety.2
 
 dev_dependencies:
   firebase_core_platform_interface: ">=4.0.0-1.0.nullsafety.0 <4.0.0-2.0.nullsafety.0"

--- a/packages/firebase_messaging/firebase_messaging_web/pubspec.yaml
+++ b/packages/firebase_messaging/firebase_messaging_web/pubspec.yaml
@@ -5,7 +5,7 @@ version: 0.2.0-1.0.nullsafety.0
 
 environment:
   sdk: '>=2.12.0-0 <3.0.0'
-  flutter: ">=1.12.13+hotfix.4 <2.0.0"
+  flutter: ">=1.12.13+hotfix.4"
 
 dependencies:
   firebase_core: ">=0.8.0-1.0.nullsafety.0 <0.8.0-2.0.nullsafety.0"


### PR DESCRIPTION
## Description

This change addresses the following:

 - Removal of upper bound flutter sdk constraint on packages, see https://dart.dev/go/flutter-upper-bound-deprecation
 - Removal of unused dependencies, e.g. pedantic & e2e.
 - Remove of no longer required dependency overrides, e.g. http & http_parser - as these are now have nullsafety releases and are used on latest flutter dev channel.
 - Update several dependencies such as `plugin_platform_interface` to their latest nullsafety version.


## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
