### PR TITLE
fix: Bump mockito to breaking change with fixes

### DIFF
--- a/packages/cloud_firestore/cloud_firestore_platform_interface/pubspec.yaml
+++ b/packages/cloud_firestore/cloud_firestore_platform_interface/pubspec.yaml
@@ -20,4 +20,4 @@ dev_dependencies:
   firebase_core_platform_interface: ">=4.0.0-1.0.nullsafety.1 <4.0.0-2.0.nullsafety.0"
   flutter_test:
     sdk: flutter
-  mockito: ^5.0.0-nullsafety.2
+  mockito: ^5.0.0-nullsafety.6

--- a/packages/cloud_firestore/cloud_firestore_platform_interface/test/method_channel_tests/method_channel_transaction_test.dart
+++ b/packages/cloud_firestore/cloud_firestore_platform_interface/test/method_channel_tests/method_channel_transaction_test.dart
@@ -15,9 +15,11 @@ import '../utils/test_common.dart';
 //ignore: avoid_implementing_value_types
 class MockDocumentReference extends Mock implements DocumentReferencePlatform {
   @override
-  String get path => super.noSuchMethod(Invocation.getter(#path), 'foo/bar');
+  String get path =>
+      super.noSuchMethod(Invocation.getter(#path), returnValue: 'foo/bar');
   @override
-  String get id => super.noSuchMethod(Invocation.getter(#id), 'mock-id');
+  String get id =>
+      super.noSuchMethod(Invocation.getter(#id), returnValue: 'mock-id');
 }
 
 const _kTransactionId = '1022';

--- a/packages/firebase_auth/firebase_auth/pubspec.yaml
+++ b/packages/firebase_auth/firebase_auth/pubspec.yaml
@@ -22,7 +22,7 @@ dev_dependencies:
   async: ^2.5.0-nullsafety.3
   flutter_test:
     sdk: flutter
-  mockito: ^5.0.0-nullsafety.2
+  mockito: ^5.0.0-nullsafety.6
   plugin_platform_interface: ^1.1.0-nullsafety.2
   test: ^1.16.0-nullsafety.15
 

--- a/packages/firebase_auth/firebase_auth/test/firebase_auth_test.dart
+++ b/packages/firebase_auth/firebase_auth/test/firebase_auth_test.dart
@@ -651,7 +651,7 @@ class MockFirebaseAuth extends Mock
   Stream<UserPlatform?> userChanges() {
     return super.noSuchMethod(
       Invocation.method(#userChanges, []),
-      const Stream<UserPlatform?>.empty(),
+      returnValue: const Stream<UserPlatform?>.empty(),
     );
   }
 
@@ -659,7 +659,7 @@ class MockFirebaseAuth extends Mock
   Stream<UserPlatform?> idTokenChanges() {
     return super.noSuchMethod(
       Invocation.method(#idTokenChanges, []),
-      const Stream<UserPlatform?>.empty(),
+      returnValue: const Stream<UserPlatform?>.empty(),
     );
   }
 
@@ -667,7 +667,7 @@ class MockFirebaseAuth extends Mock
   Stream<UserPlatform?> authStateChanges() {
     return super.noSuchMethod(
       Invocation.method(#authStateChanges, []),
-      const Stream<UserPlatform?>.empty(),
+      returnValue: const Stream<UserPlatform?>.empty(),
     );
   }
 
@@ -675,7 +675,7 @@ class MockFirebaseAuth extends Mock
   FirebaseAuthPlatform delegateFor({FirebaseApp? app}) {
     return super.noSuchMethod(
       Invocation.method(#delegateFor, [], {#app: app}),
-      TestFirebaseAuthPlatform(),
+      returnValue: TestFirebaseAuthPlatform(),
     );
   }
 
@@ -686,7 +686,7 @@ class MockFirebaseAuth extends Mock
   ) {
     return super.noSuchMethod(
       Invocation.method(#createUserWithEmailAndPassword, [email, password]),
-      neverEndingFuture<UserCredentialPlatform>(),
+      returnValue: neverEndingFuture<UserCredentialPlatform>(),
     );
   }
 
@@ -700,7 +700,7 @@ class MockFirebaseAuth extends Mock
         #signInWithPhoneNumber,
         [phoneNumber, applicationVerifier],
       ),
-      neverEndingFuture<ConfirmationResultPlatform>(),
+      returnValue: neverEndingFuture<ConfirmationResultPlatform>(),
     );
   }
 
@@ -710,7 +710,7 @@ class MockFirebaseAuth extends Mock
   ) {
     return super.noSuchMethod(
       Invocation.method(#signInWithCredential, [credential]),
-      neverEndingFuture<UserCredentialPlatform>(),
+      returnValue: neverEndingFuture<UserCredentialPlatform>(),
     );
   }
 
@@ -718,7 +718,7 @@ class MockFirebaseAuth extends Mock
   Future<UserCredentialPlatform> signInWithCustomToken(String? token) {
     return super.noSuchMethod(
       Invocation.method(#signInWithCustomToken, [token]),
-      neverEndingFuture<UserCredentialPlatform>(),
+      returnValue: neverEndingFuture<UserCredentialPlatform>(),
     );
   }
 
@@ -729,7 +729,7 @@ class MockFirebaseAuth extends Mock
   ) {
     return super.noSuchMethod(
       Invocation.method(#signInWithEmailAndPassword, [email, password]),
-      neverEndingFuture<UserCredentialPlatform>(),
+      returnValue: neverEndingFuture<UserCredentialPlatform>(),
     );
   }
 
@@ -737,7 +737,7 @@ class MockFirebaseAuth extends Mock
   Future<UserCredentialPlatform> signInWithPopup(AuthProvider? provider) {
     return super.noSuchMethod(
       Invocation.method(#signInWithPopup, [provider]),
-      neverEndingFuture<UserCredentialPlatform>(),
+      returnValue: neverEndingFuture<UserCredentialPlatform>(),
     );
   }
 
@@ -748,7 +748,7 @@ class MockFirebaseAuth extends Mock
   ) {
     return super.noSuchMethod(
       Invocation.method(#signInWithEmailLink, [email, emailLink]),
-      neverEndingFuture<UserCredentialPlatform>(),
+      returnValue: neverEndingFuture<UserCredentialPlatform>(),
     );
   }
 
@@ -756,7 +756,7 @@ class MockFirebaseAuth extends Mock
   Future<void> signInWithRedirect(AuthProvider? provider) {
     return super.noSuchMethod(
       Invocation.method(#signInWithRedirect, [provider]),
-      neverEndingFuture<void>(),
+      returnValue: neverEndingFuture<void>(),
     );
   }
 
@@ -764,7 +764,7 @@ class MockFirebaseAuth extends Mock
   Future<UserCredentialPlatform> signInAnonymously() {
     return super.noSuchMethod(
       Invocation.method(#signInAnonymously, []),
-      neverEndingFuture<UserCredentialPlatform>(),
+      returnValue: neverEndingFuture<UserCredentialPlatform>(),
     );
   }
 
@@ -778,7 +778,7 @@ class MockFirebaseAuth extends Mock
         #currentUser: currentUser,
         #languageCode: languageCode,
       }),
-      TestFirebaseAuthPlatform(),
+      returnValue: TestFirebaseAuthPlatform(),
     );
   }
 
@@ -786,7 +786,7 @@ class MockFirebaseAuth extends Mock
   Future<UserCredentialPlatform> getRedirectResult() {
     return super.noSuchMethod(
       Invocation.method(#getRedirectResult, []),
-      neverEndingFuture<UserCredentialPlatform>(),
+      returnValue: neverEndingFuture<UserCredentialPlatform>(),
     );
   }
 
@@ -794,7 +794,7 @@ class MockFirebaseAuth extends Mock
   Future<void> setLanguageCode(String? languageCode) {
     return super.noSuchMethod(
       Invocation.method(#setLanguageCode, [languageCode]),
-      neverEndingFuture<void>(),
+      returnValue: neverEndingFuture<void>(),
     );
   }
 
@@ -802,7 +802,7 @@ class MockFirebaseAuth extends Mock
   Future<void> useEmulator(String host, int port) {
     return super.noSuchMethod(
       Invocation.method(#useEmulator, [host, port]),
-      neverEndingFuture<void>(),
+      returnValue: neverEndingFuture<void>(),
     );
   }
 
@@ -810,7 +810,7 @@ class MockFirebaseAuth extends Mock
   Future<ActionCodeInfo> checkActionCode(String? code) {
     return super.noSuchMethod(
       Invocation.method(#checkActionCode, [code]),
-      neverEndingFuture<ActionCodeInfo>(),
+      returnValue: neverEndingFuture<ActionCodeInfo>(),
     );
   }
 
@@ -818,7 +818,7 @@ class MockFirebaseAuth extends Mock
   Future<void> confirmPasswordReset(String? code, String? newPassword) {
     return super.noSuchMethod(
       Invocation.method(#confirmPasswordReset, [code, newPassword]),
-      neverEndingFuture<void>(),
+      returnValue: neverEndingFuture<void>(),
     );
   }
 
@@ -826,7 +826,7 @@ class MockFirebaseAuth extends Mock
   Future<List<String>> fetchSignInMethodsForEmail(String? email) {
     return super.noSuchMethod(
       Invocation.method(#checkActionCode, [email]),
-      neverEndingFuture<List<String>>(),
+      returnValue: neverEndingFuture<List<String>>(),
     );
   }
 
@@ -834,7 +834,7 @@ class MockFirebaseAuth extends Mock
   bool isSignInWithEmailLink(String? emailLink) {
     return super.noSuchMethod(
       Invocation.method(#isSignInWithEmailLink, [emailLink]),
-      false,
+      returnValue: false,
     );
   }
 
@@ -845,7 +845,7 @@ class MockFirebaseAuth extends Mock
   ]) {
     return super.noSuchMethod(
       Invocation.method(#sendPasswordResetEmail, [email, actionCodeSettings]),
-      neverEndingFuture<void>(),
+      returnValue: neverEndingFuture<void>(),
     );
   }
 
@@ -856,7 +856,7 @@ class MockFirebaseAuth extends Mock
   ) {
     return super.noSuchMethod(
       Invocation.method(#sendSignInLinkToEmail, [email, actionCodeSettings]),
-      neverEndingFuture<void>(),
+      returnValue: neverEndingFuture<void>(),
     );
   }
 
@@ -870,7 +870,7 @@ class MockFirebaseAuth extends Mock
         appVerificationDisabledForTesting,
         userAccessGroup,
       ]),
-      neverEndingFuture<void>(),
+      returnValue: neverEndingFuture<void>(),
     );
   }
 
@@ -878,7 +878,7 @@ class MockFirebaseAuth extends Mock
   Future<void> setPersistence(Persistence? persistence) {
     return super.noSuchMethod(
       Invocation.method(#setPersistence, [persistence]),
-      neverEndingFuture<void>(),
+      returnValue: neverEndingFuture<void>(),
     );
   }
 
@@ -886,7 +886,7 @@ class MockFirebaseAuth extends Mock
   Future<void> signOut() {
     return super.noSuchMethod(
       Invocation.method(#signOut, [signOut]),
-      neverEndingFuture<void>(),
+      returnValue: neverEndingFuture<void>(),
     );
   }
 
@@ -894,7 +894,7 @@ class MockFirebaseAuth extends Mock
   Future<String> verifyPasswordResetCode(String? code) {
     return super.noSuchMethod(
       Invocation.method(#verifyPasswordResetCode, [code]),
-      neverEndingFuture<String>(),
+      returnValue: neverEndingFuture<String>(),
     );
   }
 
@@ -920,7 +920,7 @@ class MockFirebaseAuth extends Mock
         #forceResendingToken: forceResendingToken,
         #autoRetrievedSmsCodeForTesting: autoRetrievedSmsCodeForTesting,
       }),
-      neverEndingFuture<String>(),
+      returnValue: neverEndingFuture<String>(),
     );
   }
 }
@@ -1000,7 +1000,7 @@ class MockRecaptchaVerifier extends Mock
   RecaptchaVerifierFactoryPlatform get delegate {
     return super.noSuchMethod(
       Invocation.getter(#delegate),
-      MockRecaptchaVerifierFactoryPlatform(),
+      returnValue: MockRecaptchaVerifierFactoryPlatform(),
     );
   }
 }

--- a/packages/firebase_auth/firebase_auth/test/user_test.dart
+++ b/packages/firebase_auth/firebase_auth/test/user_test.dart
@@ -363,7 +363,7 @@ class MockFirebaseAuth extends Mock
   Future<UserCredentialPlatform> signInAnonymously() {
     return super.noSuchMethod(
       Invocation.method(#signInAnonymously, const []),
-      neverEndingFuture<UserCredentialPlatform>(),
+      returnValue: neverEndingFuture<UserCredentialPlatform>(),
     );
   }
 
@@ -371,7 +371,7 @@ class MockFirebaseAuth extends Mock
   FirebaseAuthPlatform delegateFor({FirebaseApp? app}) {
     return super.noSuchMethod(
       Invocation.method(#delegateFor, const [], {#app: app}),
-      TestFirebaseAuthPlatform(),
+      returnValue: TestFirebaseAuthPlatform(),
     );
   }
 
@@ -385,7 +385,7 @@ class MockFirebaseAuth extends Mock
         #currentUser: currentUser,
         #languageCode: languageCode,
       }),
-      TestFirebaseAuthPlatform(),
+      returnValue: TestFirebaseAuthPlatform(),
     );
   }
 }
@@ -401,7 +401,7 @@ class MockUserPlatform extends Mock
   Future<void> delete() {
     return super.noSuchMethod(
       Invocation.method(#delete, []),
-      neverEndingFuture<void>(),
+      returnValue: neverEndingFuture<void>(),
     );
   }
 
@@ -409,7 +409,7 @@ class MockUserPlatform extends Mock
   Future<void> reload() {
     return super.noSuchMethod(
       Invocation.method(#reload, []),
-      neverEndingFuture<void>(),
+      returnValue: neverEndingFuture<void>(),
     );
   }
 
@@ -417,7 +417,7 @@ class MockUserPlatform extends Mock
   Future<String> getIdToken(bool? forceRefresh) {
     return super.noSuchMethod(
       Invocation.method(#getIdToken, [forceRefresh]),
-      neverEndingFuture<String>(),
+      returnValue: neverEndingFuture<String>(),
     );
   }
 
@@ -425,7 +425,7 @@ class MockUserPlatform extends Mock
   Future<UserPlatform> unlink(String? providerId) {
     return super.noSuchMethod(
       Invocation.method(#unlink, [providerId]),
-      neverEndingFuture<UserPlatform>(),
+      returnValue: neverEndingFuture<UserPlatform>(),
     );
   }
 
@@ -433,7 +433,7 @@ class MockUserPlatform extends Mock
   Future<IdTokenResult> getIdTokenResult(bool? forceRefresh) {
     return super.noSuchMethod(
       Invocation.method(#getIdTokenResult, [forceRefresh]),
-      neverEndingFuture<IdTokenResult>(),
+      returnValue: neverEndingFuture<IdTokenResult>(),
     );
   }
 
@@ -443,7 +443,7 @@ class MockUserPlatform extends Mock
   ) {
     return super.noSuchMethod(
       Invocation.method(#reauthenticateWithCredential, [credential]),
-      neverEndingFuture<UserCredentialPlatform>(),
+      returnValue: neverEndingFuture<UserCredentialPlatform>(),
     );
   }
 
@@ -453,7 +453,7 @@ class MockUserPlatform extends Mock
   ) {
     return super.noSuchMethod(
       Invocation.method(#linkWithCredential, [credential]),
-      neverEndingFuture<UserCredentialPlatform>(),
+      returnValue: neverEndingFuture<UserCredentialPlatform>(),
     );
   }
 
@@ -461,7 +461,7 @@ class MockUserPlatform extends Mock
   Future<void> sendEmailVerification(ActionCodeSettings? actionCodeSettings) {
     return super.noSuchMethod(
       Invocation.method(#sendEmailVerification, [actionCodeSettings]),
-      neverEndingFuture<void>(),
+      returnValue: neverEndingFuture<void>(),
     );
   }
 
@@ -469,7 +469,7 @@ class MockUserPlatform extends Mock
   Future<void> updateEmail(String? newEmail) {
     return super.noSuchMethod(
       Invocation.method(#updateEmail, [newEmail]),
-      neverEndingFuture<void>(),
+      returnValue: neverEndingFuture<void>(),
     );
   }
 
@@ -477,7 +477,7 @@ class MockUserPlatform extends Mock
   Future<void> updatePassword(String? newPassword) {
     return super.noSuchMethod(
       Invocation.method(#updatePassword, [newPassword]),
-      neverEndingFuture<void>(),
+      returnValue: neverEndingFuture<void>(),
     );
   }
 
@@ -485,7 +485,7 @@ class MockUserPlatform extends Mock
   Future<void> updatePhoneNumber(PhoneAuthCredential? phoneCredential) {
     return super.noSuchMethod(
       Invocation.method(#updatePhoneNumber, [phoneCredential]),
-      neverEndingFuture<void>(),
+      returnValue: neverEndingFuture<void>(),
     );
   }
 
@@ -493,7 +493,7 @@ class MockUserPlatform extends Mock
   Future<void> updateProfile(Map<String, String?>? profile) {
     return super.noSuchMethod(
       Invocation.method(#updateProfile, [profile]),
-      neverEndingFuture<void>(),
+      returnValue: neverEndingFuture<void>(),
     );
   }
 
@@ -507,7 +507,7 @@ class MockUserPlatform extends Mock
         newEmail,
         actionCodeSettings,
       ]),
-      neverEndingFuture<void>(),
+      returnValue: neverEndingFuture<void>(),
     );
   }
 }

--- a/packages/firebase_core/firebase_core/pubspec.yaml
+++ b/packages/firebase_core/firebase_core/pubspec.yaml
@@ -20,7 +20,7 @@ dev_dependencies:
     sdk: flutter
   flutter_test:
     sdk: flutter
-  mockito: ^5.0.0-nullsafety.2
+  mockito: ^5.0.0-nullsafety.6
   plugin_platform_interface: ^1.1.0-nullsafety.2
 
 flutter:

--- a/packages/firebase_core/firebase_core/test/firebase_core_test.dart
+++ b/packages/firebase_core/firebase_core/test/firebase_core_test.dart
@@ -76,7 +76,7 @@ class MockFirebaseCore extends Mock
   FirebaseAppPlatform app([String name = defaultFirebaseAppName]) {
     return super.noSuchMethod(
       Invocation.method(#app, [name]),
-      FakeFirebaseAppPlatform(),
+      returnValue: FakeFirebaseAppPlatform(),
     );
   }
 
@@ -94,7 +94,7 @@ class MockFirebaseCore extends Mock
           #options: options,
         },
       ),
-      Future.value(FakeFirebaseAppPlatform()),
+      returnValue: Future.value(FakeFirebaseAppPlatform()),
     );
   }
 
@@ -102,7 +102,7 @@ class MockFirebaseCore extends Mock
   List<FirebaseAppPlatform> get apps {
     return super.noSuchMethod(
       Invocation.getter(#apps),
-      <FirebaseAppPlatform>[],
+      returnValue: <FirebaseAppPlatform>[],
     );
   }
 }

--- a/packages/firebase_messaging/firebase_messaging/pubspec.yaml
+++ b/packages/firebase_messaging/firebase_messaging/pubspec.yaml
@@ -23,7 +23,7 @@ dev_dependencies:
     sdk: flutter
   flutter_test:
     sdk: flutter
-  mockito: ^5.0.0-nullsafety.2
+    mockito: ^5.0.0-nullsafety.6
   plugin_platform_interface: ^1.1.0-nullsafety.2
   test: any
 

--- a/packages/firebase_messaging/firebase_messaging/test/mock.dart
+++ b/packages/firebase_messaging/firebase_messaging/test/mock.dart
@@ -75,14 +75,15 @@ class MockFirebaseMessaging extends Mock
 
   @override
   bool get isAutoInitEnabled {
-    return super.noSuchMethod(Invocation.getter(#isAutoInitEnabled), true);
+    return super
+        .noSuchMethod(Invocation.getter(#isAutoInitEnabled), returnValue: true);
   }
 
   @override
   FirebaseMessagingPlatform delegateFor({FirebaseApp? app}) {
     return super.noSuchMethod(
       Invocation.method(#delegateFor, [], {#app: app}),
-      TestFirebaseMessagingPlatform(),
+      returnValue: TestFirebaseMessagingPlatform(),
     );
   }
 
@@ -91,48 +92,56 @@ class MockFirebaseMessaging extends Mock
     return super.noSuchMethod(
       Invocation.method(
           #setInitialValues, [], {#isAutoInitEnabled: isAutoInitEnabled}),
-      TestFirebaseMessagingPlatform(),
+      returnValue: TestFirebaseMessagingPlatform(),
     );
   }
 
   @override
   Future<RemoteMessage?> getInitialMessage() {
-    return super.noSuchMethod(Invocation.method(#getInitialMessage, []),
-        neverEndingFuture<RemoteMessage>());
+    return super.noSuchMethod(
+      Invocation.method(#getInitialMessage, []),
+      returnValue: neverEndingFuture<RemoteMessage>(),
+    );
   }
 
   @override
   Future<void> deleteToken({String? senderId}) {
     return super.noSuchMethod(
-        Invocation.method(#deleteToken, [], {#senderId: senderId}),
-        Future<void>.value());
+      Invocation.method(#deleteToken, [], {#senderId: senderId}),
+      returnValue: Future<void>.value(),
+    );
   }
 
   @override
   Future<String?> getAPNSToken() {
     return super.noSuchMethod(
-        Invocation.method(#getAPNSToken, []), Future<String>.value(''));
+      Invocation.method(#getAPNSToken, []),
+      returnValue: Future<String>.value(''),
+    );
   }
 
   @override
   Future<String> getToken({String? senderId, String? vapidKey}) {
     return super.noSuchMethod(
-        Invocation.method(
-            #getToken, [], {#senderId: senderId, #vapidKey: vapidKey}),
-        Future<String>.value(''));
+      Invocation.method(
+          #getToken, [], {#senderId: senderId, #vapidKey: vapidKey}),
+      returnValue: Future<String>.value(''),
+    );
   }
 
   @override
   Future<void> setAutoInitEnabled(bool? enabled) {
-    return super.noSuchMethod(Invocation.method(#setAutoInitEnabled, [enabled]),
-        Future<void>.value());
+    return super.noSuchMethod(
+      Invocation.method(#setAutoInitEnabled, [enabled]),
+      returnValue: Future<void>.value(),
+    );
   }
 
   @override
   Stream<String> get onTokenRefresh {
     return super.noSuchMethod(
       Invocation.getter(#onTokenRefresh),
-      const Stream<String>.empty(),
+      returnValue: const Stream<String>.empty(),
     );
   }
 
@@ -146,28 +155,33 @@ class MockFirebaseMessaging extends Mock
       bool? provisional = false,
       bool? sound = true}) {
     return super.noSuchMethod(
-        Invocation.method(#requestPermission, [], {
-          #alert: alert,
-          #announcement: announcement,
-          #badge: badge,
-          #carPlay: carPlay,
-          #criticalAlert: criticalAlert,
-          #provisional: provisional,
-          #sound: sound
-        }),
-        neverEndingFuture<NotificationSettings>());
+      Invocation.method(#requestPermission, [], {
+        #alert: alert,
+        #announcement: announcement,
+        #badge: badge,
+        #carPlay: carPlay,
+        #criticalAlert: criticalAlert,
+        #provisional: provisional,
+        #sound: sound
+      }),
+      returnValue: neverEndingFuture<NotificationSettings>(),
+    );
   }
 
   @override
   Future<void> subscribeToTopic(String? topic) {
     return super.noSuchMethod(
-        Invocation.method(#subscribeToTopic, [topic]), Future<void>.value());
+      Invocation.method(#subscribeToTopic, [topic]),
+      returnValue: Future<void>.value(),
+    );
   }
 
   @override
   Future<void> unsubscribeFromTopic(String? topic) {
-    return super.noSuchMethod(Invocation.method(#unsubscribeFromTopic, [topic]),
-        Future<void>.value());
+    return super.noSuchMethod(
+      Invocation.method(#unsubscribeFromTopic, [topic]),
+      returnValue: Future<void>.value(),
+    );
   }
 }
 


### PR DESCRIPTION
## Description

mockito 5.0.0-nullsafety.6 includes [a breaking change](https://pub.dev/packages/mockito/versions/5.0.0-nullsafety.6/changelog) to the signature of Mock.noSuchMethod. This PR bump mockito and changes firebase_auth and firebase_core tests to match the new signature.

## Related Issues

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
