### PR TITLE
tests: mockito dependency updates due to breaking API changes

### DIFF
--- a/packages/cloud_firestore/cloud_firestore_platform_interface/test/method_channel_tests/method_channel_transaction_test.dart
+++ b/packages/cloud_firestore/cloud_firestore_platform_interface/test/method_channel_tests/method_channel_transaction_test.dart
@@ -12,12 +12,15 @@ import 'package:cloud_firestore_platform_interface/src/method_channel/method_cha
 
 import '../utils/test_common.dart';
 
+const String mockId = 'mock-id';
+const String mockPath = 'foo/bar';
+
 //ignore: avoid_implementing_value_types
 class MockDocumentReference extends Mock implements DocumentReferencePlatform {
   @override
-  String get path => super.noSuchMethod(Invocation.getter(#path), 'foo/bar');
+  String get path => super.noSuchMethod(Invocation.getter(#path), returnValue: mockPath, returnValueForMissingStub: mockPath);
   @override
-  String get id => super.noSuchMethod(Invocation.getter(#id), 'mock-id');
+  String get id => super.noSuchMethod(Invocation.getter(#id), returnValue:mockId, returnValueForMissingStub: mockId);
 }
 
 const _kTransactionId = '1022';

--- a/packages/cloud_firestore/cloud_firestore_platform_interface/test/method_channel_tests/method_channel_transaction_test.dart
+++ b/packages/cloud_firestore/cloud_firestore_platform_interface/test/method_channel_tests/method_channel_transaction_test.dart
@@ -18,9 +18,11 @@ const String mockPath = 'foo/bar';
 //ignore: avoid_implementing_value_types
 class MockDocumentReference extends Mock implements DocumentReferencePlatform {
   @override
-  String get path => super.noSuchMethod(Invocation.getter(#path), returnValue: mockPath, returnValueForMissingStub: mockPath);
+  String get path => super.noSuchMethod(Invocation.getter(#path),
+      returnValue: mockPath, returnValueForMissingStub: mockPath);
   @override
-  String get id => super.noSuchMethod(Invocation.getter(#id), returnValue:mockId, returnValueForMissingStub: mockId);
+  String get id => super.noSuchMethod(Invocation.getter(#id),
+      returnValue: mockId, returnValueForMissingStub: mockId);
 }
 
 const _kTransactionId = '1022';

--- a/packages/firebase_auth/firebase_auth/test/firebase_auth_test.dart
+++ b/packages/firebase_auth/firebase_auth/test/firebase_auth_test.dart
@@ -651,7 +651,8 @@ class MockFirebaseAuth extends Mock
   Stream<UserPlatform?> userChanges() {
     return super.noSuchMethod(
       Invocation.method(#userChanges, []),
-      const Stream<UserPlatform?>.empty(),
+      returnValue: const Stream<UserPlatform?>.empty(),
+      returnValueForMissingStub: const Stream<UserPlatform?>.empty(),
     );
   }
 
@@ -659,7 +660,8 @@ class MockFirebaseAuth extends Mock
   Stream<UserPlatform?> idTokenChanges() {
     return super.noSuchMethod(
       Invocation.method(#idTokenChanges, []),
-      const Stream<UserPlatform?>.empty(),
+      returnValue: const Stream<UserPlatform?>.empty(),
+      returnValueForMissingStub: const Stream<UserPlatform?>.empty(),
     );
   }
 
@@ -667,7 +669,8 @@ class MockFirebaseAuth extends Mock
   Stream<UserPlatform?> authStateChanges() {
     return super.noSuchMethod(
       Invocation.method(#authStateChanges, []),
-      const Stream<UserPlatform?>.empty(),
+      returnValue: const Stream<UserPlatform?>.empty(),
+      returnValueForMissingStub: const Stream<UserPlatform?>.empty(),
     );
   }
 
@@ -675,7 +678,8 @@ class MockFirebaseAuth extends Mock
   FirebaseAuthPlatform delegateFor({FirebaseApp? app}) {
     return super.noSuchMethod(
       Invocation.method(#delegateFor, [], {#app: app}),
-      TestFirebaseAuthPlatform(),
+      returnValue: TestFirebaseAuthPlatform(),
+      returnValueForMissingStub: TestFirebaseAuthPlatform(),
     );
   }
 
@@ -686,7 +690,8 @@ class MockFirebaseAuth extends Mock
   ) {
     return super.noSuchMethod(
       Invocation.method(#createUserWithEmailAndPassword, [email, password]),
-      neverEndingFuture<UserCredentialPlatform>(),
+      returnValue: neverEndingFuture<UserCredentialPlatform>(),
+      returnValueForMissingStub: neverEndingFuture<UserCredentialPlatform>(),
     );
   }
 
@@ -700,7 +705,9 @@ class MockFirebaseAuth extends Mock
         #signInWithPhoneNumber,
         [phoneNumber, applicationVerifier],
       ),
-      neverEndingFuture<ConfirmationResultPlatform>(),
+      returnValue: neverEndingFuture<ConfirmationResultPlatform>(),
+      returnValueForMissingStub:
+          neverEndingFuture<ConfirmationResultPlatform>(),
     );
   }
 
@@ -710,7 +717,8 @@ class MockFirebaseAuth extends Mock
   ) {
     return super.noSuchMethod(
       Invocation.method(#signInWithCredential, [credential]),
-      neverEndingFuture<UserCredentialPlatform>(),
+      returnValue: neverEndingFuture<UserCredentialPlatform>(),
+      returnValueForMissingStub: neverEndingFuture<UserCredentialPlatform>(),
     );
   }
 
@@ -718,7 +726,8 @@ class MockFirebaseAuth extends Mock
   Future<UserCredentialPlatform> signInWithCustomToken(String? token) {
     return super.noSuchMethod(
       Invocation.method(#signInWithCustomToken, [token]),
-      neverEndingFuture<UserCredentialPlatform>(),
+      returnValue: neverEndingFuture<UserCredentialPlatform>(),
+      returnValueForMissingStub: neverEndingFuture<UserCredentialPlatform>(),
     );
   }
 
@@ -729,7 +738,8 @@ class MockFirebaseAuth extends Mock
   ) {
     return super.noSuchMethod(
       Invocation.method(#signInWithEmailAndPassword, [email, password]),
-      neverEndingFuture<UserCredentialPlatform>(),
+      returnValue: neverEndingFuture<UserCredentialPlatform>(),
+      returnValueForMissingStub: neverEndingFuture<UserCredentialPlatform>(),
     );
   }
 
@@ -737,7 +747,8 @@ class MockFirebaseAuth extends Mock
   Future<UserCredentialPlatform> signInWithPopup(AuthProvider? provider) {
     return super.noSuchMethod(
       Invocation.method(#signInWithPopup, [provider]),
-      neverEndingFuture<UserCredentialPlatform>(),
+      returnValue: neverEndingFuture<UserCredentialPlatform>(),
+      returnValueForMissingStub: neverEndingFuture<UserCredentialPlatform>(),
     );
   }
 
@@ -748,7 +759,8 @@ class MockFirebaseAuth extends Mock
   ) {
     return super.noSuchMethod(
       Invocation.method(#signInWithEmailLink, [email, emailLink]),
-      neverEndingFuture<UserCredentialPlatform>(),
+      returnValue: neverEndingFuture<UserCredentialPlatform>(),
+      returnValueForMissingStub: neverEndingFuture<UserCredentialPlatform>(),
     );
   }
 
@@ -756,7 +768,8 @@ class MockFirebaseAuth extends Mock
   Future<void> signInWithRedirect(AuthProvider? provider) {
     return super.noSuchMethod(
       Invocation.method(#signInWithRedirect, [provider]),
-      neverEndingFuture<void>(),
+      returnValue: neverEndingFuture<void>(),
+      returnValueForMissingStub: neverEndingFuture<void>(),
     );
   }
 
@@ -764,7 +777,8 @@ class MockFirebaseAuth extends Mock
   Future<UserCredentialPlatform> signInAnonymously() {
     return super.noSuchMethod(
       Invocation.method(#signInAnonymously, []),
-      neverEndingFuture<UserCredentialPlatform>(),
+      returnValue: neverEndingFuture<UserCredentialPlatform>(),
+      returnValueForMissingStub: neverEndingFuture<UserCredentialPlatform>(),
     );
   }
 
@@ -778,7 +792,8 @@ class MockFirebaseAuth extends Mock
         #currentUser: currentUser,
         #languageCode: languageCode,
       }),
-      TestFirebaseAuthPlatform(),
+      returnValue: TestFirebaseAuthPlatform(),
+      returnValueForMissingStub: TestFirebaseAuthPlatform(),
     );
   }
 
@@ -786,7 +801,8 @@ class MockFirebaseAuth extends Mock
   Future<UserCredentialPlatform> getRedirectResult() {
     return super.noSuchMethod(
       Invocation.method(#getRedirectResult, []),
-      neverEndingFuture<UserCredentialPlatform>(),
+      returnValue: neverEndingFuture<UserCredentialPlatform>(),
+      returnValueForMissingStub: neverEndingFuture<UserCredentialPlatform>(),
     );
   }
 
@@ -794,7 +810,8 @@ class MockFirebaseAuth extends Mock
   Future<void> setLanguageCode(String? languageCode) {
     return super.noSuchMethod(
       Invocation.method(#setLanguageCode, [languageCode]),
-      neverEndingFuture<void>(),
+      returnValue: neverEndingFuture<void>(),
+      returnValueForMissingStub: neverEndingFuture<void>(),
     );
   }
 
@@ -802,7 +819,8 @@ class MockFirebaseAuth extends Mock
   Future<void> useEmulator(String host, int port) {
     return super.noSuchMethod(
       Invocation.method(#useEmulator, [host, port]),
-      neverEndingFuture<void>(),
+      returnValue: neverEndingFuture<void>(),
+      returnValueForMissingStub: neverEndingFuture<void>(),
     );
   }
 
@@ -810,7 +828,8 @@ class MockFirebaseAuth extends Mock
   Future<ActionCodeInfo> checkActionCode(String? code) {
     return super.noSuchMethod(
       Invocation.method(#checkActionCode, [code]),
-      neverEndingFuture<ActionCodeInfo>(),
+      returnValue: neverEndingFuture<ActionCodeInfo>(),
+      returnValueForMissingStub: neverEndingFuture<ActionCodeInfo>(),
     );
   }
 
@@ -818,7 +837,8 @@ class MockFirebaseAuth extends Mock
   Future<void> confirmPasswordReset(String? code, String? newPassword) {
     return super.noSuchMethod(
       Invocation.method(#confirmPasswordReset, [code, newPassword]),
-      neverEndingFuture<void>(),
+      returnValue: neverEndingFuture<void>(),
+      returnValueForMissingStub: neverEndingFuture<void>(),
     );
   }
 
@@ -826,7 +846,8 @@ class MockFirebaseAuth extends Mock
   Future<List<String>> fetchSignInMethodsForEmail(String? email) {
     return super.noSuchMethod(
       Invocation.method(#checkActionCode, [email]),
-      neverEndingFuture<List<String>>(),
+      returnValue: neverEndingFuture<List<String>>(),
+      returnValueForMissingStub: neverEndingFuture<List<String>>(),
     );
   }
 
@@ -834,7 +855,8 @@ class MockFirebaseAuth extends Mock
   bool isSignInWithEmailLink(String? emailLink) {
     return super.noSuchMethod(
       Invocation.method(#isSignInWithEmailLink, [emailLink]),
-      false,
+      returnValue: false,
+      returnValueForMissingStub: false,
     );
   }
 
@@ -845,7 +867,8 @@ class MockFirebaseAuth extends Mock
   ]) {
     return super.noSuchMethod(
       Invocation.method(#sendPasswordResetEmail, [email, actionCodeSettings]),
-      neverEndingFuture<void>(),
+      returnValue: neverEndingFuture<void>(),
+      returnValueForMissingStub: neverEndingFuture<void>(),
     );
   }
 
@@ -856,7 +879,8 @@ class MockFirebaseAuth extends Mock
   ) {
     return super.noSuchMethod(
       Invocation.method(#sendSignInLinkToEmail, [email, actionCodeSettings]),
-      neverEndingFuture<void>(),
+      returnValue: neverEndingFuture<void>(),
+      returnValueForMissingStub: neverEndingFuture<void>(),
     );
   }
 
@@ -870,7 +894,8 @@ class MockFirebaseAuth extends Mock
         appVerificationDisabledForTesting,
         userAccessGroup,
       ]),
-      neverEndingFuture<void>(),
+      returnValue: neverEndingFuture<void>(),
+      returnValueForMissingStub: neverEndingFuture<void>(),
     );
   }
 
@@ -878,7 +903,8 @@ class MockFirebaseAuth extends Mock
   Future<void> setPersistence(Persistence? persistence) {
     return super.noSuchMethod(
       Invocation.method(#setPersistence, [persistence]),
-      neverEndingFuture<void>(),
+      returnValue: neverEndingFuture<void>(),
+      returnValueForMissingStub: neverEndingFuture<void>(),
     );
   }
 
@@ -886,7 +912,8 @@ class MockFirebaseAuth extends Mock
   Future<void> signOut() {
     return super.noSuchMethod(
       Invocation.method(#signOut, [signOut]),
-      neverEndingFuture<void>(),
+      returnValue: neverEndingFuture<void>(),
+      returnValueForMissingStub: neverEndingFuture<void>(),
     );
   }
 
@@ -894,7 +921,8 @@ class MockFirebaseAuth extends Mock
   Future<String> verifyPasswordResetCode(String? code) {
     return super.noSuchMethod(
       Invocation.method(#verifyPasswordResetCode, [code]),
-      neverEndingFuture<String>(),
+      returnValue: neverEndingFuture<String>(),
+      returnValueForMissingStub: neverEndingFuture<String>(),
     );
   }
 
@@ -920,7 +948,8 @@ class MockFirebaseAuth extends Mock
         #forceResendingToken: forceResendingToken,
         #autoRetrievedSmsCodeForTesting: autoRetrievedSmsCodeForTesting,
       }),
-      neverEndingFuture<String>(),
+      returnValue: neverEndingFuture<String>(),
+      returnValueForMissingStub: neverEndingFuture<String>(),
     );
   }
 }
@@ -1000,7 +1029,8 @@ class MockRecaptchaVerifier extends Mock
   RecaptchaVerifierFactoryPlatform get delegate {
     return super.noSuchMethod(
       Invocation.getter(#delegate),
-      MockRecaptchaVerifierFactoryPlatform(),
+      returnValue: MockRecaptchaVerifierFactoryPlatform(),
+      returnValueForMissingStub: MockRecaptchaVerifierFactoryPlatform(),
     );
   }
 }

--- a/packages/firebase_auth/firebase_auth/test/user_test.dart
+++ b/packages/firebase_auth/firebase_auth/test/user_test.dart
@@ -363,7 +363,8 @@ class MockFirebaseAuth extends Mock
   Future<UserCredentialPlatform> signInAnonymously() {
     return super.noSuchMethod(
       Invocation.method(#signInAnonymously, const []),
-      neverEndingFuture<UserCredentialPlatform>(),
+      returnValue: neverEndingFuture<UserCredentialPlatform>(),
+      returnValueForMissingStub: neverEndingFuture<UserCredentialPlatform>(),
     );
   }
 
@@ -371,7 +372,8 @@ class MockFirebaseAuth extends Mock
   FirebaseAuthPlatform delegateFor({FirebaseApp? app}) {
     return super.noSuchMethod(
       Invocation.method(#delegateFor, const [], {#app: app}),
-      TestFirebaseAuthPlatform(),
+      returnValue: TestFirebaseAuthPlatform(),
+      returnValueForMissingStub: TestFirebaseAuthPlatform(),
     );
   }
 
@@ -385,7 +387,8 @@ class MockFirebaseAuth extends Mock
         #currentUser: currentUser,
         #languageCode: languageCode,
       }),
-      TestFirebaseAuthPlatform(),
+      returnValue: TestFirebaseAuthPlatform(),
+      returnValueForMissingStub: TestFirebaseAuthPlatform(),
     );
   }
 }
@@ -401,7 +404,8 @@ class MockUserPlatform extends Mock
   Future<void> delete() {
     return super.noSuchMethod(
       Invocation.method(#delete, []),
-      neverEndingFuture<void>(),
+      returnValue: neverEndingFuture<void>(),
+      returnValueForMissingStub: neverEndingFuture<void>(),
     );
   }
 
@@ -409,7 +413,8 @@ class MockUserPlatform extends Mock
   Future<void> reload() {
     return super.noSuchMethod(
       Invocation.method(#reload, []),
-      neverEndingFuture<void>(),
+      returnValue: neverEndingFuture<void>(),
+      returnValueForMissingStub: neverEndingFuture<void>(),
     );
   }
 
@@ -417,7 +422,8 @@ class MockUserPlatform extends Mock
   Future<String> getIdToken(bool? forceRefresh) {
     return super.noSuchMethod(
       Invocation.method(#getIdToken, [forceRefresh]),
-      neverEndingFuture<String>(),
+      returnValue: neverEndingFuture<String>(),
+      returnValueForMissingStub: neverEndingFuture<String>(),
     );
   }
 
@@ -425,7 +431,8 @@ class MockUserPlatform extends Mock
   Future<UserPlatform> unlink(String? providerId) {
     return super.noSuchMethod(
       Invocation.method(#unlink, [providerId]),
-      neverEndingFuture<UserPlatform>(),
+      returnValue: neverEndingFuture<UserPlatform>(),
+      returnValueForMissingStub: neverEndingFuture<UserPlatform>(),
     );
   }
 
@@ -433,7 +440,8 @@ class MockUserPlatform extends Mock
   Future<IdTokenResult> getIdTokenResult(bool? forceRefresh) {
     return super.noSuchMethod(
       Invocation.method(#getIdTokenResult, [forceRefresh]),
-      neverEndingFuture<IdTokenResult>(),
+      returnValue: neverEndingFuture<IdTokenResult>(),
+      returnValueForMissingStub: neverEndingFuture<IdTokenResult>(),
     );
   }
 
@@ -443,7 +451,8 @@ class MockUserPlatform extends Mock
   ) {
     return super.noSuchMethod(
       Invocation.method(#reauthenticateWithCredential, [credential]),
-      neverEndingFuture<UserCredentialPlatform>(),
+      returnValue: neverEndingFuture<UserCredentialPlatform>(),
+      returnValueForMissingStub: neverEndingFuture<UserCredentialPlatform>(),
     );
   }
 
@@ -453,7 +462,8 @@ class MockUserPlatform extends Mock
   ) {
     return super.noSuchMethod(
       Invocation.method(#linkWithCredential, [credential]),
-      neverEndingFuture<UserCredentialPlatform>(),
+      returnValue: neverEndingFuture<UserCredentialPlatform>(),
+      returnValueForMissingStub: neverEndingFuture<UserCredentialPlatform>(),
     );
   }
 
@@ -461,7 +471,8 @@ class MockUserPlatform extends Mock
   Future<void> sendEmailVerification(ActionCodeSettings? actionCodeSettings) {
     return super.noSuchMethod(
       Invocation.method(#sendEmailVerification, [actionCodeSettings]),
-      neverEndingFuture<void>(),
+      returnValue: neverEndingFuture<void>(),
+      returnValueForMissingStub: neverEndingFuture<void>(),
     );
   }
 
@@ -469,7 +480,8 @@ class MockUserPlatform extends Mock
   Future<void> updateEmail(String? newEmail) {
     return super.noSuchMethod(
       Invocation.method(#updateEmail, [newEmail]),
-      neverEndingFuture<void>(),
+      returnValue: neverEndingFuture<void>(),
+      returnValueForMissingStub: neverEndingFuture<void>(),
     );
   }
 
@@ -477,7 +489,8 @@ class MockUserPlatform extends Mock
   Future<void> updatePassword(String? newPassword) {
     return super.noSuchMethod(
       Invocation.method(#updatePassword, [newPassword]),
-      neverEndingFuture<void>(),
+      returnValue: neverEndingFuture<void>(),
+      returnValueForMissingStub: neverEndingFuture<void>(),
     );
   }
 
@@ -485,7 +498,8 @@ class MockUserPlatform extends Mock
   Future<void> updatePhoneNumber(PhoneAuthCredential? phoneCredential) {
     return super.noSuchMethod(
       Invocation.method(#updatePhoneNumber, [phoneCredential]),
-      neverEndingFuture<void>(),
+      returnValue: neverEndingFuture<void>(),
+      returnValueForMissingStub: neverEndingFuture<void>(),
     );
   }
 
@@ -493,7 +507,8 @@ class MockUserPlatform extends Mock
   Future<void> updateProfile(Map<String, String?>? profile) {
     return super.noSuchMethod(
       Invocation.method(#updateProfile, [profile]),
-      neverEndingFuture<void>(),
+      returnValue: neverEndingFuture<void>(),
+      returnValueForMissingStub: neverEndingFuture<void>(),
     );
   }
 
@@ -507,7 +522,8 @@ class MockUserPlatform extends Mock
         newEmail,
         actionCodeSettings,
       ]),
-      neverEndingFuture<void>(),
+      returnValue: neverEndingFuture<void>(),
+      returnValueForMissingStub: neverEndingFuture<void>(),
     );
   }
 }

--- a/packages/firebase_core/firebase_core/test/firebase_core_test.dart
+++ b/packages/firebase_core/firebase_core/test/firebase_core_test.dart
@@ -76,7 +76,8 @@ class MockFirebaseCore extends Mock
   FirebaseAppPlatform app([String name = defaultFirebaseAppName]) {
     return super.noSuchMethod(
       Invocation.method(#app, [name]),
-      FakeFirebaseAppPlatform(),
+      returnValue: FakeFirebaseAppPlatform(),
+      returnValueForMissingStub: FakeFirebaseAppPlatform(),
     );
   }
 
@@ -94,7 +95,8 @@ class MockFirebaseCore extends Mock
           #options: options,
         },
       ),
-      Future.value(FakeFirebaseAppPlatform()),
+      returnValue: Future.value(FakeFirebaseAppPlatform()),
+      returnValueForMissingStub: Future.value(FakeFirebaseAppPlatform()),
     );
   }
 
@@ -102,7 +104,8 @@ class MockFirebaseCore extends Mock
   List<FirebaseAppPlatform> get apps {
     return super.noSuchMethod(
       Invocation.getter(#apps),
-      <FirebaseAppPlatform>[],
+      returnValue: <FirebaseAppPlatform>[],
+      returnValueForMissingStub: <FirebaseAppPlatform>[],
     );
   }
 }

--- a/packages/firebase_messaging/firebase_messaging/test/mock.dart
+++ b/packages/firebase_messaging/firebase_messaging/test/mock.dart
@@ -75,14 +75,16 @@ class MockFirebaseMessaging extends Mock
 
   @override
   bool get isAutoInitEnabled {
-    return super.noSuchMethod(Invocation.getter(#isAutoInitEnabled), true);
+    return super.noSuchMethod(Invocation.getter(#isAutoInitEnabled),
+        returnValue: true, returnValueForMissingStub: true);
   }
 
   @override
   FirebaseMessagingPlatform delegateFor({FirebaseApp? app}) {
     return super.noSuchMethod(
       Invocation.method(#delegateFor, [], {#app: app}),
-      TestFirebaseMessagingPlatform(),
+      returnValue: TestFirebaseMessagingPlatform(),
+      returnValueForMissingStub: TestFirebaseMessagingPlatform(),
     );
   }
 
@@ -91,27 +93,31 @@ class MockFirebaseMessaging extends Mock
     return super.noSuchMethod(
       Invocation.method(
           #setInitialValues, [], {#isAutoInitEnabled: isAutoInitEnabled}),
-      TestFirebaseMessagingPlatform(),
+      returnValue: TestFirebaseMessagingPlatform(),
+      returnValueForMissingStub: TestFirebaseMessagingPlatform(),
     );
   }
 
   @override
   Future<RemoteMessage?> getInitialMessage() {
     return super.noSuchMethod(Invocation.method(#getInitialMessage, []),
-        neverEndingFuture<RemoteMessage>());
+        returnValue: neverEndingFuture<RemoteMessage>(),
+        returnValueForMissingStub: neverEndingFuture<RemoteMessage>());
   }
 
   @override
   Future<void> deleteToken({String? senderId}) {
     return super.noSuchMethod(
         Invocation.method(#deleteToken, [], {#senderId: senderId}),
-        Future<void>.value());
+        returnValue: Future<void>.value(),
+        returnValueForMissingStub: Future<void>.value());
   }
 
   @override
   Future<String?> getAPNSToken() {
-    return super.noSuchMethod(
-        Invocation.method(#getAPNSToken, []), Future<String>.value(''));
+    return super.noSuchMethod(Invocation.method(#getAPNSToken, []),
+        returnValue: Future<String>.value(''),
+        returnValueForMissingStub: Future<String>.value(''));
   }
 
   @override
@@ -119,20 +125,23 @@ class MockFirebaseMessaging extends Mock
     return super.noSuchMethod(
         Invocation.method(
             #getToken, [], {#senderId: senderId, #vapidKey: vapidKey}),
-        Future<String>.value(''));
+        returnValue: Future<String>.value(''),
+        returnValueForMissingStub: Future<String>.value(''));
   }
 
   @override
   Future<void> setAutoInitEnabled(bool? enabled) {
     return super.noSuchMethod(Invocation.method(#setAutoInitEnabled, [enabled]),
-        Future<void>.value());
+        returnValue: Future<void>.value(),
+        returnValueForMissingStub: Future<void>.value());
   }
 
   @override
   Stream<String> get onTokenRefresh {
     return super.noSuchMethod(
       Invocation.getter(#onTokenRefresh),
-      const Stream<String>.empty(),
+      returnValue: const Stream<String>.empty(),
+      returnValueForMissingStub: const Stream<String>.empty(),
     );
   }
 
@@ -155,19 +164,22 @@ class MockFirebaseMessaging extends Mock
           #provisional: provisional,
           #sound: sound
         }),
-        neverEndingFuture<NotificationSettings>());
+        returnValue: neverEndingFuture<NotificationSettings>(),
+        returnValueForMissingStub: neverEndingFuture<NotificationSettings>());
   }
 
   @override
   Future<void> subscribeToTopic(String? topic) {
-    return super.noSuchMethod(
-        Invocation.method(#subscribeToTopic, [topic]), Future<void>.value());
+    return super.noSuchMethod(Invocation.method(#subscribeToTopic, [topic]),
+        returnValue: Future<void>.value(),
+        returnValueForMissingStub: Future<void>.value());
   }
 
   @override
   Future<void> unsubscribeFromTopic(String? topic) {
     return super.noSuchMethod(Invocation.method(#unsubscribeFromTopic, [topic]),
-        Future<void>.value());
+        returnValue: Future<void>.value(),
+        returnValueForMissingStub: Future<void>.value());
   }
 }
 


### PR DESCRIPTION
## Description

`mockito` dependency breaks the `all_plugins/tests` check for github actions. It made a breaking change to the API which this PR resolves.

This PR affects `auth`, `core`, `messaging` & `firestore` packages.

## Related Issues

*Replace this paragraph with a list of issues related to this PR from the [issue database](https://github.com/flutter/flutter/issues). Indicate, which of these issues are resolved or fixed by this PR. Note that you'll have to prefix the issue numbers with flutter/flutter#.*

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
