### PR TITLE
tests: convert DateTime to UTC before getting the year in tests.

### DIFF
--- a/packages/cloud_firestore/cloud_firestore_platform_interface/test/timestamp_test.dart
+++ b/packages/cloud_firestore/cloud_firestore_platform_interface/test/timestamp_test.dart
@@ -60,17 +60,17 @@ void main() {
 
     test('fromMillisecondsSinceEpoch can handle 0', () {
       Timestamp t = Timestamp.fromMillisecondsSinceEpoch(0);
-      expect(t.toDate().year, 1970);
-      expect(t.toDate().month, 1);
-      expect(t.toDate().day, 1);
+      expect(t.toDate().toUtc().year, 1970);
+      expect(t.toDate().toUtc().month, 1);
+      expect(t.toDate().toUtc().day, 1);
     });
 
     test('fromMillisecondsSinceEpoch can handle negative millisecond values',
         () {
       Timestamp t = Timestamp.fromMillisecondsSinceEpoch(-9999999999);
 
-      expect(t.toDate().year, 1969);
-      expect(t.toDate().month, 9);
+      expect(t.toDate().toUtc().year, 1969);
+      expect(t.toDate().toUtc().month, 9);
     });
 
     test('millisecondsSinceEpoch returns correct negative epoch value', () {


### PR DESCRIPTION
The unix epoch is actually in year 1969 in the US! Converting the time
to UTC makes sure that the test will pass even when the local time zone
is negative.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
