### PR TITLE
docs: fix incorrect icon property

### DIFF
--- a/docs/messaging/notifications.mdx
+++ b/docs/messaging/notifications.mdx
@@ -230,6 +230,7 @@ FirebaseMessaging.onMessage.listen((RemoteMessage message) {
 
   // If `onMessage` is triggered with a notification, construct our own
   // local notification to show to users using the created channel.
+  // Set null in icon property to use app default icon
   if (notification != null && android != null) {
     flutterLocalNotificationsPlugin.show(
         notification.hashCode,
@@ -240,7 +241,7 @@ FirebaseMessaging.onMessage.listen((RemoteMessage message) {
             channel.id,
             channel.name,
             channel.description,
-            icon: android?.smallIcon,
+            icon: null,
             // other properties...
           ),
         ));


### PR DESCRIPTION
## Description

Documented page have an issue with property `icon: android?.smallIcon`, getting an error when listen onMessage in foreground.

## Related Issues

`E/flutter ( 6588): [ERROR:flutter/lib/ui/ui_dart_state.cc(177)] Unhandled Exception: PlatformException(INVALID_ICON, The resource ic_launcher could not be found. Please make sure it has been added as a drawable resource to your Android head project., null, null)`

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
