### PR TITLE
docs(emulators): add instructions for firebase emulator suite networking

### DIFF
--- a/docs/auth/usage.mdx
+++ b/docs/auth/usage.mdx
@@ -477,3 +477,13 @@ Future<void> linkGoogleAndTwitter() async {
   await googleUserCredential.user.linkWithCredential(twitterAuthCredential);
 }
 ```
+
+### Emulator Usage
+
+If you are using the local Cloud Functions emulators, then it is possible to connect to these using the `useEmulator` method.
+Ensure you pass the correct port on which the Firebase emulator is running on.
+Ensure you have enabled network connections to the emulators in your apps following the emulator usage instructions in the general FlutterFire installation notes for each operating system.
+
+```dart
+FirebaseAuth.instance.useEmulator(origin: 'http://localhost:9099');
+```

--- a/docs/firestore/usage.mdx
+++ b/docs/firestore/usage.mdx
@@ -689,6 +689,8 @@ If you are using the local [Firestore emulators](https://firebase.google.com/doc
 connect to these by passing a [`host`](!cloud_firestore.Settings.host) parameter to the [`settings`](!cloud_firestore.FirebaseFirestore.settings) method,
 immediately after initializing Firebase. Ensure you pass the correct port on which the Firebase emulator is running on.
 
+Ensure you have enabled network connections to the emulators in your apps following the emulator usage instructions in the general FlutterFire installation notes for each operating system.
+
 > On Android emulators, to reference `localhost`, use the `10.0.2.2` IP address instead.
 
 ```dart

--- a/docs/functions/usage.mdx
+++ b/docs/functions/usage.mdx
@@ -61,12 +61,11 @@ HttpsCallableResult callable = await FirebaseFunctions
   .httpsCallable('getName');
 ```
 
-
 ## Emulator Usage
 
 If you are using the local Cloud Functions emulators, then it is possible to connect to these using the `useFunctionsEmulator` method.
 Ensure you pass the correct port on which the Firebase emulator is running on.
-
+Ensure you have enabled network connections to the emulators in your apps following the emulator usage instructions in the general FlutterFire installation notes for each operating system.
 
 ```dart
 FirebaseFunctions.instance

--- a/docs/installation/android.mdx
+++ b/docs/installation/android.mdx
@@ -76,6 +76,20 @@ dependencies {
 
 Visit the [official Android documentation](https://developer.android.com/studio/build/multidex#mdex-gradle) to learn more.
 
+### Enabling use of Firebase Emulator Suite
+
+The [Firebase Emulator Suite](https://firebase.google.com/docs/emulator-suite) uses un-encrypted networking connections in order to enable fast, uncomplicated setup. However Android by default requires encrypted networking connections. If you would like to use any part of the Firebase Emulator Suite to emulate firebase services on your local machine during development, you must allow your Android app to connect to local network services over insecure connections.
+
+To allow insecure connections, we recommend adding the [`usesCleartextTraffic=true`](https://developer.android.com/guide/topics/manifest/application-element#usesCleartextTraffic) attribute to the `application` element of `AndroidManifest.xml` in the debug configuration tree, so you do not accidentally allow unencrypted traffic in release builds.
+
+Specifically in your app, edit (or create the file if necessary) `android/app/src/debug/AndroidManifest.xml`:
+
+```xml
+<application usesCleartextTraffic="true">
+  <!-- possibly other elements -->
+</application>
+```
+
 ## Initializing FlutterFire
 
 Once complete follow the instructions on [Initializing FlutterFire](../overview.mdx#initializing-flutterfire).

--- a/docs/installation/ios.mdx
+++ b/docs/installation/ios.mdx
@@ -32,6 +32,22 @@ Select the `GoogleService-Info.plist` file you downloaded, and ensure the "Copy 
   caption={false}
 />
 
+### Enabling use of Firebase Emulator Suite
+
+The [Firebase Emulator Suite](https://firebase.google.com/docs/emulator-suite) uses un-encrypted networking connections in order to enable fast, uncomplicated setup. However iOS by default requires encrypted networking connections. If you would like to use any part of the Firebase Emulator Suite to emulate firebase services on your local machine during development, you must allow your iOS app to connect to local network services over insecure connections.
+
+To allow insecure connections, we recommend adding the [`NSAllowsLocalNetworking`](https://developer.apple.com/documentation/bundleresources/information_property_list/nsapptransportsecurity/nsallowslocalnetworking) key to the [`NSAppTransportSecurity`](https://developer.apple.com/documentation/bundleresources/information_property_list/nsapptransportsecurity) dictionary in your application's plist file.
+
+Specifically if your app is named 'MyApp', you might add these keys in `ios/MyApp/Info.plist`:
+
+```xml
+<key>NSAppTransportSecurity</key>
+<dict>
+    <key>NSAllowsLocalNetworking</key>
+    <true/>
+</dict>
+```
+
 ## Initializing FlutterFire
 
 Once complete follow the instructions on [Initializing FlutterFire](../overview.mdx#initializing-flutterfire).

--- a/docs/installation/macos.mdx
+++ b/docs/installation/macos.mdx
@@ -32,6 +32,22 @@ Select the `GoogleService-Info.plist` file you downloaded, and ensure the "Copy 
   caption={false}
 />
 
+## Enabling use of Firebase Emulator Suite
+
+The [Firebase Emulator Suite](https://firebase.google.com/docs/emulator-suite) uses un-encrypted networking connections in order to enable fast, uncomplicated setup. However macOS by default requires encrypted networking connections. If you would like to use any part of the Firebase Emulator Suite to emulate firebase services on your local machine during development, you must allow your macOS app to connect to local network services over insecure connections.
+
+To allow insecure connections, we recommend adding the [`NSAllowsLocalNetworking`](https://developer.apple.com/documentation/bundleresources/information_property_list/nsapptransportsecurity/nsallowslocalnetworking) key to the [`NSAppTransportSecurity`](https://developer.apple.com/documentation/bundleresources/information_property_list/nsapptransportsecurity) dictionary in your application's plist file.
+
+Specifically if your app is named 'MyApp', and are sharing your configuration between iOS and macOS you might add these keys in `ios/MyApp/Info.plist`:
+
+```xml
+<key>NSAppTransportSecurity</key>
+<dict>
+    <key>NSAllowsLocalNetworking</key>
+    <true/>
+</dict>
+```
+
 ## Initializing FlutterFire
 
 Once complete follow the instructions on [Initializing FlutterFire](../overview.mdx#initializing-flutterfire).


### PR DESCRIPTION

## Description

Android, iOS and macOS all enforce encrypted connections for networking, but
the firebase emulator suite uses unencrypted connections to avoid encryptiong
setup. These instructions explain how to allow unencrypted connections so
native apps can use the emulators

## Related Issues

#5102 - firestore emulator docs request
https://github.com/FirebaseExtended/flutterfire/issues/5096#issuecomment-784122845 - firestore auth docs request

## Checklist

This is a change to .mdx files - docs - only, so should be easy though I am always open to wording improvements of course - sometimes takes a couple passes before the wording is as good as it can be

Cheers

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
