### PR TITLE
fix(auth, web): correct use of underlying useEmulator API, sync not async

### DIFF
--- a/packages/firebase_auth/firebase_auth_web/lib/firebase_auth_web.dart
+++ b/packages/firebase_auth/firebase_auth_web/lib/firebase_auth_web.dart
@@ -348,7 +348,7 @@ class FirebaseAuthWeb extends FirebaseAuthPlatform {
       // The generic platform interface is with host and port split to
       // centralize logic between android/ios native, but web takes the
       // origin as a single string
-      await _webAuth!.useEmulator('http://$host:$port');
+      _webAuth!.useEmulator('http://$host:$port');
     } catch (e) {
       throw getFirebaseAuthException(e);
     }

--- a/packages/firebase_auth/firebase_auth_web/lib/src/interop/auth.dart
+++ b/packages/firebase_auth/firebase_auth_web/lib/src/interop/auth.dart
@@ -615,8 +615,7 @@ class Auth extends JsObjectWrapper<auth_interop.AuthJsImpl> {
   ///
   /// Note: must be called before using auth methods, do not use
   /// with production credentials as local connections are unencrypted
-  Future useEmulator(String origin) =>
-      handleThenable(jsObject.useEmulator(origin));
+  void useEmulator(String origin) => jsObject.useEmulator(origin);
 
   /// Sets the current language to the default device/browser preference.
   void useDeviceLanguage() => jsObject.useDeviceLanguage();


### PR DESCRIPTION
## Description

My original implementation of auth.useEmulator for FlutterFire in #4263 used the underlying firebase-js-sdk incorrectly for the web implementation

Underlying web API for useEmulator is sync not async, so attempting to await it and call .then resulted in an error since no Promise was returned.

Supporting auth.useEmulator officially should still require the Firestore issue uncovered in firebase-js-sdk >= v8.0.1 to be resolved, tracked here #4127 - but if users are willing to pin firebase-js-sdk === v8.0.1 auth.useEmulator will now work for them and firebase web in general should work

**For people testing this and using firestore on web: firebase-js-sdk v8.0.1 is reported to work with auth.useEmulator without triggering the problem described in #4127 - thanks to @wtfiwtz for success report**

## Related Issues

Fixes #5096

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
