### PR TITLE
fix(crashlytics)!: `checkForUnsentReports` should error if `isCrashlyticsCollectionEnabled` is false

### DIFF
--- a/packages/firebase_crashlytics/firebase_crashlytics/example/test_driver/firebase_crashlytics_e2e.dart
+++ b/packages/firebase_crashlytics/firebase_crashlytics/example/test_driver/firebase_crashlytics_e2e.dart
@@ -23,13 +23,10 @@ void testsMain() {
       test('should throw if automatic crash report is enabled', () async {
         await crashlytics.setCrashlyticsCollectionEnabled(true);
 
-        try {
-          await crashlytics.checkForUnsentReports();
-        } catch (error) {
-          expect(error, isInstanceOf<StateError>());
-          return;
-        }
-        fail('Error did not throw');
+        await expectLater(
+          crashlytics.checkForUnsentReports,
+          throwsA(isA<StateError>()),
+        );
       });
 
       test('checks device cache for unsent crashlytics reports', () async {

--- a/packages/firebase_crashlytics/firebase_crashlytics/example/test_driver/firebase_crashlytics_e2e.dart
+++ b/packages/firebase_crashlytics/firebase_crashlytics/example/test_driver/firebase_crashlytics_e2e.dart
@@ -20,25 +20,17 @@ void testsMain() {
     });
 
     group('checkForUnsentReports', () {
-      //TODO(russellwheatley) debug test. The fail() function doesn't fail test and an error isn't thrown on android platform
-      // test('should throw if automatic crash report is enabled', () async {
+      test('should throw if automatic crash report is enabled', () async {
+        await crashlytics.setCrashlyticsCollectionEnabled(true);
 
-      //previous implementation
-      // try {
-      //   await crashlytics.checkForUnsentReports();
-      //   fail('Error did not throw');
-      // } catch (e) {
-      //   // Do nothing. test will fail.
-      // }
-
-      // current implementation
-      //   await crashlytics.setCrashlyticsCollectionEnabled(true);
-
-      //   await expectLater(
-      //     crashlytics.checkForUnsentReports,
-      //     throwsA(isA<FirebaseException>()),
-      //   );
-      // });
+        try {
+          await crashlytics.checkForUnsentReports();
+        } catch (error) {
+          expect(error, isInstanceOf<StateError>());
+          return;
+        }
+        fail('Error did not throw');
+      });
 
       test('checks device cache for unsent crashlytics reports', () async {
         await crashlytics.setCrashlyticsCollectionEnabled(false);

--- a/packages/firebase_crashlytics/firebase_crashlytics/test/firebase_crashlytics_test.dart
+++ b/packages/firebase_crashlytics/firebase_crashlytics/test/firebase_crashlytics_test.dart
@@ -30,9 +30,12 @@ void main() {
     tearDown(methodCallLog.clear);
 
     test('checkForUnsentReports', () async {
+      await crashlytics!.setCrashlyticsCollectionEnabled(false);
       await crashlytics!.checkForUnsentReports();
 
       expect(methodCallLog, <Matcher>[
+        isMethodCall('Crashlytics#setCrashlyticsCollectionEnabled',
+            arguments: {'enabled': false}),
         isMethodCall('Crashlytics#checkForUnsentReports', arguments: null)
       ]);
     });

--- a/packages/firebase_crashlytics/firebase_crashlytics_platform_interface/lib/src/method_channel/method_channel_crashlytics.dart
+++ b/packages/firebase_crashlytics/firebase_crashlytics_platform_interface/lib/src/method_channel/method_channel_crashlytics.dart
@@ -40,6 +40,11 @@ class MethodChannelFirebaseCrashlytics extends FirebaseCrashlyticsPlatform {
 
   @override
   Future<bool> checkForUnsentReports() async {
+    if (isCrashlyticsCollectionEnabled) {
+      throw StateError(
+          "Crashlytics#setCrashlyticsCollectionEnabled has been set to 'true', all reports are automatically sent.");
+    }
+
     try {
       Map<String, dynamic>? data =
           await channel.invokeMapMethod<String, dynamic>(

--- a/packages/firebase_crashlytics/firebase_crashlytics_platform_interface/test/method_channel_tests/method_channel_crashlytics_test.dart
+++ b/packages/firebase_crashlytics/firebase_crashlytics_platform_interface/test/method_channel_tests/method_channel_crashlytics_test.dart
@@ -12,7 +12,7 @@ import '../mock.dart';
 
 void main() {
   setupFirebaseCrashlyticsMocks();
-
+  TestMethodChannelFirebaseCrashlytics? mockCrashlytics;
   FirebaseCrashlyticsPlatform? crashlytics;
   final List<MethodCall> logger = <MethodCall>[];
 
@@ -76,6 +76,7 @@ void main() {
       });
 
       crashlytics = MethodChannelFirebaseCrashlytics(app: app);
+      mockCrashlytics = TestMethodChannelFirebaseCrashlytics(app);
     });
 
     setUp(() async {
@@ -92,7 +93,7 @@ void main() {
     group('checkForUnsentReports', () {
       test('should call delegate method successfully', () async {
         kUnsentReports = true;
-        var isUnsentReports = await crashlytics!.checkForUnsentReports();
+        var isUnsentReports = await mockCrashlytics!.checkForUnsentReports();
 
         expect(isUnsentReports, isTrue);
 
@@ -113,7 +114,7 @@ void main() {
         mockPlatformExceptionThrown = true;
 
         await testExceptionHandling(
-            'PLATFORM', crashlytics!.checkForUnsentReports);
+            'PLATFORM', mockCrashlytics!.checkForUnsentReports);
       });
     });
 
@@ -339,4 +340,11 @@ void main() {
       });
     });
   });
+}
+
+class TestMethodChannelFirebaseCrashlytics
+    extends MethodChannelFirebaseCrashlytics {
+  TestMethodChannelFirebaseCrashlytics(FirebaseApp app) : super(app: app);
+  @override
+  bool get isCrashlyticsCollectionEnabled => false;
 }

--- a/packages/firebase_crashlytics/firebase_crashlytics_platform_interface/test/platform_interface_tests/platform_interface_crashlytics_test.dart
+++ b/packages/firebase_crashlytics/firebase_crashlytics_platform_interface/test/platform_interface_tests/platform_interface_crashlytics_test.dart
@@ -62,8 +62,8 @@ void main() {
     test('throws if .checkForUnsentReports', () {
       expect(
         () => firebaseCrashlyticsPlatform!.checkForUnsentReports(),
-        throwsA(isA<UnimplementedError>()
-            .having((e) => e.message, 'message', 'checkForUnsentReports() is not implemented')),
+        throwsA(isA<UnimplementedError>().having((e) => e.message, 'message',
+            'checkForUnsentReports() is not implemented')),
       );
     });
 

--- a/packages/firebase_crashlytics/firebase_crashlytics_platform_interface/test/platform_interface_tests/platform_interface_crashlytics_test.dart
+++ b/packages/firebase_crashlytics/firebase_crashlytics_platform_interface/test/platform_interface_tests/platform_interface_crashlytics_test.dart
@@ -60,82 +60,60 @@ void main() {
     });
 
     test('throws if .checkForUnsentReports', () {
-      try {
-        firebaseCrashlyticsPlatform!.checkForUnsentReports();
-        // ignore: avoid_catching_errors, acceptable as UnimplementedError usage is correct
-      } on UnimplementedError catch (e) {
-        expect(e.message, equals('checkForUnsentReports() is not implemented'));
-        return;
-      }
-      fail('Should have thrown an [UnimplementedError]');
+      expect(
+        () => firebaseCrashlyticsPlatform!.checkForUnsentReports(),
+        throwsA(isA<UnimplementedError>()
+            .having((e) => e.message, 'message', 'checkForUnsentReports() is not implemented')),
+      );
     });
 
     test('throws if .crash', () {
-      try {
-        firebaseCrashlyticsPlatform!.crash();
-        // ignore: avoid_catching_errors, acceptable as UnimplementedError usage is correct
-      } on UnimplementedError catch (e) {
-        expect(e.message, equals('crash() is not implemented'));
-        return;
-      }
-      fail('Should have thrown an [UnimplementedError]');
+      expect(
+        () => firebaseCrashlyticsPlatform!.crash(),
+        throwsA(isA<UnimplementedError>()
+            .having((e) => e.message, 'message', 'crash() is not implemented')),
+      );
     });
 
     test('throws if .deleteUnsentReports', () {
-      try {
-        firebaseCrashlyticsPlatform!.deleteUnsentReports();
-        // ignore: avoid_catching_errors, acceptable as UnimplementedError usage is correct
-      } on UnimplementedError catch (e) {
-        expect(e.message, equals('deleteUnsentReports() is not implemented'));
-        return;
-      }
-      fail('Should have thrown an [UnimplementedError]');
+      expect(
+        () => firebaseCrashlyticsPlatform!.deleteUnsentReports(),
+        throwsA(isA<UnimplementedError>().having((e) => e.message, 'message',
+            'deleteUnsentReports() is not implemented')),
+      );
     });
 
     test('throws if .didCrashOnPreviousExecution', () {
-      try {
-        firebaseCrashlyticsPlatform!.didCrashOnPreviousExecution();
-        // ignore: avoid_catching_errors, acceptable as UnimplementedError usage is correct
-      } on UnimplementedError catch (e) {
-        expect(e.message,
-            equals('didCrashOnPreviousExecution() is not implemented'));
-        return;
-      }
-      fail('Should have thrown an [UnimplementedError]');
+      expect(
+        () => firebaseCrashlyticsPlatform!.didCrashOnPreviousExecution(),
+        throwsA(isA<UnimplementedError>().having((e) => e.message, 'message',
+            'didCrashOnPreviousExecution() is not implemented')),
+      );
     });
 
     test('throws if .log', () {
-      try {
-        firebaseCrashlyticsPlatform!.log('foo');
-        // ignore: avoid_catching_errors, acceptable as UnimplementedError usage is correct
-      } on UnimplementedError catch (e) {
-        expect(e.message, equals('log() is not implemented'));
-        return;
-      }
-      fail('Should have thrown an [UnimplementedError]');
+      expect(
+        () => firebaseCrashlyticsPlatform!.log('foo'),
+        throwsA(isA<UnimplementedError>()
+            .having((e) => e.message, 'message', 'log() is not implemented')),
+      );
     });
 
     test('throws if .sendUnsentReports', () {
-      try {
-        firebaseCrashlyticsPlatform!.sendUnsentReports();
-        // ignore: avoid_catching_errors, acceptable as UnimplementedError usage is correct
-      } on UnimplementedError catch (e) {
-        expect(e.message, equals('sendUnsentReports() is not implemented'));
-        return;
-      }
-      fail('Should have thrown an [UnimplementedError]');
+      expect(
+        () => firebaseCrashlyticsPlatform!.sendUnsentReports(),
+        throwsA(isA<UnimplementedError>().having((e) => e.message, 'message',
+            'sendUnsentReports() is not implemented')),
+      );
     });
 
     test('throws if .setCrashlyticsCollectionEnabled', () {
-      try {
-        firebaseCrashlyticsPlatform!.setCrashlyticsCollectionEnabled(true);
-        // ignore: avoid_catching_errors, acceptable as UnimplementedError usage is correct
-      } on UnimplementedError catch (e) {
-        expect(e.message,
-            equals('setCrashlyticsCollectionEnabled() is not implemented'));
-        return;
-      }
-      fail('Should have thrown an [UnimplementedError]');
+      expect(
+        () =>
+            firebaseCrashlyticsPlatform!.setCrashlyticsCollectionEnabled(true),
+        throwsA(isA<UnimplementedError>().having((e) => e.message, 'message',
+            'setCrashlyticsCollectionEnabled() is not implemented')),
+      );
     });
 
     test('throws if .setUserIdentifier', () {


### PR DESCRIPTION
## Description

This is a follow up PR for [FF-19](https://yt.invertase.io/youtrack/issue/FLUTTERFIRE-19) & [FF-20](https://yt.invertase.io/youtrack/issue/FLUTTERFIRE-20). 

Unsure if this is a breaking change as I've updated this [checkForUnsentReports()](https://github.com/FirebaseExtended/flutterfire/compare/@russell/crashlytics-follow-up-pr?expand=1#diff-ec378bc3ccbeedd0a391d573aacc9b6d96edbd7c82ab8bfc2993661151e8085aR43-R46) to throw an error if `isCrashlyticsCollectionEnabled` is set to `true`. This now matches the behaviour of [RNFB Crashlytics](https://github.com/invertase/react-native-firebase/blob/master/packages/crashlytics/lib/index.js#L52) and is the reason this [test](https://github.com/FirebaseExtended/flutterfire/blob/master/packages/firebase_crashlytics/firebase_crashlytics/example/test_driver/firebase_crashlytics_e2e.dart#L22-L41) wasn't erroring as expected.


## Related Issues

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [x] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [ ] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
