### PR TITLE
fix(cloud_firestore_web): Fix wrong cast (FirebaseExtended#5050)

### DIFF
--- a/packages/cloud_firestore/cloud_firestore_web/lib/src/interop/utils/utils.dart
+++ b/packages/cloud_firestore/cloud_firestore_web/lib/src/interop/utils/utils.dart
@@ -12,25 +12,22 @@ import '../firestore_interop.dart' hide FieldValue;
 
 /// Returns Dart representation from JS Object.
 dynamic dartify(Object? jsObject) {
-  return core_interop.dartify(
-      jsObject,
-      (Object object) {
-        if (util.instanceof(object, DocumentReferenceJsConstructor)) {
-          return DocumentReference.getInstance(
-              object as DocumentReferenceJsImpl);
-        }
-        if (util.instanceof(object, GeoPointConstructor)) {
-          return object;
-        }
-        if (util.instanceof(object, TimestampJsConstructor)) {
-          return DateTime.fromMillisecondsSinceEpoch(
-              (object as TimestampJsImpl).toMillis());
-        }
-        if (util.instanceof(object, BlobConstructor)) {
-          return object as Blob;
-        }
-        return null;
-      } as Object Function(Object?)?);
+  return core_interop.dartify(jsObject, (Object object) {
+    if (util.instanceof(object, DocumentReferenceJsConstructor)) {
+      return DocumentReference.getInstance(object as DocumentReferenceJsImpl);
+    }
+    if (util.instanceof(object, GeoPointConstructor)) {
+      return object;
+    }
+    if (util.instanceof(object, TimestampJsConstructor)) {
+      return DateTime.fromMillisecondsSinceEpoch(
+          (object as TimestampJsImpl).toMillis());
+    }
+    if (util.instanceof(object, BlobConstructor)) {
+      return object as Blob;
+    }
+    return null;
+  });
 }
 
 /// Returns the JS implementation from Dart Object.
@@ -39,34 +36,32 @@ dynamic jsify(Object? dartObject) {
     return null;
   }
 
-  return core_interop.jsify(
-      dartObject,
-      (Object? object) {
-        if (object is DateTime) {
-          return TimestampJsImpl.fromMillis(object.millisecondsSinceEpoch);
-        }
+  return core_interop.jsify(dartObject, (Object object) {
+    if (object is DateTime) {
+      return TimestampJsImpl.fromMillis(object.millisecondsSinceEpoch);
+    }
 
-        if (object is DocumentReference) {
-          return object.jsObject;
-        }
+    if (object is DocumentReference) {
+      return object.jsObject;
+    }
 
-        if (object is FieldValue) {
-          return jsifyFieldValue(object);
-        }
+    if (object is FieldValue) {
+      return jsifyFieldValue(object);
+    }
 
-        if (object is Blob) {
-          return object;
-        }
+    if (object is Blob) {
+      return object;
+    }
 
-        // NOTE: if the firestore JS lib is not imported, we'll get a DDC warning here
-        if (object is GeoPoint) {
-          return dartObject;
-        }
+    // NOTE: if the firestore JS lib is not imported, we'll get a DDC warning here
+    if (object is GeoPoint) {
+      return dartObject;
+    }
 
-        if (object is Function) {
-          return allowInterop(object);
-        }
+    if (object is Function) {
+      return allowInterop(object);
+    }
 
-        return null;
-      } as Object Function(Object)?);
+    return null;
+  });
 }

--- a/packages/firebase_core/firebase_core_web/lib/src/interop/utils/utils.dart
+++ b/packages/firebase_core/firebase_core_web/lib/src/interop/utils/utils.dart
@@ -14,9 +14,12 @@ import 'func.dart';
 import 'js_interop.dart' as js;
 
 /// Returns Dart representation from JS Object.
+///
+/// The optional [customDartify] function may return `null` to indicate,
+/// that it could not handle the given JS Object.
 dynamic dartify(
   Object? jsObject, [
-  Object Function(Object? object)? customDartify,
+  Object? Function(Object object)? customDartify,
 ]) {
   if (_isBasicType(jsObject)) {
     return jsObject;
@@ -49,15 +52,18 @@ dynamic dartify(
 // Converts an Iterable into a JS Array
 dynamic jsifyList(
   Iterable list, [
-  Object Function(Object object)? customJsify,
+  Object? Function(Object object)? customJsify,
 ]) {
   return js.toJSArray(list.map((item) => jsify(item, customJsify)).toList());
 }
 
-// Returns the JS implementation from Dart Object.
+/// Returns the JS implementation from Dart Object.
+///
+/// The optional [customJsify] function may return `null` to indicate,
+/// that it could not handle the given Dart Object.
 dynamic jsify(
   Object dartObject, [
-  Object Function(Object object)? customJsify,
+  Object? Function(Object object)? customJsify,
 ]) {
   if (_isBasicType(dartObject)) {
     return dartObject;


### PR DESCRIPTION
## Description

* Fixed signature of `dartify` and `jsify` utils funtions
* Improved documentation of `dartify` and `jsify` utils funtions
* Removed wrong cast from `Function(Object)` to `Function(Object?)`
  when `core_interop.dartify(...)` is called with a `customDartify` parameter
* Removed wrong cast from `Function(Object?)` to `Function(Object)`
  when `core_interop.jsify(...)` is called with a `customJsify` parameter

I don't know why `melos run format` changed the indentation.

I did not add tests, because I essentially did not add new code.

## Related Issues

This fixes the issue #5050 (as well as the duplicate #5238)
 - Fixes #5050
 - Fixes #5238

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.
