### PR TITLE
docs(firebase_auth): fixed example code to delete a user

### DIFF
--- a/docs/auth/usage.mdx
+++ b/docs/auth/usage.mdx
@@ -406,7 +406,7 @@ example:
 ```dart
 try {
   await FirebaseAuth.instance.currentUser.delete();
-} catch on FirebaseAuthException (e) {
+} on FirebaseAuthException catch (e) {
   if (e.code == 'requires-recent-login') {
     print('The user must reauthenticate before this operation can be executed.');
   }


### PR DESCRIPTION
## Description

The example code for deleting a user cannot be compiled, because `catch` is in the wrong place. 

## Related Issues

No related issues found.

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.
