### PR TITLE
fix: cannot store null values in firestore on the web

### DIFF
--- a/packages/cloud_firestore/cloud_firestore/example/test_driver/document_change_e2e.dart
+++ b/packages/cloud_firestore/cloud_firestore/example/test_driver/document_change_e2e.dart
@@ -93,7 +93,7 @@ void runDocumentChangeTests() {
           expect(change.newIndex, equals(0));
           expect(change.oldIndex, equals(-1));
           expect(change.type, equals(DocumentChangeType.added));
-          expect(change.doc.data()['name'], equals('doc1'));
+          expect(change.doc.data()!['name'], equals('doc1'));
         } else if (call == 2) {
           expect(snapshot.docs.length, equals(0));
           expect(snapshot.docChanges.length, equals(1));
@@ -102,7 +102,7 @@ void runDocumentChangeTests() {
           expect(change.newIndex, equals(-1));
           expect(change.oldIndex, equals(0));
           expect(change.type, equals(DocumentChangeType.removed));
-          expect(change.doc.data()['name'], equals('doc1'));
+          expect(change.doc.data()!['name'], equals('doc1'));
         } else {
           fail('Should not have been called');
         }
@@ -139,7 +139,7 @@ void runDocumentChangeTests() {
             expect(change.oldIndex, equals(-1));
             expect(change.newIndex, equals(index));
             expect(change.type, equals(DocumentChangeType.added));
-            expect(change.doc.data()['value'], equals(index + 1));
+            expect(change.doc.data()!['value'], equals(index + 1));
           });
         } else if (call == 2) {
           expect(snapshot.docs.length, equals(3));

--- a/packages/cloud_firestore/cloud_firestore_web/lib/src/interop/utils/utils.dart
+++ b/packages/cloud_firestore/cloud_firestore_web/lib/src/interop/utils/utils.dart
@@ -2,7 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:firebase_core_web/firebase_core_web_interop.dart' as core_interop;
+import 'package:firebase_core_web/firebase_core_web_interop.dart'
+    as core_interop;
 import 'package:js/js.dart';
 import 'package:js/js_util.dart' as util;
 
@@ -19,7 +20,8 @@ dynamic dartify(Object? jsObject) {
       return object;
     }
     if (util.instanceof(object, TimestampJsConstructor)) {
-      return DateTime.fromMillisecondsSinceEpoch((object! as TimestampJsImpl).toMillis());
+      return DateTime.fromMillisecondsSinceEpoch(
+          (object! as TimestampJsImpl).toMillis());
     }
     if (util.instanceof(object, BlobConstructor)) {
       return object! as Blob;

--- a/packages/cloud_firestore/cloud_firestore_web/lib/src/interop/utils/utils.dart
+++ b/packages/cloud_firestore/cloud_firestore_web/lib/src/interop/utils/utils.dart
@@ -2,8 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:firebase_core_web/firebase_core_web_interop.dart'
-    as core_interop;
+import 'package:firebase_core_web/firebase_core_web_interop.dart' as core_interop;
 import 'package:js/js.dart';
 import 'package:js/js_util.dart' as util;
 
@@ -12,7 +11,7 @@ import '../firestore_interop.dart' hide FieldValue;
 
 /// Returns Dart representation from JS Object.
 dynamic dartify(Object? jsObject) {
-  return core_interop.dartify(jsObject, (Object object) {
+  return core_interop.dartify(jsObject, (Object? object) {
     if (util.instanceof(object, DocumentReferenceJsConstructor)) {
       return DocumentReference.getInstance(object as DocumentReferenceJsImpl);
     }
@@ -20,8 +19,7 @@ dynamic dartify(Object? jsObject) {
       return object;
     }
     if (util.instanceof(object, TimestampJsConstructor)) {
-      return DateTime.fromMillisecondsSinceEpoch(
-          (object as TimestampJsImpl).toMillis());
+      return DateTime.fromMillisecondsSinceEpoch((object as TimestampJsImpl).toMillis());
     }
     if (util.instanceof(object, BlobConstructor)) {
       return object as Blob;
@@ -36,7 +34,7 @@ dynamic jsify(Object? dartObject) {
     return null;
   }
 
-  return core_interop.jsify(dartObject, (Object object) {
+  return core_interop.jsify(dartObject, (Object? object) {
     if (object is DateTime) {
       return TimestampJsImpl.fromMillis(object.millisecondsSinceEpoch);
     }

--- a/packages/cloud_firestore/cloud_firestore_web/lib/src/interop/utils/utils.dart
+++ b/packages/cloud_firestore/cloud_firestore_web/lib/src/interop/utils/utils.dart
@@ -2,7 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:firebase_core_web/firebase_core_web_interop.dart' as core_interop;
+import 'package:firebase_core_web/firebase_core_web_interop.dart'
+    as core_interop;
 import 'package:js/js.dart';
 import 'package:js/js_util.dart' as util;
 
@@ -19,7 +20,8 @@ dynamic dartify(Object? jsObject) {
       return object;
     }
     if (util.instanceof(object, TimestampJsConstructor)) {
-      return DateTime.fromMillisecondsSinceEpoch((object as TimestampJsImpl).toMillis());
+      return DateTime.fromMillisecondsSinceEpoch(
+          (object as TimestampJsImpl).toMillis());
     }
     if (util.instanceof(object, BlobConstructor)) {
       return object as Blob;

--- a/packages/cloud_firestore/cloud_firestore_web/lib/src/interop/utils/utils.dart
+++ b/packages/cloud_firestore/cloud_firestore_web/lib/src/interop/utils/utils.dart
@@ -2,8 +2,7 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:firebase_core_web/firebase_core_web_interop.dart'
-    as core_interop;
+import 'package:firebase_core_web/firebase_core_web_interop.dart' as core_interop;
 import 'package:js/js.dart';
 import 'package:js/js_util.dart' as util;
 
@@ -14,17 +13,16 @@ import '../firestore_interop.dart' hide FieldValue;
 dynamic dartify(Object? jsObject) {
   return core_interop.dartify(jsObject, (Object? object) {
     if (util.instanceof(object, DocumentReferenceJsConstructor)) {
-      return DocumentReference.getInstance(object as DocumentReferenceJsImpl);
+      return DocumentReference.getInstance(object! as DocumentReferenceJsImpl);
     }
     if (util.instanceof(object, GeoPointConstructor)) {
       return object;
     }
     if (util.instanceof(object, TimestampJsConstructor)) {
-      return DateTime.fromMillisecondsSinceEpoch(
-          (object as TimestampJsImpl).toMillis());
+      return DateTime.fromMillisecondsSinceEpoch((object! as TimestampJsImpl).toMillis());
     }
     if (util.instanceof(object, BlobConstructor)) {
-      return object as Blob;
+      return object! as Blob;
     }
     return null;
   });

--- a/packages/firebase_core/firebase_core_web/lib/src/interop/utils/utils.dart
+++ b/packages/firebase_core/firebase_core_web/lib/src/interop/utils/utils.dart
@@ -19,7 +19,7 @@ import 'js_interop.dart' as js;
 /// that it could not handle the given JS Object.
 dynamic dartify(
   Object? jsObject, [
-  Object? Function(Object object)? customDartify,
+  Object? Function(Object? object)? customDartify,
 ]) {
   if (_isBasicType(jsObject)) {
     return jsObject;
@@ -52,7 +52,7 @@ dynamic dartify(
 // Converts an Iterable into a JS Array
 dynamic jsifyList(
   Iterable list, [
-  Object? Function(Object object)? customJsify,
+  Object? Function(Object? object)? customJsify,
 ]) {
   return js.toJSArray(list.map((item) => jsify(item, customJsify)).toList());
 }
@@ -62,8 +62,8 @@ dynamic jsifyList(
 /// The optional [customJsify] function may return `null` to indicate,
 /// that it could not handle the given Dart Object.
 dynamic jsify(
-  Object dartObject, [
-  Object? Function(Object object)? customJsify,
+  Object? dartObject, [
+  Object? Function(Object? object)? customJsify,
 ]) {
   if (_isBasicType(dartObject)) {
     return dartObject;


### PR DESCRIPTION
## Description

With the introduction of null safety you are not being able to store nested null values in Firestore on the web anymore.

Not working before this fix:

```dart
 await FirebaseFirestore.instance.collection("collection").doc("test").update(<String, dynamic>{
     'test': {
         'nestedKey': null  // <--- causes 
     },
});
```
Exception:

`Expected a value of type 'Object', but got one of type 'Null'`

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [X] All existing and new tests are passing.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [X] I read and followed the [Flutter Style Guide].
- [X] I signed the [CLA].
- [X] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [X] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
