### PR TITLE
chore: Remove conflicting linting rules

### DIFF
--- a/all_lint_rules.yaml
+++ b/all_lint_rules.yaml
@@ -8,7 +8,6 @@ linter:
     - always_put_control_body_on_new_line
     - always_put_required_named_parameters_first
     - always_require_non_null_named_parameters
-    - always_specify_types
     - always_use_package_imports
     - annotate_overrides
     - avoid_annotating_with_dynamic
@@ -108,7 +107,6 @@ linter:
     - prefer_const_literals_to_create_immutables
     - prefer_constructors_over_static_methods
     - prefer_contains
-    - prefer_double_quotes
     - prefer_equal_for_default_values
     - prefer_expression_function_bodies
     - prefer_final_fields
@@ -153,7 +151,6 @@ linter:
     - unnecessary_await_in_return
     - unnecessary_brace_in_string_interps
     - unnecessary_const
-    - unnecessary_final
     - unnecessary_getters_setters
     - unnecessary_lambdas
     - unnecessary_new


### PR DESCRIPTION
## Description

In the `all_lint_rules.yaml` there are 3 conflicting rules specified. This PR resolves the conflict by removing one of the conflicting rules (If I should remove the other I would be happy to adjust it :))

To reproduce it, add this `analysis_options.yaml` file to `packages/firebase_analytics/firebase_analytics`:

```
include: ../../../all_lint_rules.yaml
```

You will get this error:

```
warning • Warning in the included options file /Users/dennis/develop/flutterfire/all_lint_rules.yaml(2984..3008): The rule 'omit_local_variable_types' is incompatible with the rule 'always_specify_types' • analysis_options.yaml:6:10 •
       included_file_warning
warning • Warning in the included options file /Users/dennis/develop/flutterfire/all_lint_rules.yaml(4369..4388): The rule 'prefer_single_quotes' is incompatible with the rule 'prefer_double_quotes' • analysis_options.yaml:6:10 •
       included_file_warning
warning • Warning in the included options file /Users/dennis/develop/flutterfire/all_lint_rules.yaml(5047..5063): The rule 'unnecessary_final' is incompatible with the rule 'prefer_final_locals' • analysis_options.yaml:6:10 •
       included_file_warning
```

## Related Issues

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
