### PR TITLE
feat!: Migrate firebase_dynamic_links to sound null safety

### DIFF
--- a/packages/firebase_dynamic_links/CHANGELOG.md
+++ b/packages/firebase_dynamic_links/CHANGELOG.md
@@ -1,7 +1,3 @@
-## 1.0.0
-
-- **BREAKING** **FEAT**: Upgrade to sound null-safety.
-
 ## 0.8.0
 
  - This version is not null-safe but has been created to allow compatibility with other null-safe FlutterFire packages such as `firebase_core`.

--- a/packages/firebase_dynamic_links/CHANGELOG.md
+++ b/packages/firebase_dynamic_links/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.0.0
+
+- **BREAKING** **FEAT**: Upgrade to sound null-safety.
+
 ## 0.8.0
 
  - This version is not null-safe but has been created to allow compatibility with other null-safe FlutterFire packages such as `firebase_core`.

--- a/packages/firebase_dynamic_links/example/lib/main.dart
+++ b/packages/firebase_dynamic_links/example/lib/main.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart=2.9
+
 
 import 'dart:async';
 
@@ -27,7 +27,7 @@ class _MainScreen extends StatefulWidget {
 }
 
 class _MainScreenState extends State<_MainScreen> {
-  String _linkMessage;
+  String? _linkMessage;
   bool _isCreatingLink = false;
   String _testString =
       'To test: long press link and then copy and click from a non-browser '
@@ -43,8 +43,8 @@ class _MainScreenState extends State<_MainScreen> {
 
   Future<void> initDynamicLinks() async {
     FirebaseDynamicLinks.instance.onLink(
-        onSuccess: (PendingDynamicLinkData dynamicLink) async {
-      final Uri deepLink = dynamicLink?.link;
+        onSuccess: (PendingDynamicLinkData? dynamicLink) async {
+      final Uri? deepLink = dynamicLink?.link;
 
       if (deepLink != null) {
         // ignore: unawaited_futures
@@ -55,9 +55,9 @@ class _MainScreenState extends State<_MainScreen> {
       print(e.message);
     });
 
-    final PendingDynamicLinkData data =
+    final PendingDynamicLinkData? data =
         await FirebaseDynamicLinks.instance.getInitialLink();
-    final Uri deepLink = data?.link;
+    final Uri? deepLink = data?.link;
 
     if (deepLink != null) {
       // ignore: unawaited_futures
@@ -132,7 +132,7 @@ class _MainScreenState extends State<_MainScreen> {
                 InkWell(
                   onTap: () async {
                     if (_linkMessage != null) {
-                      await launch(_linkMessage);
+                      await launch(_linkMessage!);
                     }
                   },
                   onLongPress: () {

--- a/packages/firebase_dynamic_links/example/lib/main.dart
+++ b/packages/firebase_dynamic_links/example/lib/main.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-
-
 import 'dart:async';
 
 import 'package:firebase_dynamic_links/firebase_dynamic_links.dart';

--- a/packages/firebase_dynamic_links/example/pubspec.yaml
+++ b/packages/firebase_dynamic_links/example/pubspec.yaml
@@ -2,8 +2,8 @@ name: firebase_dynamic_links_example
 description: Demonstrates how to use the firebase_dynamic_links plugin.
 
 environment:
-  sdk: ">=2.12.0-0 <3.0.0"
-  flutter: ">=1.10.0"
+  sdk: '>=2.12.0 <3.0.0'
+  flutter: ">=1.12.0"
 
 dependencies:
   firebase_core:
@@ -12,7 +12,7 @@ dependencies:
     path: ../
   flutter:
     sdk: flutter
-  url_launcher: ^5.1.6
+  url_launcher: ^6.0.2
 
 dependency_overrides:
   firebase_core:
@@ -23,10 +23,7 @@ dependency_overrides:
     path: ../../firebase_core/firebase_core_web
 
 dev_dependencies:
-  e2e: ^0.6.1
-  flutter_driver:
-    sdk: flutter
-  pedantic: ^1.8.0
+  pedantic: ^1.11.0
 
 flutter:
   uses-material-design: true

--- a/packages/firebase_dynamic_links/lib/firebase_dynamic_links.dart
+++ b/packages/firebase_dynamic_links/lib/firebase_dynamic_links.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-
-
 library firebase_dynamic_links;
 
 import 'dart:async';

--- a/packages/firebase_dynamic_links/lib/firebase_dynamic_links.dart
+++ b/packages/firebase_dynamic_links/lib/firebase_dynamic_links.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart=2.9
+
 
 library firebase_dynamic_links;
 

--- a/packages/firebase_dynamic_links/lib/src/dynamic_link_parameters.dart
+++ b/packages/firebase_dynamic_links/lib/src/dynamic_link_parameters.dart
@@ -66,7 +66,8 @@ class DynamicLinkParameters {
   static Future<ShortDynamicLink> shortenUrl(Uri url,
       [DynamicLinkParametersOptions? options]) async {
     final Map<String, dynamic>? reply = await FirebaseDynamicLinks.channel
-        .invokeMapMethod<String, dynamic>('DynamicLinkParameters#shortenUrl', <String, dynamic>{
+        .invokeMapMethod<String, dynamic>(
+            'DynamicLinkParameters#shortenUrl', <String, dynamic>{
       'url': url.toString(),
       'dynamicLinkParametersOptions': options?._data,
     });
@@ -79,7 +80,8 @@ class DynamicLinkParameters {
         'dynamicLinkParametersOptions': dynamicLinkParametersOptions?._data,
         'googleAnalyticsParameters': googleAnalyticsParameters?._data,
         'iosParameters': iosParameters?._data,
-        'itunesConnectAnalyticsParameters': itunesConnectAnalyticsParameters?._data,
+        'itunesConnectAnalyticsParameters':
+            itunesConnectAnalyticsParameters?._data,
         'link': link.toString(),
         'navigationInfoParameters': navigationInfoParameters?._data,
         'socialMetaTagParameters': socialMetaTagParameters?._data,
@@ -95,7 +97,8 @@ class DynamicLinkParameters {
   /// Generate a short Dynamic Link.
   Future<ShortDynamicLink> buildShortLink() async {
     final Map<String, dynamic>? reply = await FirebaseDynamicLinks.channel
-        .invokeMapMethod<String, dynamic>('DynamicLinkParameters#buildShortLink', _data);
+        .invokeMapMethod<String, dynamic>(
+            'DynamicLinkParameters#buildShortLink', _data);
     return _parseShortLink(reply!);
   }
 
@@ -118,7 +121,8 @@ class ShortDynamicLink {
 
 /// The Dynamic Link Android parameters.
 class AndroidParameters {
-  AndroidParameters({this.fallbackUrl, this.minimumVersion, required this.packageName});
+  AndroidParameters(
+      {this.fallbackUrl, this.minimumVersion, required this.packageName});
 
   /// The link to open when the app isn’t installed.
   ///
@@ -260,7 +264,8 @@ class IosParameters {
 
 /// The Dynamic Link iTunes Connect parameters.
 class ItunesConnectAnalyticsParameters {
-  ItunesConnectAnalyticsParameters({this.affiliateToken, this.campaignToken, this.providerToken});
+  ItunesConnectAnalyticsParameters(
+      {this.affiliateToken, this.campaignToken, this.providerToken});
 
   /// The iTunes Connect affiliate token.
   final String? affiliateToken;

--- a/packages/firebase_dynamic_links/lib/src/dynamic_link_parameters.dart
+++ b/packages/firebase_dynamic_links/lib/src/dynamic_link_parameters.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart=2.9
-
 part of firebase_dynamic_links;
 
 /// The class used for Dynamic Link URL generation.
@@ -14,19 +12,18 @@ part of firebase_dynamic_links;
 class DynamicLinkParameters {
   DynamicLinkParameters({
     this.androidParameters,
-    @required this.uriPrefix,
+    required this.uriPrefix,
     this.dynamicLinkParametersOptions,
     this.googleAnalyticsParameters,
     this.iosParameters,
     this.itunesConnectAnalyticsParameters,
-    @required this.link,
+    required this.link,
     this.navigationInfoParameters,
     this.socialMetaTagParameters,
-  })  : assert(uriPrefix != null),
-        assert(link != null);
+  });
 
   /// Android parameters for a generated Dynamic Link URL.
-  final AndroidParameters androidParameters;
+  final AndroidParameters? androidParameters;
 
   /// Domain URI Prefix of your App.
   // This value must be your assigned domain from the Firebase console.
@@ -36,16 +33,16 @@ class DynamicLinkParameters {
   final String uriPrefix;
 
   /// Defines behavior for generating Dynamic Link URLs.
-  final DynamicLinkParametersOptions dynamicLinkParametersOptions;
+  final DynamicLinkParametersOptions? dynamicLinkParametersOptions;
 
   /// Analytics parameters for a generated Dynamic Link URL.
-  final GoogleAnalyticsParameters googleAnalyticsParameters;
+  final GoogleAnalyticsParameters? googleAnalyticsParameters;
 
   /// iOS parameters for a generated Dynamic Link URL.
-  final IosParameters iosParameters;
+  final IosParameters? iosParameters;
 
   /// iTunes Connect parameters for a generated Dynamic Link URL.
-  final ItunesConnectAnalyticsParameters itunesConnectAnalyticsParameters;
+  final ItunesConnectAnalyticsParameters? itunesConnectAnalyticsParameters;
 
   /// The link the target app will open.
   ///
@@ -57,24 +54,23 @@ class DynamicLinkParameters {
   final Uri link;
 
   /// Navigation Info parameters for a generated Dynamic Link URL.
-  final NavigationInfoParameters navigationInfoParameters;
+  final NavigationInfoParameters? navigationInfoParameters;
 
   /// Social Meta Tag parameters for a generated Dynamic Link URL.
-  final SocialMetaTagParameters socialMetaTagParameters;
+  final SocialMetaTagParameters? socialMetaTagParameters;
 
   /// Shortens a Dynamic Link URL.
   ///
   /// This method may be used for shortening a custom URL that was not generated
   /// using [DynamicLinkParameters].
   static Future<ShortDynamicLink> shortenUrl(Uri url,
-      [DynamicLinkParametersOptions options]) async {
-    final Map<String, dynamic> reply = await FirebaseDynamicLinks.channel
-        .invokeMapMethod<String, dynamic>(
-            'DynamicLinkParameters#shortenUrl', <String, dynamic>{
+      [DynamicLinkParametersOptions? options]) async {
+    final Map<String, dynamic>? reply = await FirebaseDynamicLinks.channel
+        .invokeMapMethod<String, dynamic>('DynamicLinkParameters#shortenUrl', <String, dynamic>{
       'url': url.toString(),
       'dynamicLinkParametersOptions': options?._data,
     });
-    return _parseShortLink(reply);
+    return _parseShortLink(reply!);
   }
 
   Map<String, dynamic> get _data => <String, dynamic>{
@@ -83,8 +79,7 @@ class DynamicLinkParameters {
         'dynamicLinkParametersOptions': dynamicLinkParametersOptions?._data,
         'googleAnalyticsParameters': googleAnalyticsParameters?._data,
         'iosParameters': iosParameters?._data,
-        'itunesConnectAnalyticsParameters':
-            itunesConnectAnalyticsParameters?._data,
+        'itunesConnectAnalyticsParameters': itunesConnectAnalyticsParameters?._data,
         'link': link.toString(),
         'navigationInfoParameters': navigationInfoParameters?._data,
         'socialMetaTagParameters': socialMetaTagParameters?._data,
@@ -92,21 +87,20 @@ class DynamicLinkParameters {
 
   /// Generate a long Dynamic Link URL.
   Future<Uri> buildUrl() async {
-    final String url = await FirebaseDynamicLinks.channel
+    final String? url = await FirebaseDynamicLinks.channel
         .invokeMethod<String>('DynamicLinkParameters#buildUrl', _data);
-    return Uri.parse(url);
+    return Uri.parse(url!);
   }
 
   /// Generate a short Dynamic Link.
   Future<ShortDynamicLink> buildShortLink() async {
-    final Map<String, dynamic> reply = await FirebaseDynamicLinks.channel
-        .invokeMapMethod<String, dynamic>(
-            'DynamicLinkParameters#buildShortLink', _data);
-    return _parseShortLink(reply);
+    final Map<String, dynamic>? reply = await FirebaseDynamicLinks.channel
+        .invokeMapMethod<String, dynamic>('DynamicLinkParameters#buildShortLink', _data);
+    return _parseShortLink(reply!);
   }
 
   static ShortDynamicLink _parseShortLink(Map<String, dynamic> reply) {
-    final List<dynamic> warnings = reply['warnings'];
+    final List<dynamic>? warnings = reply['warnings'];
     return ShortDynamicLink._(Uri.parse(reply['url']), warnings?.cast());
   }
 }
@@ -119,27 +113,25 @@ class ShortDynamicLink {
   final Uri shortUrl;
 
   /// Information about potential warnings on link creation.
-  final List<String> warnings;
+  final List<String>? warnings;
 }
 
 /// The Dynamic Link Android parameters.
 class AndroidParameters {
-  AndroidParameters(
-      {this.fallbackUrl, this.minimumVersion, @required this.packageName})
-      : assert(packageName != null);
+  AndroidParameters({this.fallbackUrl, this.minimumVersion, required this.packageName});
 
   /// The link to open when the app isn’t installed.
   ///
   /// Specify this to do something other than install the app from the Play
   /// Store when the app isn’t installed, such as open the mobile web version of
   /// the content, or display a promotional page for the app.
-  final Uri fallbackUrl;
+  final Uri? fallbackUrl;
 
   /// The version of the minimum version of your app that can open the link.
   ///
   /// If the installed app is an older version, the user is taken to the Play
   /// Store to upgrade the app.
-  final int minimumVersion;
+  final int? minimumVersion;
 
   /// The Android app’s package name.
   final String packageName;
@@ -159,7 +151,7 @@ class DynamicLinkParametersOptions {
   DynamicLinkParametersOptions({this.shortDynamicLinkPathLength});
 
   /// Specifies the length of the path component of a short Dynamic Link.
-  final ShortDynamicLinkPathLength shortDynamicLinkPathLength;
+  final ShortDynamicLinkPathLength? shortDynamicLinkPathLength;
 
   Map<String, dynamic> get _data => <String, dynamic>{
         'shortDynamicLinkPathLength': shortDynamicLinkPathLength?.index,
@@ -169,14 +161,12 @@ class DynamicLinkParametersOptions {
 /// The Dynamic Link analytics parameters.
 class GoogleAnalyticsParameters {
   GoogleAnalyticsParameters({
-    @required this.campaign,
+    required String this.campaign,
     this.content,
-    @required this.medium,
-    @required this.source,
+    required String this.medium,
+    required String this.source,
     this.term,
-  })  : assert(campaign != null),
-        assert(medium != null),
-        assert(source != null);
+  });
 
   GoogleAnalyticsParameters.empty()
       : campaign = null,
@@ -186,19 +176,19 @@ class GoogleAnalyticsParameters {
         term = null;
 
   /// The utm_campaign analytics parameter.
-  final String campaign;
+  final String? campaign;
 
   /// The utm_content analytics parameter.
-  final String content;
+  final String? content;
 
   /// The utm_medium analytics parameter.
-  final String medium;
+  final String? medium;
 
   /// The utm_source analytics parameter.
-  final String source;
+  final String? source;
 
   /// The utm_term analytics parameter.
-  final String term;
+  final String? term;
 
   Map<String, dynamic> get _data => <String, dynamic>{
         'campaign': campaign,
@@ -213,16 +203,16 @@ class GoogleAnalyticsParameters {
 class IosParameters {
   IosParameters({
     this.appStoreId,
-    @required this.bundleId,
+    required this.bundleId,
     this.customScheme,
     this.fallbackUrl,
     this.ipadBundleId,
     this.ipadFallbackUrl,
     this.minimumVersion,
-  }) : assert(bundleId != null);
+  });
 
   /// The appStore ID of the iOS app in AppStore.
-  final String appStoreId;
+  final String? appStoreId;
 
   /// The bundle ID of the iOS app to use to open the link.
   final String bundleId;
@@ -230,32 +220,32 @@ class IosParameters {
   /// The target app’s custom URL scheme.
   ///
   /// Defined to be something other than the app’s bundle ID.
-  final String customScheme;
+  final String? customScheme;
 
   /// The link to open when the app isn’t installed.
   ///
   /// Specify this to do something other than install the app from the App Store
   /// when the app isn’t installed, such as open the mobile web version of the
   /// content, or display a promotional page for the app.
-  final Uri fallbackUrl;
+  final Uri? fallbackUrl;
 
   /// The bundle ID of the iOS app to use on iPads to open the link.
   ///
   /// This is only required if there are separate iPhone and iPad applications.
-  final String ipadBundleId;
+  final String? ipadBundleId;
 
   /// The link to open on iPads when the app isn’t installed.
   ///
   /// Specify this to do something other than install the app from the App Store
   /// when the app isn’t installed, such as open the web version of the content,
   /// or display a promotional page for the app.
-  final Uri ipadFallbackUrl;
+  final Uri? ipadFallbackUrl;
 
   /// The the minimum version of your app that can open the link.
   ///
   /// It is app’s developer responsibility to open AppStore when received link
   /// declares higher [minimumVersion] than currently installed.
-  final String minimumVersion;
+  final String? minimumVersion;
 
   Map<String, dynamic> get _data => <String, dynamic>{
         'appStoreId': appStoreId,
@@ -270,17 +260,16 @@ class IosParameters {
 
 /// The Dynamic Link iTunes Connect parameters.
 class ItunesConnectAnalyticsParameters {
-  ItunesConnectAnalyticsParameters(
-      {this.affiliateToken, this.campaignToken, this.providerToken});
+  ItunesConnectAnalyticsParameters({this.affiliateToken, this.campaignToken, this.providerToken});
 
   /// The iTunes Connect affiliate token.
-  final String affiliateToken;
+  final String? affiliateToken;
 
   /// The iTunes Connect campaign token.
-  final String campaignToken;
+  final String? campaignToken;
 
   /// The iTunes Connect provider token.
-  final String providerToken;
+  final String? providerToken;
 
   Map<String, dynamic> get _data => <String, dynamic>{
         'affiliateToken': affiliateToken,
@@ -302,7 +291,7 @@ class NavigationInfoParameters {
   /// where user tap will initiate navigation to the App (or AppStore if not
   /// installed). Disabled force redirect normally improves reliability of the
   /// click.
-  final bool forcedRedirectEnabled;
+  final bool? forcedRedirectEnabled;
 
   Map<String, dynamic> get _data => <String, dynamic>{
         'forcedRedirectEnabled': forcedRedirectEnabled,
@@ -314,13 +303,13 @@ class SocialMetaTagParameters {
   SocialMetaTagParameters({this.description, this.imageUrl, this.title});
 
   /// The description to use when the Dynamic Link is shared in a social post.
-  final String description;
+  final String? description;
 
   /// The URL to an image related to this link.
-  final Uri imageUrl;
+  final Uri? imageUrl;
 
   /// The title to use when the Dynamic Link is shared in a social post.
-  final String title;
+  final String? title;
 
   Map<String, dynamic> get _data => <String, dynamic>{
         'description': description,

--- a/packages/firebase_dynamic_links/lib/src/firebase_dynamic_links.dart
+++ b/packages/firebase_dynamic_links/lib/src/firebase_dynamic_links.dart
@@ -2,12 +2,12 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart=2.9
+
 
 part of firebase_dynamic_links;
 
 typedef OnLinkSuccessCallback = Future<dynamic> Function(
-    PendingDynamicLinkData linkData);
+    PendingDynamicLinkData? linkData);
 typedef OnLinkErrorCallback = Future<dynamic> Function(
     OnLinkErrorException error);
 
@@ -24,36 +24,36 @@ class FirebaseDynamicLinks {
   /// Singleton of [FirebaseDynamicLinks].
   static final FirebaseDynamicLinks instance = FirebaseDynamicLinks._();
 
-  OnLinkSuccessCallback _onLinkSuccess;
-  OnLinkErrorCallback _onLinkError;
+  OnLinkSuccessCallback? _onLinkSuccess;
+  OnLinkErrorCallback? _onLinkError;
 
   /// Attempts to retrieve the dynamic link which launched the app.
   ///
   /// This method always returns a Future. That Future completes to null if
   /// there is no pending dynamic link or any call to this method after the
   /// the first attempt.
-  Future<PendingDynamicLinkData> getInitialLink() async {
-    final Map<String, dynamic> linkData =
+  Future<PendingDynamicLinkData?> getInitialLink() async {
+    final Map<String, dynamic>? linkData =
         await channel.invokeMapMethod<String, dynamic>(
             'FirebaseDynamicLinks#getInitialLink');
     return getPendingDynamicLinkDataFromMap(linkData);
   }
 
-  Future<PendingDynamicLinkData> getDynamicLink(Uri url) async {
-    final Map<String, dynamic> linkData = await FirebaseDynamicLinks.channel
+  Future<PendingDynamicLinkData?> getDynamicLink(Uri url) async {
+    final Map<String, dynamic>? linkData = await FirebaseDynamicLinks.channel
         .invokeMapMethod<String, dynamic>('FirebaseDynamicLinks#getDynamicLink',
             <String, dynamic>{'url': url.toString()});
     return getPendingDynamicLinkDataFromMap(linkData);
   }
 
-  PendingDynamicLinkData getPendingDynamicLinkDataFromMap(
-      Map<dynamic, dynamic> linkData) {
+  PendingDynamicLinkData? getPendingDynamicLinkDataFromMap(
+      Map<dynamic, dynamic>? linkData) {
     if (linkData == null) return null;
 
     final link = linkData['link'];
     if (link == null) return null;
 
-    PendingDynamicLinkDataAndroid androidData;
+    PendingDynamicLinkDataAndroid? androidData;
     if (linkData['android'] != null) {
       final Map<dynamic, dynamic> data = linkData['android'];
       androidData = PendingDynamicLinkDataAndroid._(
@@ -62,7 +62,7 @@ class FirebaseDynamicLinks {
       );
     }
 
-    PendingDynamicLinkDataIOS iosData;
+    PendingDynamicLinkDataIOS? iosData;
     if (linkData['ios'] != null) {
       final Map<dynamic, dynamic> data = linkData['ios'];
       iosData = PendingDynamicLinkDataIOS._(data['minimumVersion']);
@@ -77,8 +77,8 @@ class FirebaseDynamicLinks {
 
   /// Configures onLink listeners: it has two methods for success and failure.
   void onLink({
-    OnLinkSuccessCallback onSuccess,
-    OnLinkErrorCallback onError,
+    OnLinkSuccessCallback? onSuccess,
+    OnLinkErrorCallback? onError,
   }) {
     _onLinkSuccess = onSuccess;
     _onLinkError = onError;
@@ -88,19 +88,19 @@ class FirebaseDynamicLinks {
   Future<dynamic> _handleMethod(MethodCall call) async {
     switch (call.method) {
       case 'onLinkSuccess':
-        PendingDynamicLinkData linkData;
+        PendingDynamicLinkData? linkData;
         if (call.arguments != null) {
-          final Map<dynamic, dynamic> data =
+          final Map<dynamic, dynamic>? data =
               call.arguments.cast<dynamic, dynamic>();
           linkData = getPendingDynamicLinkDataFromMap(data);
         }
-        return _onLinkSuccess(linkData);
+        return _onLinkSuccess!(linkData);
       case 'onLinkError':
         final Map<dynamic, dynamic> data =
             call.arguments.cast<dynamic, dynamic>();
         final OnLinkErrorException e = OnLinkErrorException._(
             data['code'], data['message'], data['details']);
-        return _onLinkError(e);
+        return _onLinkError!(e);
     }
   }
 }
@@ -113,13 +113,13 @@ class PendingDynamicLinkData {
   ///
   /// Can be null if [link] equals null or dynamic link was not received on an
   /// Android device.
-  final PendingDynamicLinkDataAndroid android;
+  final PendingDynamicLinkDataAndroid? android;
 
   /// Provides iOS specific data from received dynamic link.
   ///
   /// Can be null if [link] equals null or dynamic link was not received on an
   /// iOS device.
-  final PendingDynamicLinkDataIOS ios;
+  final PendingDynamicLinkDataIOS? ios;
 
   /// Deep link parameter of the dynamic link.
   final Uri link;
@@ -135,7 +135,7 @@ class PendingDynamicLinkDataAndroid {
   /// The time the user clicked on the dynamic link.
   ///
   /// Equals the number of milliseconds that have elapsed since January 1, 1970.
-  final int clickTimestamp;
+  final int? clickTimestamp;
 
   /// The minimum version of your app that can open the link.
   ///
@@ -144,7 +144,7 @@ class PendingDynamicLinkDataAndroid {
   ///
   /// If the installed app is an older version, the user is taken to the Play
   /// Store to upgrade the app.
-  final int minimumVersion;
+  final int? minimumVersion;
 }
 
 /// Provides iOS specific data from received dynamic link.
@@ -155,11 +155,11 @@ class PendingDynamicLinkDataIOS {
   ///
   /// It is app developer's responsibility to open AppStore when received link
   /// declares higher [minimumVersion] than currently installed.
-  final String minimumVersion;
+  final String? minimumVersion;
 }
 
 /// This object is returned by the handler when an error occurs.
 class OnLinkErrorException extends PlatformException {
-  OnLinkErrorException._(String code, String message, dynamic details)
+  OnLinkErrorException._(String code, String? message, dynamic details)
       : super(code: code, message: message, details: details);
 }

--- a/packages/firebase_dynamic_links/lib/src/firebase_dynamic_links.dart
+++ b/packages/firebase_dynamic_links/lib/src/firebase_dynamic_links.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-
-
 part of firebase_dynamic_links;
 
 typedef OnLinkSuccessCallback = Future<dynamic> Function(

--- a/packages/firebase_dynamic_links/pubspec.yaml
+++ b/packages/firebase_dynamic_links/pubspec.yaml
@@ -2,12 +2,12 @@ name: firebase_dynamic_links
 description:
   Flutter plugin for Google Dynamic Links for Firebase, an app solution for creating
   and handling links across multiple platforms.
-version: 0.8.0
+version: 1.0.0
 homepage: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/firebase_dynamic_links
 
 environment:
-  sdk: ">=2.12.0-0 <3.0.0"
-  flutter: ">=1.10.0"
+  sdk: '>=2.12.0 <3.0.0'
+  flutter: ">=1.12.0"
 
 dependencies:
   firebase_core: ^1.0.1
@@ -15,13 +15,10 @@ dependencies:
     sdk: flutter
 
 dev_dependencies:
-  e2e: ^0.6.1
-  flutter_driver:
-    sdk: flutter
   flutter_test:
     sdk: flutter
-  pedantic: ^1.8.0
-  url_launcher: ^5.1.6
+  pedantic: ^1.11.0
+  url_launcher: ^6.0.2
 
 flutter:
   plugin:

--- a/packages/firebase_dynamic_links/test/firebase_dynamic_links_e2e.dart
+++ b/packages/firebase_dynamic_links/test/firebase_dynamic_links_e2e.dart
@@ -1,12 +1,7 @@
-// @dart=2.9
-
 import 'package:firebase_dynamic_links/firebase_dynamic_links.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:e2e/e2e.dart';
 
 void main() {
-  E2EWidgetsFlutterBinding.ensureInitialized();
-
   testWidgets('buildUrl', (WidgetTester tester) async {
     final DynamicLinkParameters parameters = DynamicLinkParameters(
       uriPrefix: 'https://cx4k7.app.goo.gl',

--- a/packages/firebase_dynamic_links/test/firebase_dynamic_links_test.dart
+++ b/packages/firebase_dynamic_links/test/firebase_dynamic_links_test.dart
@@ -15,7 +15,8 @@ void main() {
     final List<MethodCall> log = <MethodCall>[];
 
     setUp(() {
-      FirebaseDynamicLinks.channel.setMockMethodCallHandler((MethodCall methodCall) async {
+      FirebaseDynamicLinks.channel
+          .setMockMethodCallHandler((MethodCall methodCall) async {
         log.add(methodCall);
         final Map<dynamic, dynamic> returnUrl = <dynamic, dynamic>{
           'url': 'google.com',
@@ -52,7 +53,8 @@ void main() {
 
     group('getInitialLink', () {
       test('link can be parsed', () async {
-        final PendingDynamicLinkData? data = await FirebaseDynamicLinks.instance.getInitialLink();
+        final PendingDynamicLinkData? data =
+            await FirebaseDynamicLinks.instance.getInitialLink();
 
         expect(data!.link, Uri.parse('https://google.com'));
 
@@ -72,7 +74,8 @@ void main() {
       // Both iOS FIRDynamicLink.url and android PendingDynamicLinkData.getUrl()
       // might return null link. In such a case we want to ignore the deep-link.
       test('for null link, returns null', () async {
-        FirebaseDynamicLinks.channel.setMockMethodCallHandler((MethodCall methodCall) async {
+        FirebaseDynamicLinks.channel
+            .setMockMethodCallHandler((MethodCall methodCall) async {
           log.add(methodCall);
           switch (methodCall.method) {
             case 'FirebaseDynamicLinks#getInitialLink':
@@ -91,7 +94,8 @@ void main() {
           }
         });
 
-        final PendingDynamicLinkData? data = await FirebaseDynamicLinks.instance.getInitialLink();
+        final PendingDynamicLinkData? data =
+            await FirebaseDynamicLinks.instance.getInitialLink();
 
         expect(data, isNull);
 
@@ -104,7 +108,8 @@ void main() {
       });
 
       test('for null result, returns null', () async {
-        FirebaseDynamicLinks.channel.setMockMethodCallHandler((MethodCall methodCall) async {
+        FirebaseDynamicLinks.channel
+            .setMockMethodCallHandler((MethodCall methodCall) async {
           log.add(methodCall);
           switch (methodCall.method) {
             case 'FirebaseDynamicLinks#getInitialLink':
@@ -114,7 +119,8 @@ void main() {
           }
         });
 
-        final PendingDynamicLinkData? data = await FirebaseDynamicLinks.instance.getInitialLink();
+        final PendingDynamicLinkData? data =
+            await FirebaseDynamicLinks.instance.getInitialLink();
 
         expect(data, isNull);
 
@@ -135,17 +141,20 @@ void main() {
       expect(data!.link.host, 'google.com');
 
       expect(log, <Matcher>[
-        isMethodCall('FirebaseDynamicLinks#getDynamicLink', arguments: <String, dynamic>{
-          'url': argument.toString(),
-        })
+        isMethodCall('FirebaseDynamicLinks#getDynamicLink',
+            arguments: <String, dynamic>{
+              'url': argument.toString(),
+            })
       ]);
     });
 
     group('$DynamicLinkParameters', () {
       test('shortenUrl', () async {
         final Uri url = Uri.parse('google.com');
-        final DynamicLinkParametersOptions options = DynamicLinkParametersOptions(
-            shortDynamicLinkPathLength: ShortDynamicLinkPathLength.unguessable);
+        final DynamicLinkParametersOptions options =
+            DynamicLinkParametersOptions(
+                shortDynamicLinkPathLength:
+                    ShortDynamicLinkPathLength.unguessable);
 
         await DynamicLinkParameters.shortenUrl(url, options);
 
@@ -155,7 +164,8 @@ void main() {
             arguments: <String, dynamic>{
               'url': url.toString(),
               'dynamicLinkParametersOptions': <String, dynamic>{
-                'shortDynamicLinkPathLength': ShortDynamicLinkPathLength.unguessable.index,
+                'shortDynamicLinkPathLength':
+                    ShortDynamicLinkPathLength.unguessable.index,
               },
             },
           ),
@@ -234,7 +244,8 @@ void main() {
               'androidParameters': null,
               'uriPrefix': 'https://test-domain/',
               'dynamicLinkParametersOptions': <String, dynamic>{
-                'shortDynamicLinkPathLength': ShortDynamicLinkPathLength.short.index,
+                'shortDynamicLinkPathLength':
+                    ShortDynamicLinkPathLength.short.index,
               },
               'googleAnalyticsParameters': null,
               'iosParameters': null,
@@ -250,7 +261,8 @@ void main() {
               'androidParameters': null,
               'uriPrefix': 'https://test-domain/',
               'dynamicLinkParametersOptions': <String, dynamic>{
-                'shortDynamicLinkPathLength': ShortDynamicLinkPathLength.short.index,
+                'shortDynamicLinkPathLength':
+                    ShortDynamicLinkPathLength.short.index,
               },
               'googleAnalyticsParameters': null,
               'iosParameters': null,
@@ -452,7 +464,8 @@ void main() {
         final DynamicLinkParameters components = DynamicLinkParameters(
           uriPrefix: 'https://test-domain/',
           link: Uri.parse('test-link.com'),
-          navigationInfoParameters: NavigationInfoParameters(forcedRedirectEnabled: true),
+          navigationInfoParameters:
+              NavigationInfoParameters(forcedRedirectEnabled: true),
         );
 
         await components.buildUrl();
@@ -552,7 +565,8 @@ void main() {
     group('onLink', () {
       OnLinkSuccessCallback? onSuccess;
       OnLinkErrorCallback? onError;
-      final List<PendingDynamicLinkData?> successLog = <PendingDynamicLinkData?>[];
+      final List<PendingDynamicLinkData?> successLog =
+          <PendingDynamicLinkData?>[];
       final List<OnLinkErrorException> errorLog = <OnLinkErrorException>[];
       setUp(() {
         onSuccess = (linkData) async {
@@ -581,7 +595,8 @@ void main() {
       }
 
       test('onSuccess', () async {
-        FirebaseDynamicLinks.instance.onLink(onSuccess: onSuccess, onError: onError);
+        FirebaseDynamicLinks.instance
+            .onLink(onSuccess: onSuccess, onError: onError);
         await callMethodHandler('onLinkSuccess', <dynamic, dynamic>{
           'link': 'https://google.com',
           'android': <dynamic, dynamic>{
@@ -606,7 +621,8 @@ void main() {
       });
 
       test('onSuccess with null link', () async {
-        FirebaseDynamicLinks.instance.onLink(onSuccess: onSuccess, onError: onError);
+        FirebaseDynamicLinks.instance
+            .onLink(onSuccess: onSuccess, onError: onError);
         await callMethodHandler('onLinkSuccess', <dynamic, dynamic>{
           'link': null,
           'android': <dynamic, dynamic>{
@@ -626,7 +642,8 @@ void main() {
       });
 
       test('onSuccess with null', () async {
-        FirebaseDynamicLinks.instance.onLink(onSuccess: onSuccess, onError: onError);
+        FirebaseDynamicLinks.instance
+            .onLink(onSuccess: onSuccess, onError: onError);
         await callMethodHandler('onLinkSuccess', null);
 
         expect(successLog, hasLength(1));
@@ -637,7 +654,8 @@ void main() {
       });
 
       test('onError', () async {
-        FirebaseDynamicLinks.instance.onLink(onSuccess: onSuccess, onError: onError);
+        FirebaseDynamicLinks.instance
+            .onLink(onSuccess: onSuccess, onError: onError);
         await callMethodHandler('onLinkError', <dynamic, dynamic>{
           'code': 'code',
           'message': 'message',

--- a/packages/firebase_dynamic_links/test/firebase_dynamic_links_test.dart
+++ b/packages/firebase_dynamic_links/test/firebase_dynamic_links_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart=2.9
-
 import 'dart:async';
 
 import 'package:firebase_dynamic_links/firebase_dynamic_links.dart';
@@ -17,8 +15,7 @@ void main() {
     final List<MethodCall> log = <MethodCall>[];
 
     setUp(() {
-      FirebaseDynamicLinks.channel
-          .setMockMethodCallHandler((MethodCall methodCall) async {
+      FirebaseDynamicLinks.channel.setMockMethodCallHandler((MethodCall methodCall) async {
         log.add(methodCall);
         final Map<dynamic, dynamic> returnUrl = <dynamic, dynamic>{
           'url': 'google.com',
@@ -55,15 +52,14 @@ void main() {
 
     group('getInitialLink', () {
       test('link can be parsed', () async {
-        final PendingDynamicLinkData data =
-            await FirebaseDynamicLinks.instance.getInitialLink();
+        final PendingDynamicLinkData? data = await FirebaseDynamicLinks.instance.getInitialLink();
 
-        expect(data.link, Uri.parse('https://google.com'));
+        expect(data!.link, Uri.parse('https://google.com'));
 
-        expect(data.android.clickTimestamp, 1234567);
-        expect(data.android.minimumVersion, 12);
+        expect(data.android!.clickTimestamp, 1234567);
+        expect(data.android!.minimumVersion, 12);
 
-        expect(data.ios.minimumVersion, 'Version 12');
+        expect(data.ios!.minimumVersion, 'Version 12');
 
         expect(log, <Matcher>[
           isMethodCall(
@@ -76,8 +72,7 @@ void main() {
       // Both iOS FIRDynamicLink.url and android PendingDynamicLinkData.getUrl()
       // might return null link. In such a case we want to ignore the deep-link.
       test('for null link, returns null', () async {
-        FirebaseDynamicLinks.channel
-            .setMockMethodCallHandler((MethodCall methodCall) async {
+        FirebaseDynamicLinks.channel.setMockMethodCallHandler((MethodCall methodCall) async {
           log.add(methodCall);
           switch (methodCall.method) {
             case 'FirebaseDynamicLinks#getInitialLink':
@@ -96,8 +91,7 @@ void main() {
           }
         });
 
-        final PendingDynamicLinkData data =
-            await FirebaseDynamicLinks.instance.getInitialLink();
+        final PendingDynamicLinkData? data = await FirebaseDynamicLinks.instance.getInitialLink();
 
         expect(data, isNull);
 
@@ -110,8 +104,7 @@ void main() {
       });
 
       test('for null result, returns null', () async {
-        FirebaseDynamicLinks.channel
-            .setMockMethodCallHandler((MethodCall methodCall) async {
+        FirebaseDynamicLinks.channel.setMockMethodCallHandler((MethodCall methodCall) async {
           log.add(methodCall);
           switch (methodCall.method) {
             case 'FirebaseDynamicLinks#getInitialLink':
@@ -121,8 +114,7 @@ void main() {
           }
         });
 
-        final PendingDynamicLinkData data =
-            await FirebaseDynamicLinks.instance.getInitialLink();
+        final PendingDynamicLinkData? data = await FirebaseDynamicLinks.instance.getInitialLink();
 
         expect(data, isNull);
 
@@ -137,26 +129,23 @@ void main() {
 
     test('getDynamicLink', () async {
       final Uri argument = Uri.parse('short-link');
-      final PendingDynamicLinkData data =
+      final PendingDynamicLinkData? data =
           await FirebaseDynamicLinks.instance.getDynamicLink(argument);
 
-      expect(data.link.host, 'google.com');
+      expect(data!.link.host, 'google.com');
 
       expect(log, <Matcher>[
-        isMethodCall('FirebaseDynamicLinks#getDynamicLink',
-            arguments: <String, dynamic>{
-              'url': argument.toString(),
-            })
+        isMethodCall('FirebaseDynamicLinks#getDynamicLink', arguments: <String, dynamic>{
+          'url': argument.toString(),
+        })
       ]);
     });
 
     group('$DynamicLinkParameters', () {
       test('shortenUrl', () async {
         final Uri url = Uri.parse('google.com');
-        final DynamicLinkParametersOptions options =
-            DynamicLinkParametersOptions(
-                shortDynamicLinkPathLength:
-                    ShortDynamicLinkPathLength.unguessable);
+        final DynamicLinkParametersOptions options = DynamicLinkParametersOptions(
+            shortDynamicLinkPathLength: ShortDynamicLinkPathLength.unguessable);
 
         await DynamicLinkParameters.shortenUrl(url, options);
 
@@ -166,8 +155,7 @@ void main() {
             arguments: <String, dynamic>{
               'url': url.toString(),
               'dynamicLinkParametersOptions': <String, dynamic>{
-                'shortDynamicLinkPathLength':
-                    ShortDynamicLinkPathLength.unguessable.index,
+                'shortDynamicLinkPathLength': ShortDynamicLinkPathLength.unguessable.index,
               },
             },
           ),
@@ -246,8 +234,7 @@ void main() {
               'androidParameters': null,
               'uriPrefix': 'https://test-domain/',
               'dynamicLinkParametersOptions': <String, dynamic>{
-                'shortDynamicLinkPathLength':
-                    ShortDynamicLinkPathLength.short.index,
+                'shortDynamicLinkPathLength': ShortDynamicLinkPathLength.short.index,
               },
               'googleAnalyticsParameters': null,
               'iosParameters': null,
@@ -263,8 +250,7 @@ void main() {
               'androidParameters': null,
               'uriPrefix': 'https://test-domain/',
               'dynamicLinkParametersOptions': <String, dynamic>{
-                'shortDynamicLinkPathLength':
-                    ShortDynamicLinkPathLength.short.index,
+                'shortDynamicLinkPathLength': ShortDynamicLinkPathLength.short.index,
               },
               'googleAnalyticsParameters': null,
               'iosParameters': null,
@@ -466,8 +452,7 @@ void main() {
         final DynamicLinkParameters components = DynamicLinkParameters(
           uriPrefix: 'https://test-domain/',
           link: Uri.parse('test-link.com'),
-          navigationInfoParameters:
-              NavigationInfoParameters(forcedRedirectEnabled: true),
+          navigationInfoParameters: NavigationInfoParameters(forcedRedirectEnabled: true),
         );
 
         await components.buildUrl();
@@ -565,10 +550,9 @@ void main() {
     });
 
     group('onLink', () {
-      OnLinkSuccessCallback onSuccess;
-      OnLinkErrorCallback onError;
-      final List<PendingDynamicLinkData> successLog =
-          <PendingDynamicLinkData>[];
+      OnLinkSuccessCallback? onSuccess;
+      OnLinkErrorCallback? onError;
+      final List<PendingDynamicLinkData?> successLog = <PendingDynamicLinkData?>[];
       final List<OnLinkErrorException> errorLog = <OnLinkErrorException>[];
       setUp(() {
         onSuccess = (linkData) async {
@@ -597,8 +581,7 @@ void main() {
       }
 
       test('onSuccess', () async {
-        FirebaseDynamicLinks.instance
-            .onLink(onSuccess: onSuccess, onError: onError);
+        FirebaseDynamicLinks.instance.onLink(onSuccess: onSuccess, onError: onError);
         await callMethodHandler('onLinkSuccess', <dynamic, dynamic>{
           'link': 'https://google.com',
           'android': <dynamic, dynamic>{
@@ -612,19 +595,18 @@ void main() {
 
         expect(successLog, hasLength(1));
         expect(errorLog, hasLength(0));
-        final success = successLog[0];
+        final success = successLog[0]!;
 
         expect(success.link, Uri.parse('https://google.com'));
 
-        expect(success.android.clickTimestamp, 1234567);
-        expect(success.android.minimumVersion, 12);
+        expect(success.android!.clickTimestamp, 1234567);
+        expect(success.android!.minimumVersion, 12);
 
-        expect(success.ios.minimumVersion, 'Version 12');
+        expect(success.ios!.minimumVersion, 'Version 12');
       });
 
       test('onSuccess with null link', () async {
-        FirebaseDynamicLinks.instance
-            .onLink(onSuccess: onSuccess, onError: onError);
+        FirebaseDynamicLinks.instance.onLink(onSuccess: onSuccess, onError: onError);
         await callMethodHandler('onLinkSuccess', <dynamic, dynamic>{
           'link': null,
           'android': <dynamic, dynamic>{
@@ -644,8 +626,7 @@ void main() {
       });
 
       test('onSuccess with null', () async {
-        FirebaseDynamicLinks.instance
-            .onLink(onSuccess: onSuccess, onError: onError);
+        FirebaseDynamicLinks.instance.onLink(onSuccess: onSuccess, onError: onError);
         await callMethodHandler('onLinkSuccess', null);
 
         expect(successLog, hasLength(1));
@@ -656,8 +637,7 @@ void main() {
       });
 
       test('onError', () async {
-        FirebaseDynamicLinks.instance
-            .onLink(onSuccess: onSuccess, onError: onError);
+        FirebaseDynamicLinks.instance.onLink(onSuccess: onSuccess, onError: onError);
         await callMethodHandler('onLinkError', <dynamic, dynamic>{
           'code': 'code',
           'message': 'message',


### PR DESCRIPTION
## Description

This PR updates firebase dynamic links to sound null safety.

The primary uncertainty is integration_test package consuming e2e. It appears flutter_driver is holding packages back. It also appeared in other null-safe releases of other flutterfire packages (e.g., firebase_core), the integration tests were removed (not sure if this is a temporary measure or not). Hence, I followed suit and removed the dependency on e2e & flutter_driver.

## Related Issues

https://github.com/FirebaseExtended/flutterfire/discussions/4182

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [x] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [ ] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
