### PR TITLE
fix: RemoteMessage.fromMap

### DIFF
--- a/packages/firebase_messaging/firebase_messaging_platform_interface/lib/src/remote_message.dart
+++ b/packages/firebase_messaging/firebase_messaging_platform_interface/lib/src/remote_message.dart
@@ -28,7 +28,7 @@ class RemoteMessage {
       senderId: map['senderId'],
       category: map['category'],
       collapseKey: map['collapseKey'],
-      contentAvailable: map['contentAvailable'],
+      contentAvailable: map['contentAvailable']==true,
       data: map['data'] == null
           ? <String, dynamic>{}
           : Map<String, dynamic>.from(map['data']),
@@ -36,7 +36,7 @@ class RemoteMessage {
       // Note: using toString on messageId as it can be an int or string when being sent from native.
       messageId: map['messageId']?.toString(),
       messageType: map['messageType'],
-      mutableContent: map['mutableContent'],
+      mutableContent: map['mutableContent']==true,
       notification: map['notification'] == null
           ? null
           : RemoteNotification.fromMap(


### PR DESCRIPTION
## Description

fix  the case when `contentAvailable` &  `mutableContent` are null this cause events not working at all

## Related Issues

#5324 
#4949

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
