### PR TITLE
docs(admob): update docs to reference new external plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,6 @@ and open source.
 
 **Table of contents:**
 
-- [AdMob (`firebase_admob`)](#firebase_admob)
 - [Analytics (`firebase_analytics`)](#firebase_analytics)
 - [Authentication (`firebase_auth`)](#firebase_auth)
 - [Cloud Firestore (`cloud_firestore`)](#cloud_firestore)
@@ -51,23 +50,6 @@ and open source.
 - [Remote Config (`firebase_remote_config`)](#firebase_remote_config)
 
 ---
-
-### `firebase_admob`
-
-> [![firebase_admob][admob_badge_pub]][admob_pub] [![pub points][admob_badge_pub_points]][admob_pub_points]
-
-Google AdMob is a mobile advertising platform that you can use to generate revenue from your app. Using AdMob with
-Firebase provides you with additional app usage data and analytics capabilities. [[Learn More][admob_product]]
-
-[[View Source][admob_code]]
-
-#### Platform Support
-
-| Android | iOS | MacOS | Web |
-|:-------:|:---:|:-----:|:---:|
-|    ✔️    |  ✔️  |       |     |
-
-----
 
 ### `firebase_analytics`
 
@@ -347,19 +329,6 @@ and open a [pull request](https://github.com/FirebaseExtended/flutterfire/pulls)
 
 This repository is maintained by Googlers but is not a supported Firebase product. Issues here are answered by
 maintainers and other community members on GitHub on a best-effort basis.
-
-
-[admob_pub]: https://pub.dev/packages/firebase_admob
-
-[admob_product]: https://firebase.google.com/docs/admob/
-
-[admob_code]: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/firebase_admob
-
-[admob_pub_points]: https://pub.dev/packages/firebase_admob/score
-
-[admob_badge_pub_points]: https://badges.bar/firebase_admob/pub%20points
-
-[admob_badge_pub]: https://img.shields.io/pub/v/firebase_admob.svg
 
 [analytics_pub]: https://pub.dev/packages/firebase_analytics
 

--- a/docs/admob/usage.mdx
+++ b/docs/admob/usage.mdx
@@ -1,6 +1,0 @@
----
-title: AdMob
-sidebar_label: Usage
----
-
-AdMob usage

--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -17,7 +17,6 @@ module.exports = {
       "migration",
       "null-safety",
     ],
-    // AdMob: ["admob/usage", toReferenceAPI("firebase_admob")],
     Analytics: ["analytics/overview", toReferenceAPI("firebase_analytics")],
     Authentication: [
       "auth/overview",

--- a/docs/versions.js
+++ b/docs/versions.js
@@ -2,8 +2,6 @@ export default {
   // Plugin versions are sourced from the public pub.dev API
   // See website/plugins/source-versions.js for more information on how these are sourced & injected via Webpack
   plugins: {
-    firebase_admob: PUB_FIREBASE_ADMOB,
-    firebase_admob_ns: PUB_NS_FIREBASE_ADMOB,
     firebase_analytics: PUB_FIREBASE_ANALYTICS,
     firebase_analytics_ns: PUB_NS_FIREBASE_ANALYTICS,
     firebase_auth: PUB_FIREBASE_AUTH,

--- a/website/plugins.js
+++ b/website/plugins.js
@@ -4,7 +4,7 @@ module.exports = [
     pub: 'google_mobile_ads',
     firebase: 'admob',
     remoteSource: 'https://github.com/googleads/googleads-mobile-flutter',
-    documentation:'',
+    documentation: 'https://pub.dev/documentation/google_mobile_ads/latest/',
     support: {
       web: false,
       mobile: true,

--- a/website/plugins.js
+++ b/website/plugins.js
@@ -3,6 +3,7 @@ module.exports = [
     name: 'AdMob',
     pub: 'firebase_admob',
     firebase: 'admob',
+    remoteSource:'https://github.com/googleads/googleads-mobile-flutter',
     documentation:'',
     support: {
       web: false,

--- a/website/plugins.js
+++ b/website/plugins.js
@@ -1,7 +1,7 @@
 module.exports = [
   {
     name: 'AdMob',
-    pub: 'firebase_admob',
+    pub: 'google_mobile_ads',
     firebase: 'admob',
     remoteSource:'https://github.com/googleads/googleads-mobile-flutter',
     documentation:'',

--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -16,6 +16,7 @@ interface Plugin {
   pub: string;
   documentation: string;
   firebase: string;
+  remoteSource?:string;
   support: {
     web: boolean;
     mobile: boolean;
@@ -129,7 +130,7 @@ function Home() {
                   </td>
                   <td>
                     <a
-                      href={`https://github.com/FirebaseExtended/flutterfire/tree/master/packages/${plugin.pub}`}
+                      href={plugin.remoteSource ? plugin.remoteSource : `https://github.com/FirebaseExtended/flutterfire/tree/master/packages/${plugin.pub}`}
                       target="_blank"
                     >
                       <code>{plugin.pub}</code>

--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -100,10 +100,10 @@ function Home() {
                     <strong>{plugin.name}</strong>
                   </td>
                   <td style={{ minWidth: 150 }}>
-                    {!plugin.remoteSource && <img
+                    <img
                       src={`https://img.shields.io/pub/v/${plugin.pub}.svg`}
                       alt={`${plugin.name} Badge`}
-                    />}
+                    />
                   </td>
                   <td>
                     <a href={`https://pub.dev/packages/${plugin.pub}`}>

--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -100,10 +100,10 @@ function Home() {
                     <strong>{plugin.name}</strong>
                   </td>
                   <td style={{ minWidth: 150 }}>
-                    <img
+                    {!plugin.remoteSource && <img
                       src={`https://img.shields.io/pub/v/${plugin.pub}.svg`}
                       alt={`${plugin.name} Badge`}
-                    />
+                    />}
                   </td>
                   <td>
                     <a href={`https://pub.dev/packages/${plugin.pub}`}>


### PR DESCRIPTION
## Description

Points to [remote source](https://github.com/googleads/googleads-mobile-flutter) following deprecation of admob package from this repository.
## Related Issues

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change (please indicate a breaking change in CHANGELOG.md and increment major revision).
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
