### PR TITLE
chore(repository): fix issue template discussion categories' links

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,11 +1,11 @@
 blank_issues_enabled: false
 contact_links:
   - name: Feature Request
-    url: https://github.com/FirebaseExtended/flutterfire/discussions/new?category_id=24213383
+    url: https://github.com/FirebaseExtended/flutterfire/discussions/new?category=feature-request
     about: Share ideas for new features.
   - name: Ask a Question
-    url: https://github.com/FirebaseExtended/flutterfire/discussions/new?category_id=24213382
+    url: https://github.com/FirebaseExtended/flutterfire/discussions/new?category=q-a
     about: Ask the community for help.
   - name: Show and tell
-    url: https://github.com/FirebaseExtended/flutterfire/discussions/new?category_id=24213384
+    url: https://github.com/FirebaseExtended/flutterfire/discussions/new?category=show-and-tell
     about: Share what you've built with FlutterFire.


### PR DESCRIPTION
## Description

Fix issue template discussion's link to specific categories

## Checklist

- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

<!-- LINKS -->
[CLA]: https://cla.developers.google.com/
