### PR TITLE
fix: Added `android:` to `usesCleartextTraffic` in docs

### DIFF
--- a/docs/installation/android.mdx
+++ b/docs/installation/android.mdx
@@ -85,7 +85,7 @@ To allow insecure connections, we recommend adding the [`usesCleartextTraffic=tr
 Specifically in your app, edit (or create the file if necessary) `android/app/src/debug/AndroidManifest.xml`:
 
 ```xml
-<application usesCleartextTraffic="true">
+<application android:usesCleartextTraffic="true">
   <!-- possibly other elements -->
 </application>
 ```


### PR DESCRIPTION
## Description

This reflects the usage on the [android docs](https://developer.android.com/guide/topics/manifest/application-element#usesCleartextTraffic)

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [X] All existing and new tests are passing.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [X] I read and followed the [Flutter Style Guide].
- [X] I signed the [CLA].
- [X] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [X] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
