### PR TITLE
docs: stable channel is null-safe

### DIFF
--- a/docs/analytics/overview.mdx
+++ b/docs/analytics/overview.mdx
@@ -26,7 +26,7 @@ values={[
 
 :::caution
 This package version is not null safe migrated yet, but has been implemented to be compatible with other null safe FlutterFire packages.
-Null safety is now available in Flutter's  `stable` channel for Web, Android & iOS targets.
+Null safety is now available in Flutter's `stable` channel for Web, Android & iOS targets.
 :::
 
 #### Flutter Web, Android & iOS targets:

--- a/docs/analytics/overview.mdx
+++ b/docs/analytics/overview.mdx
@@ -26,23 +26,23 @@ values={[
 
 :::caution
 This package version is not null safe migrated yet, but has been implemented to be compatible with other null safe FlutterFire packages.
-With that in mind, you will need to use the `beta` channel which supports null safe projects.
+Null safety is now available in Flutter's  `stable` channel for Web, Android & iOS targets.
 :::
 
 #### Flutter Web, Android & iOS targets:
 
-Web, Android & iOS targets require the Flutter `beta` channel:
+Web, Android & iOS targets require the Flutter `stable` channel:
 
 ```bash
-$ flutter channel beta
+$ flutter channel stable
 ```
 
 #### Flutter desktop targets:
 
-Desktop targets such as macOS requires  the Flutter `dev` channel:
+Desktop targets such as macOS requires  the Flutter `beta` channel:
 
 ```bash
-$ flutter channel dev
+$ flutter channel beta
 ```
 
 If your app is mixing legacy and null-safe packages, use the `--no-sound-null-safety` flag:

--- a/docs/analytics/overview.mdx
+++ b/docs/analytics/overview.mdx
@@ -24,25 +24,10 @@ values={[
 </TabItem>
 <TabItem value="null-safe">
 
-:::caution
-This package version is not null safe migrated yet, but has been implemented to be compatible with other null safe FlutterFire packages.
-Null safety is now available in Flutter's `stable` channel for Web, Android & iOS targets.
-:::
-
-#### Flutter Web, Android & iOS targets:
-
-Web, Android & iOS targets require the Flutter `stable` channel:
+Ensure you're using the Flutter `stable` channel:
 
 ```bash
 $ flutter channel stable
-```
-
-#### Flutter desktop targets:
-
-Desktop targets such as macOS requires  the Flutter `beta` channel:
-
-```bash
-$ flutter channel beta
 ```
 
 If your app is mixing legacy and null-safe packages, use the `--no-sound-null-safety` flag:

--- a/docs/auth/overview.mdx
+++ b/docs/auth/overview.mdx
@@ -33,18 +33,18 @@ To develop in a null-safe environment, it is a prerequisite to switch to the cor
 
 #### Flutter Web, Android & iOS targets:
 
-Web, Android & iOS targets require the Flutter `beta` channel:
+Web, Android & iOS targets require the Flutter `stable` channel:
 
 ```bash
-$ flutter channel beta
+$ flutter channel stable
 ```
 
 #### Flutter desktop targets:
 
-Desktop targets such as macOS requires  the Flutter `dev` channel:
+Desktop targets such as macOS requires  the Flutter `beta` channel:
 
 ```bash
-$ flutter channel dev
+$ flutter channel beta
 ```
 
 If your app is mixing legacy and null-safe packages, use the `--no-sound-null-safety` flag:

--- a/docs/auth/overview.mdx
+++ b/docs/auth/overview.mdx
@@ -29,22 +29,10 @@ values={[
 
 <TabItem value="null-safe">
 
-To develop in a null-safe environment, it is a prerequisite to switch to the correct Flutter channel.
-
-#### Flutter Web, Android & iOS targets:
-
-Web, Android & iOS targets require the Flutter `stable` channel:
+Ensure you're using the Flutter `stable` channel:
 
 ```bash
 $ flutter channel stable
-```
-
-#### Flutter desktop targets:
-
-Desktop targets such as macOS requires  the Flutter `beta` channel:
-
-```bash
-$ flutter channel beta
 ```
 
 If your app is mixing legacy and null-safe packages, use the `--no-sound-null-safety` flag:

--- a/docs/core/usage.mdx
+++ b/docs/core/usage.mdx
@@ -24,22 +24,10 @@ values={[
 </TabItem>
 <TabItem value="null-safe">
 
-To develop in a null-safe environment, it is a prerequisite to switch to the correct Flutter channel.
-
-#### Flutter Web, Android & iOS targets:
-
-Web, Android & iOS targets require the Flutter `stable` channel:
+Ensure you're using the Flutter `stable` channel:
 
 ```bash
 $ flutter channel stable
-```
-
-#### Flutter desktop targets:
-
-Desktop targets such as macOS requires  the Flutter `beta` channel:
-
-```bash
-$ flutter channel beta
 ```
 
 If your app is mixing legacy and null-safe packages, use the `--no-sound-null-safety` flag:

--- a/docs/core/usage.mdx
+++ b/docs/core/usage.mdx
@@ -28,18 +28,18 @@ To develop in a null-safe environment, it is a prerequisite to switch to the cor
 
 #### Flutter Web, Android & iOS targets:
 
-Web, Android & iOS targets require the Flutter `beta` channel:
+Web, Android & iOS targets require the Flutter `stable` channel:
 
 ```bash
-$ flutter channel beta
+$ flutter channel stable
 ```
 
 #### Flutter desktop targets:
 
-Desktop targets such as macOS requires  the Flutter `dev` channel:
+Desktop targets such as macOS requires  the Flutter `beta` channel:
 
 ```bash
-$ flutter channel dev
+$ flutter channel beta
 ```
 
 If your app is mixing legacy and null-safe packages, use the `--no-sound-null-safety` flag:

--- a/docs/crashlytics/overview.mdx
+++ b/docs/crashlytics/overview.mdx
@@ -31,18 +31,18 @@ To develop in a null-safe environment, it is a prerequisite to switch to the cor
 
 #### Flutter Web, Android & iOS targets:
 
-Web, Android & iOS targets require the Flutter `beta` channel:
+Web, Android & iOS targets require the Flutter `stable` channel:
 
 ```bash
-$ flutter channel beta
+$ flutter channel stable
 ```
 
 #### Flutter desktop targets:
 
-Desktop targets such as macOS requires  the Flutter `dev` channel:
+Desktop targets such as macOS requires  the Flutter `beta` channel:
 
 ```bash
-$ flutter channel dev
+$ flutter channel beta
 ```
 
 If your app is mixing legacy and null-safe packages, use the `--no-sound-null-safety` flag:

--- a/docs/crashlytics/overview.mdx
+++ b/docs/crashlytics/overview.mdx
@@ -27,22 +27,10 @@ values={[
 </TabItem>
 <TabItem value="null-safe">
 
-To develop in a null-safe environment, it is a prerequisite to switch to the correct Flutter channel.
-
-#### Flutter Web, Android & iOS targets:
-
-Web, Android & iOS targets require the Flutter `stable` channel:
+Ensure you're using the Flutter `stable` channel:
 
 ```bash
 $ flutter channel stable
-```
-
-#### Flutter desktop targets:
-
-Desktop targets such as macOS requires  the Flutter `beta` channel:
-
-```bash
-$ flutter channel beta
 ```
 
 If your app is mixing legacy and null-safe packages, use the `--no-sound-null-safety` flag:

--- a/docs/database/overview.mdx
+++ b/docs/database/overview.mdx
@@ -29,20 +29,10 @@ values={[
 This package version is not null safe migrated yet, but has been implemented to be compatible with other null safe FlutterFire packages.
 :::
 
-#### Flutter Web, Android & iOS targets:
-
-Web, Android & iOS targets require the Flutter `stable` channel:
+Ensure you're using the Flutter `stable` channel:
 
 ```bash
 $ flutter channel stable
-```
-
-#### Flutter desktop targets:
-
-Desktop targets such as macOS requires  the Flutter `beta` channel:
-
-```bash
-$ flutter channel beta
 ```
 
 If your app is mixing legacy and null-safe packages, use the `--no-sound-null-safety` flag:

--- a/docs/database/overview.mdx
+++ b/docs/database/overview.mdx
@@ -27,23 +27,23 @@ values={[
 
 :::caution
 This package version is not null safe migrated yet, but has been implemented to be compatible with other null safe FlutterFire packages.
-With that in mind, you will need to use the `beta` channel which supports null safe projects.
+Null safety is now available in Flutter's  `stable` channel for Web, Android & iOS targets.
 :::
 
 #### Flutter Web, Android & iOS targets:
 
-Web, Android & iOS targets require the Flutter `beta` channel:
+Web, Android & iOS targets require the Flutter `stable` channel:
 
 ```bash
-$ flutter channel beta
+$ flutter channel stable
 ```
 
 #### Flutter desktop targets:
 
-Desktop targets such as macOS requires  the Flutter `dev` channel:
+Desktop targets such as macOS requires  the Flutter `beta` channel:
 
 ```bash
-$ flutter channel dev
+$ flutter channel beta
 ```
 
 If your app is mixing legacy and null-safe packages, use the `--no-sound-null-safety` flag:

--- a/docs/database/overview.mdx
+++ b/docs/database/overview.mdx
@@ -27,7 +27,7 @@ values={[
 
 :::caution
 This package version is not null safe migrated yet, but has been implemented to be compatible with other null safe FlutterFire packages.
-Null safety is now available in Flutter's  `stable` channel for Web, Android & iOS targets.
+Null safety is now available in Flutter's `stable` channel for Web, Android & iOS targets.
 :::
 
 #### Flutter Web, Android & iOS targets:

--- a/docs/database/overview.mdx
+++ b/docs/database/overview.mdx
@@ -27,7 +27,6 @@ values={[
 
 :::caution
 This package version is not null safe migrated yet, but has been implemented to be compatible with other null safe FlutterFire packages.
-Null safety is now available in Flutter's `stable` channel for Web, Android & iOS targets.
 :::
 
 #### Flutter Web, Android & iOS targets:

--- a/docs/firestore/overview.mdx
+++ b/docs/firestore/overview.mdx
@@ -24,30 +24,16 @@ values={[
 </TabItem>
 <TabItem value="null-safe">
 
-
-To develop in a null-safe environment, it is a prerequisite to switch to the correct Flutter channel.
-
-#### Flutter Web, Android & iOS targets:
-
-Web, Android & iOS targets require the Flutter `stable` channel:
+Ensure you're using the Flutter `stable` channel:
 
 ```bash
 $ flutter channel stable
-```
-
-#### Flutter desktop targets:
-
-Desktop targets such as macOS requires  the Flutter `beta` channel:
-
-```bash
-$ flutter channel beta
 ```
 
 If your app is mixing legacy and null-safe packages, use the `--no-sound-null-safety` flag:
 ```bash
 $ flutter run --no-sound-null-safety
 ```
-
 For legacy package imports, place the following ignore comment to hide Dart analyzer warnings:
 
 ```dart

--- a/docs/firestore/overview.mdx
+++ b/docs/firestore/overview.mdx
@@ -29,18 +29,18 @@ To develop in a null-safe environment, it is a prerequisite to switch to the cor
 
 #### Flutter Web, Android & iOS targets:
 
-Web, Android & iOS targets require the Flutter `beta` channel:
+Web, Android & iOS targets require the Flutter `stable` channel:
 
 ```bash
-$ flutter channel beta
+$ flutter channel stable
 ```
 
 #### Flutter desktop targets:
 
-Desktop targets such as macOS requires  the Flutter `dev` channel:
+Desktop targets such as macOS requires  the Flutter `beta` channel:
 
 ```bash
-$ flutter channel dev
+$ flutter channel beta
 ```
 
 If your app is mixing legacy and null-safe packages, use the `--no-sound-null-safety` flag:

--- a/docs/functions/overview.mdx
+++ b/docs/functions/overview.mdx
@@ -34,18 +34,18 @@ To develop in a null-safe environment, it is a prerequisite to switch to the cor
 
 #### Flutter Web, Android & iOS targets:
 
-Web, Android & iOS targets require the Flutter `beta` channel:
+Web, Android & iOS targets require the Flutter `stable` channel:
 
 ```bash
-$ flutter channel beta
+$ flutter channel stable
 ```
 
 #### Flutter desktop targets:
 
-Desktop targets such as macOS requires  the Flutter `dev` channel:
+Desktop targets such as macOS requires  the Flutter `beta` channel:
 
 ```bash
-$ flutter channel dev
+$ flutter channel beta
 ```
 
 If your app is mixing legacy and null-safe packages, use the `--no-sound-null-safety` flag:

--- a/docs/functions/overview.mdx
+++ b/docs/functions/overview.mdx
@@ -29,23 +29,10 @@ values={[
 </TabItem>
 <TabItem value="null-safe">
 
-
-To develop in a null-safe environment, it is a prerequisite to switch to the correct Flutter channel.
-
-#### Flutter Web, Android & iOS targets:
-
-Web, Android & iOS targets require the Flutter `stable` channel:
+Ensure you're using the Flutter `stable` channel:
 
 ```bash
 $ flutter channel stable
-```
-
-#### Flutter desktop targets:
-
-Desktop targets such as macOS requires  the Flutter `beta` channel:
-
-```bash
-$ flutter channel beta
 ```
 
 If your app is mixing legacy and null-safe packages, use the `--no-sound-null-safety` flag:

--- a/docs/messaging/overview.mdx
+++ b/docs/messaging/overview.mdx
@@ -32,18 +32,18 @@ To develop in a null-safe environment, it is a prerequisite to switch to the cor
 
 #### Flutter Web, Android & iOS targets:
 
-Web, Android & iOS targets require the Flutter `beta` channel:
+Web, Android & iOS targets require the Flutter `stable` channel:
 
 ```bash
-$ flutter channel beta
+$ flutter channel stable
 ```
 
 #### Flutter desktop targets:
 
-Desktop targets such as macOS requires  the Flutter `dev` channel:
+Desktop targets such as macOS requires  the Flutter `beta` channel:
 
 ```bash
-$ flutter channel dev
+$ flutter channel beta
 ```
 
 If your app is mixing legacy and null-safe packages, use the `--no-sound-null-safety` flag:

--- a/docs/messaging/overview.mdx
+++ b/docs/messaging/overview.mdx
@@ -27,23 +27,10 @@ values={[
 </TabItem>
 <TabItem value="null-safe">
 
-
-To develop in a null-safe environment, it is a prerequisite to switch to the correct Flutter channel.
-
-#### Flutter Web, Android & iOS targets:
-
-Web, Android & iOS targets require the Flutter `stable` channel:
+Ensure you're using the Flutter `stable` channel:
 
 ```bash
 $ flutter channel stable
-```
-
-#### Flutter desktop targets:
-
-Desktop targets such as macOS requires  the Flutter `beta` channel:
-
-```bash
-$ flutter channel beta
 ```
 
 If your app is mixing legacy and null-safe packages, use the `--no-sound-null-safety` flag:

--- a/docs/performance/overview.mdx
+++ b/docs/performance/overview.mdx
@@ -25,7 +25,6 @@ values={[
 
 :::caution
 This package version is not null safe migrated yet, but has been implemented to be compatible with other null safe FlutterFire packages.
-Null safety is now available in Flutter's `stable` channel for Web, Android & iOS targets.
 :::
 
 #### Flutter Web, Android & iOS targets:

--- a/docs/performance/overview.mdx
+++ b/docs/performance/overview.mdx
@@ -25,23 +25,23 @@ values={[
 
 :::caution
 This package version is not null safe migrated yet, but has been implemented to be compatible with other null safe FlutterFire packages.
-With that in mind, you will need to use the `beta` channel which supports null safe projects.
+Null safety is now available in Flutter's  `stable` channel for Web, Android & iOS targets.
 :::
 
 #### Flutter Web, Android & iOS targets:
 
-Web, Android & iOS targets require the Flutter `beta` channel:
+Web, Android & iOS targets require the Flutter `stable` channel:
 
 ```bash
-$ flutter channel beta
+$ flutter channel stable
 ```
 
 #### Flutter desktop targets:
 
-Desktop targets such as macOS requires  the Flutter `dev` channel:
+Desktop targets such as macOS requires  the Flutter `beta` channel:
 
 ```bash
-$ flutter channel dev
+$ flutter channel beta
 ```
 
 If your app is mixing legacy and null-safe packages, use the `--no-sound-null-safety` flag:

--- a/docs/performance/overview.mdx
+++ b/docs/performance/overview.mdx
@@ -27,20 +27,10 @@ values={[
 This package version is not null safe migrated yet, but has been implemented to be compatible with other null safe FlutterFire packages.
 :::
 
-#### Flutter Web, Android & iOS targets:
-
-Web, Android & iOS targets require the Flutter `stable` channel:
+Ensure you're using the Flutter `stable` channel:
 
 ```bash
 $ flutter channel stable
-```
-
-#### Flutter desktop targets:
-
-Desktop targets such as macOS requires  the Flutter `beta` channel:
-
-```bash
-$ flutter channel beta
 ```
 
 If your app is mixing legacy and null-safe packages, use the `--no-sound-null-safety` flag:

--- a/docs/performance/overview.mdx
+++ b/docs/performance/overview.mdx
@@ -25,7 +25,7 @@ values={[
 
 :::caution
 This package version is not null safe migrated yet, but has been implemented to be compatible with other null safe FlutterFire packages.
-Null safety is now available in Flutter's  `stable` channel for Web, Android & iOS targets.
+Null safety is now available in Flutter's `stable` channel for Web, Android & iOS targets.
 :::
 
 #### Flutter Web, Android & iOS targets:

--- a/docs/remote-config/overview.mdx
+++ b/docs/remote-config/overview.mdx
@@ -29,7 +29,7 @@ values={[
 
 :::caution
 This package version is not null safe migrated yet, but has been implemented to be compatible with other null safe FlutterFire packages.
-Null safety is now available in Flutter's  `stable` channel for Web, Android & iOS targets.
+Null safety is now available in Flutter's `stable` channel for Web, Android & iOS targets.
 :::
 
 #### Flutter Web, Android & iOS targets:

--- a/docs/remote-config/overview.mdx
+++ b/docs/remote-config/overview.mdx
@@ -31,20 +31,10 @@ values={[
 This package version is not null safe migrated yet, but has been implemented to be compatible with other null safe FlutterFire packages.
 :::
 
-#### Flutter Web, Android & iOS targets:
-
-Web, Android & iOS targets require the Flutter `stable` channel:
+Ensure you're using the Flutter `stable` channel:
 
 ```bash
 $ flutter channel stable
-```
-
-#### Flutter desktop targets:
-
-Desktop targets such as macOS requires  the Flutter `beta` channel:
-
-```bash
-$ flutter channel beta
 ```
 
 If your app is mixing legacy and null-safe packages, use the `--no-sound-null-safety` flag:

--- a/docs/remote-config/overview.mdx
+++ b/docs/remote-config/overview.mdx
@@ -29,23 +29,23 @@ values={[
 
 :::caution
 This package version is not null safe migrated yet, but has been implemented to be compatible with other null safe FlutterFire packages.
-With that in mind, you will need to use the `beta` channel which supports null safe projects.
+Null safety is now available in Flutter's  `stable` channel for Web, Android & iOS targets.
 :::
 
 #### Flutter Web, Android & iOS targets:
 
-Web, Android & iOS targets require the Flutter `beta` channel:
+Web, Android & iOS targets require the Flutter `stable` channel:
 
 ```bash
-$ flutter channel beta
+$ flutter channel stable
 ```
 
 #### Flutter desktop targets:
 
-Desktop targets such as macOS requires  the Flutter `dev` channel:
+Desktop targets such as macOS requires  the Flutter `beta` channel:
 
 ```bash
-$ flutter channel dev
+$ flutter channel beta
 ```
 
 If your app is mixing legacy and null-safe packages, use the `--no-sound-null-safety` flag:

--- a/docs/remote-config/overview.mdx
+++ b/docs/remote-config/overview.mdx
@@ -29,7 +29,6 @@ values={[
 
 :::caution
 This package version is not null safe migrated yet, but has been implemented to be compatible with other null safe FlutterFire packages.
-Null safety is now available in Flutter's `stable` channel for Web, Android & iOS targets.
 :::
 
 #### Flutter Web, Android & iOS targets:

--- a/docs/storage/overview.mdx
+++ b/docs/storage/overview.mdx
@@ -27,18 +27,18 @@ To develop in a null-safe environment, it is a prerequisite to switch to the cor
 
 #### Flutter Web, Android & iOS targets:
 
-Web, Android & iOS targets require the Flutter `beta` channel:
+Web, Android & iOS targets require the Flutter `stable` channel:
 
 ```bash
-$ flutter channel beta
+$ flutter channel stable
 ```
 
 #### Flutter desktop targets:
 
-Desktop targets such as macOS requires  the Flutter `dev` channel:
+Desktop targets such as macOS requires  the Flutter `beta` channel:
 
 ```bash
-$ flutter channel dev
+$ flutter channel beta
 ```
 
 If your app is mixing legacy and null-safe packages, use the `--no-sound-null-safety` flag:

--- a/docs/storage/overview.mdx
+++ b/docs/storage/overview.mdx
@@ -23,22 +23,10 @@ values={[
 </TabItem>
 <TabItem value="null-safe">
 
-To develop in a null-safe environment, it is a prerequisite to switch to the correct Flutter channel.
-
-#### Flutter Web, Android & iOS targets:
-
-Web, Android & iOS targets require the Flutter `stable` channel:
+Ensure you're using the Flutter `stable` channel:
 
 ```bash
 $ flutter channel stable
-```
-
-#### Flutter desktop targets:
-
-Desktop targets such as macOS requires  the Flutter `beta` channel:
-
-```bash
-$ flutter channel beta
 ```
 
 If your app is mixing legacy and null-safe packages, use the `--no-sound-null-safety` flag:

--- a/website/api.js
+++ b/website/api.js
@@ -60,7 +60,7 @@ async function fetchPluginVersions(plugin) {
     if (nsIndex === 0) {
       return ['', nsVersions[0]];
     }
-    
+
     return [sorted[nsIndex - 1], nsVersions[nsVersions.length - 1]];
   } catch (e) {
     console.log(`Failed to load version for plugin "${plugin}".`);

--- a/website/plugins.js
+++ b/website/plugins.js
@@ -15,7 +15,7 @@ module.exports = [
     name: 'Analytics',
     pub: 'firebase_analytics',
     firebase: 'analytics',
-    documentation:'https://firebase.flutter.dev/docs/analytics/overview',
+    documentation: 'https://firebase.flutter.dev/docs/analytics/overview',
     support: {
       web: true,
       mobile: true,
@@ -26,7 +26,7 @@ module.exports = [
     name: 'Authentication',
     pub: 'firebase_auth',
     firebase: 'auth',
-    documentation:'https://firebase.flutter.dev/docs/auth/overview',
+    documentation: 'https://firebase.flutter.dev/docs/auth/overview',
     support: {
       web: true,
       mobile: true,
@@ -37,7 +37,7 @@ module.exports = [
     name: 'Cloud Firestore',
     pub: 'cloud_firestore',
     firebase: 'firestore',
-    documentation:'https://firebase.flutter.dev/docs/firestore/overview',
+    documentation: 'https://firebase.flutter.dev/docs/firestore/overview',
     support: {
       web: true,
       mobile: true,
@@ -48,7 +48,7 @@ module.exports = [
     name: 'Cloud Functions',
     pub: 'cloud_functions',
     firebase: 'functions',
-    documentation:'https://firebase.flutter.dev/docs/functions/overview',
+    documentation: 'https://firebase.flutter.dev/docs/functions/overview',
     support: {
       web: true,
       mobile: true,
@@ -59,7 +59,7 @@ module.exports = [
     name: 'Cloud Messaging',
     pub: 'firebase_messaging',
     firebase: 'cloud-messaging',
-    documentation:'https://firebase.flutter.dev/docs/messaging/overview',
+    documentation: 'https://firebase.flutter.dev/docs/messaging/overview',
     support: {
       web: true,
       mobile: true,
@@ -70,7 +70,7 @@ module.exports = [
     name: 'Cloud Storage',
     pub: 'firebase_storage',
     firebase: 'storage',
-    documentation:'https://firebase.flutter.dev/docs/storage/overview',
+    documentation: 'https://firebase.flutter.dev/docs/storage/overview',
     support: {
       web: true,
       mobile: true,
@@ -81,7 +81,7 @@ module.exports = [
     name: 'Core',
     pub: 'firebase_core',
     firebase: '',
-    documentation:'https://firebase.flutter.dev/docs/core/usage',
+    documentation: 'https://firebase.flutter.dev/docs/core/usage',
     support: {
       web: true,
       mobile: true,
@@ -92,7 +92,7 @@ module.exports = [
     name: 'Crashlytics',
     pub: 'firebase_crashlytics',
     firebase: 'crashlytics',
-    documentation:'https://firebase.flutter.dev/docs/crashlytics/overview',
+    documentation: 'https://firebase.flutter.dev/docs/crashlytics/overview',
     support: {
       web: false,
       mobile: true,
@@ -103,7 +103,7 @@ module.exports = [
     name: 'Realtime Database',
     pub: 'firebase_database',
     firebase: 'database',
-    documentation:'https://firebase.flutter.dev/docs/database/overview',
+    documentation: 'https://firebase.flutter.dev/docs/database/overview',
     support: {
       web: false,
       mobile: true,
@@ -114,7 +114,7 @@ module.exports = [
     name: 'Dynamic Links',
     pub: 'firebase_dynamic_links',
     firebase: 'dynamic-links',
-    documentation:'',
+    documentation: '',
     support: {
       web: false,
       mobile: true,
@@ -136,7 +136,7 @@ module.exports = [
     name: 'In-App Messaging',
     pub: 'firebase_in_app_messaging',
     firebase: 'in-app-messaging',
-    documentation:'',
+    documentation: '',
     support: {
       web: false,
       mobile: true,
@@ -158,7 +158,7 @@ module.exports = [
     name: 'ML Kit Vision',
     pub: 'firebase_ml_vision',
     firebase: 'ml-kit',
-    documentation:'',
+    documentation: '',
     support: {
       web: false,
       mobile: true,
@@ -169,7 +169,7 @@ module.exports = [
     name: 'Performance Monitoring',
     pub: 'firebase_performance',
     firebase: 'performance',
-    documentation:'https://firebase.flutter.dev/docs/performance/overview',
+    documentation: 'https://firebase.flutter.dev/docs/performance/overview',
     support: {
       web: false,
       mobile: true,
@@ -180,7 +180,7 @@ module.exports = [
     name: 'Remote Config',
     pub: 'firebase_remote_config',
     firebase: 'remote-config',
-    documentation:'https://firebase.flutter.dev/docs/remote-config/overview',
+    documentation: 'https://firebase.flutter.dev/docs/remote-config/overview',
     support: {
       web: false,
       mobile: true,


### PR DESCRIPTION
## Description

Null safety is now available in the `stable` Flutter channel for Web, Android & iOS targets.

~~Null-safe support for [Desktop](https://flutter.dev/desktop) is in `beta` (although there is a "snapshot" in `stable`, I figure it is best to point users to the channel which will be regularly updated).~~

Also documented its availability for Desktop even if it is a "snapshot".

## Related Issues

*Replace this paragraph with a list of issues related to this PR from the [issue database](https://github.com/flutter/flutter/issues). Indicate, which of these issues are resolved or fixed by this PR. Note that you'll have to prefix the issue numbers with flutter/flutter#.*

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
