### PR TITLE
fix(*): operator `==` takes `Object` parameter

### DIFF
--- a/packages/cloud_firestore/cloud_firestore/lib/src/collection_reference.dart
+++ b/packages/cloud_firestore/cloud_firestore/lib/src/collection_reference.dart
@@ -65,7 +65,7 @@ class CollectionReference extends Query {
   }
 
   @override
-  bool operator ==(dynamic other) =>
+  bool operator ==(Object other) =>
       other is CollectionReference &&
       other.firestore == firestore &&
       other.path == path;

--- a/packages/cloud_firestore/cloud_firestore/lib/src/document_reference.dart
+++ b/packages/cloud_firestore/cloud_firestore/lib/src/document_reference.dart
@@ -88,7 +88,7 @@ class DocumentReference {
 
   @override
   // ignore: avoid_equals_and_hash_code_on_mutable_classes
-  bool operator ==(dynamic other) =>
+  bool operator ==(Object other) =>
       other is DocumentReference &&
       other.firestore == firestore &&
       other.path == path;

--- a/packages/cloud_firestore/cloud_firestore/lib/src/firestore.dart
+++ b/packages/cloud_firestore/cloud_firestore/lib/src/firestore.dart
@@ -207,7 +207,7 @@ class FirebaseFirestore extends FirebasePluginPlatform {
 
   @override
   // ignore: avoid_equals_and_hash_code_on_mutable_classes
-  bool operator ==(dynamic other) =>
+  bool operator ==(Object other) =>
       other is FirebaseFirestore && other.app.name == app.name;
 
   @override

--- a/packages/cloud_firestore/cloud_firestore_platform_interface/lib/src/blob.dart
+++ b/packages/cloud_firestore/cloud_firestore_platform_interface/lib/src/blob.dart
@@ -19,7 +19,7 @@ class Blob {
   final Uint8List bytes;
 
   @override
-  bool operator ==(dynamic other) =>
+  bool operator ==(Object other) =>
       other is Blob &&
       const DeepCollectionEquality().equals(other.bytes, bytes);
 

--- a/packages/cloud_firestore/cloud_firestore_platform_interface/lib/src/field_path.dart
+++ b/packages/cloud_firestore/cloud_firestore_platform_interface/lib/src/field_path.dart
@@ -50,7 +50,7 @@ class FieldPath {
         assert(!path.contains(']'), _reserved);
 
   @override
-  bool operator ==(dynamic other) =>
+  bool operator ==(Object other) =>
       other is FieldPath &&
       const ListEquality().equals(other.components, components);
 

--- a/packages/cloud_firestore/cloud_firestore_platform_interface/lib/src/geo_point.dart
+++ b/packages/cloud_firestore/cloud_firestore_platform_interface/lib/src/geo_point.dart
@@ -18,7 +18,7 @@ class GeoPoint {
   final double longitude; // ignore: public_member_api_docs
 
   @override
-  bool operator ==(dynamic other) =>
+  bool operator ==(Object other) =>
       other is GeoPoint &&
       other.latitude == latitude &&
       other.longitude == longitude;

--- a/packages/cloud_firestore/cloud_firestore_platform_interface/lib/src/internal/pointer.dart
+++ b/packages/cloud_firestore/cloud_firestore_platform_interface/lib/src/internal/pointer.dart
@@ -73,7 +73,7 @@ class Pointer {
   }
 
   @override
-  bool operator ==(dynamic other) => other is Pointer && other.path == path;
+  bool operator ==(Object other) => other is Pointer && other.path == path;
 
   @override
   int get hashCode => path.hashCode;

--- a/packages/cloud_firestore/cloud_firestore_platform_interface/lib/src/method_channel/method_channel_field_value.dart
+++ b/packages/cloud_firestore/cloud_firestore_platform_interface/lib/src/method_channel/method_channel_field_value.dart
@@ -44,7 +44,7 @@ class MethodChannelFieldValue {
   final dynamic value;
 
   @override
-  bool operator ==(dynamic other) =>
+  bool operator ==(Object other) =>
       other is MethodChannelFieldValue &&
       other.type == type &&
       const DeepCollectionEquality().equals(other.value, value);

--- a/packages/cloud_firestore/cloud_firestore_platform_interface/lib/src/settings.dart
+++ b/packages/cloud_firestore/cloud_firestore_platform_interface/lib/src/settings.dart
@@ -53,7 +53,7 @@ class Settings {
   }
 
   @override
-  bool operator ==(dynamic other) =>
+  bool operator ==(Object other) =>
       other is Settings && other.asMap.toString() == asMap.toString();
 
   @override

--- a/packages/cloud_firestore/cloud_firestore_platform_interface/lib/src/timestamp.dart
+++ b/packages/cloud_firestore/cloud_firestore_platform_interface/lib/src/timestamp.dart
@@ -87,7 +87,7 @@ class Timestamp implements Comparable<Timestamp> {
   int get hashCode => hashValues(seconds, nanoseconds);
 
   @override
-  bool operator ==(dynamic other) =>
+  bool operator ==(Object other) =>
       other is Timestamp &&
       other.seconds == seconds &&
       other.nanoseconds == nanoseconds;

--- a/packages/cloud_firestore/cloud_firestore_web/lib/src/field_value_web.dart
+++ b/packages/cloud_firestore/cloud_firestore_web/lib/src/field_value_web.dart
@@ -17,7 +17,7 @@ class FieldValueWeb {
 
   @override
   //ignore: avoid_equals_and_hash_code_on_mutable_classes
-  bool operator ==(dynamic other) =>
+  bool operator ==(Object other) =>
       other is FieldValueWeb && other.data == data;
 
   @override

--- a/packages/firebase_core/firebase_core/lib/src/firebase.dart
+++ b/packages/firebase_core/firebase_core/lib/src/firebase.dart
@@ -59,7 +59,7 @@ class Firebase {
   // TODO(rrousselGit): remove ==/hashCode
   @override
   // ignore: avoid_equals_and_hash_code_on_mutable_classes
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     if (identical(this, other)) return true;
     if (other is! Firebase) return false;
     return other.hashCode == hashCode;

--- a/packages/firebase_core/firebase_core/lib/src/firebase_app.dart
+++ b/packages/firebase_core/firebase_core/lib/src/firebase_app.dart
@@ -56,7 +56,7 @@ class FirebaseApp {
 
   @override
   // ignore: avoid_equals_and_hash_code_on_mutable_classes
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     if (identical(this, other)) return true;
     if (other is! FirebaseApp) return false;
     return other.name == name && other.options == options;

--- a/packages/firebase_core/firebase_core/test/firebase_core_test.dart
+++ b/packages/firebase_core/firebase_core/test/firebase_core_test.dart
@@ -114,7 +114,7 @@ class MockFirebaseCore extends Mock
 class FakeFirebaseAppPlatform extends Fake implements FirebaseAppPlatform {
   @override
   // ignore: avoid_equals_and_hash_code_on_mutable_classes, hash_and_equals
-  bool operator ==(Object? other) {
+  bool operator ==(Object other) {
     return super == other;
   }
 }

--- a/packages/firebase_core/firebase_core/test/firebase_core_test.dart
+++ b/packages/firebase_core/firebase_core/test/firebase_core_test.dart
@@ -111,10 +111,4 @@ class MockFirebaseCore extends Mock
 }
 
 // ignore: avoid_implementing_value_types
-class FakeFirebaseAppPlatform extends Fake implements FirebaseAppPlatform {
-  @override
-  // ignore: avoid_equals_and_hash_code_on_mutable_classes, hash_and_equals
-  bool operator ==(Object other) {
-    return super == other;
-  }
-}
+class FakeFirebaseAppPlatform extends Fake implements FirebaseAppPlatform {}

--- a/packages/firebase_core/firebase_core_platform_interface/lib/src/firebase_exception.dart
+++ b/packages/firebase_core/firebase_core_platform_interface/lib/src/firebase_exception.dart
@@ -54,7 +54,7 @@ class FirebaseException implements Exception {
   final StackTrace? stackTrace;
 
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     if (identical(this, other)) return true;
     if (other is! FirebaseException) return false;
     return other.hashCode == hashCode;

--- a/packages/firebase_core/firebase_core_platform_interface/lib/src/firebase_options.dart
+++ b/packages/firebase_core/firebase_core_platform_interface/lib/src/firebase_options.dart
@@ -165,7 +165,7 @@ class FirebaseOptions {
 
   // Required from `fromMap` comparison
   @override
-  bool operator ==(dynamic other) {
+  bool operator ==(Object other) {
     if (identical(this, other)) return true;
     if (other is! FirebaseOptions) return false;
     return other.asMap.toString() == asMap.toString();

--- a/packages/firebase_core/firebase_core_platform_interface/lib/src/platform_interface/platform_interface_firebase_app.dart
+++ b/packages/firebase_core/firebase_core_platform_interface/lib/src/platform_interface/platform_interface_firebase_app.dart
@@ -60,7 +60,7 @@ class FirebaseAppPlatform extends PlatformInterface {
 
   @override
   // ignore: avoid_equals_and_hash_code_on_mutable_classes
-  bool operator ==(Object? other) {
+  bool operator ==(Object other) {
     if (identical(this, other)) return true;
     if (other is! FirebaseAppPlatform) return false;
     return other.name == name && other.options == options;

--- a/packages/firebase_core/firebase_core_platform_interface/test/platform_interface_tests/platform_interface_firebase_core_test.dart
+++ b/packages/firebase_core/firebase_core_platform_interface/test/platform_interface_tests/platform_interface_firebase_core_test.dart
@@ -55,7 +55,7 @@ class ImplementsFirebasePlatform implements FirebasePlatform {
 class FakeFirebaseAppPlatform extends Fake implements FirebaseAppPlatform {
   @override
   // ignore: avoid_equals_and_hash_code_on_mutable_classes, hash_and_equals, false positive
-  bool operator ==(Object? other) {
+  bool operator ==(Object other) {
     return super == other;
   }
 }

--- a/packages/firebase_core/firebase_core_platform_interface/test/platform_interface_tests/platform_interface_firebase_core_test.dart
+++ b/packages/firebase_core/firebase_core_platform_interface/test/platform_interface_tests/platform_interface_firebase_core_test.dart
@@ -52,13 +52,7 @@ class ImplementsFirebasePlatform implements FirebasePlatform {
 }
 
 // ignore: avoid_implementing_value_types
-class FakeFirebaseAppPlatform extends Fake implements FirebaseAppPlatform {
-  @override
-  // ignore: avoid_equals_and_hash_code_on_mutable_classes, hash_and_equals, false positive
-  bool operator ==(Object other) {
-    return super == other;
-  }
-}
+class FakeFirebaseAppPlatform extends Fake implements FirebaseAppPlatform {}
 
 class ExtendsFirebasePlatform extends FirebasePlatform {}
 

--- a/packages/firebase_storage/firebase_storage/lib/src/firebase_storage.dart
+++ b/packages/firebase_storage/firebase_storage/lib/src/firebase_storage.dart
@@ -150,7 +150,7 @@ class FirebaseStorage extends FirebasePluginPlatform {
   }
 
   @override
-  bool operator ==(Object? other) =>
+  bool operator ==(Object other) =>
       other is FirebaseStorage &&
       other.app.name == app.name &&
       other.bucket == bucket;

--- a/packages/firebase_storage/firebase_storage/lib/src/reference.dart
+++ b/packages/firebase_storage/firebase_storage/lib/src/reference.dart
@@ -195,7 +195,7 @@ class Reference {
   }
 
   @override
-  bool operator ==(Object? other) =>
+  bool operator ==(Object other) =>
       other is Reference &&
       other.fullPath == fullPath &&
       other.storage == storage;


### PR DESCRIPTION
## Description

Replace `operator ==(dynamic other)` with `operator ==(Object other)` everywhere.

If this seems reasonable, I'll follow up on the checklist.

## Related Issues

Fixes #5288

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [ ] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
