### PR TITLE
docs: Refer to Authentication emulator in docs

### DIFF
--- a/docs/auth/usage.mdx
+++ b/docs/auth/usage.mdx
@@ -484,7 +484,7 @@ Future<void> linkGoogleAndTwitter() async {
 
 ### Emulator Usage
 
-If you are using the local Cloud Functions emulators, then it is possible to connect to these using the `useEmulator` method.
+If you are using the local Authentication emulator, then it is possible to connect to this using the `useEmulator` method.
 Ensure you pass the correct port on which the Firebase emulator is running on.
 Ensure you have enabled network connections to the emulators in your apps following the emulator usage instructions in the general FlutterFire installation notes for each operating system.
 


### PR DESCRIPTION
## Description

In the documentation for Authentication under the Emulator Usage there is an instruction on how to use the emulator. This section seems to be copied from the instructions for Cloud Functions and is suggesting you can connect to the cloud functions emulator from the firebase authentication package. 

## Related Issues

*Replace this paragraph with a list of issues related to this PR from the [issue database](https://github.com/flutter/flutter/issues). Indicate, which of these issues are resolved or fixed by this PR. Note that you'll have to prefix the issue numbers with flutter/flutter#.*

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
