### PR TITLE
docs: Add firebase_dynamic_links to non-null-safe list

### DIFF
--- a/docs/null-safety.mdx
+++ b/docs/null-safety.mdx
@@ -29,6 +29,7 @@ The below table outlines the latest FlutterFire packages that **are not** null-s
 |    `firebase_database` |    `^{{ plugins.firebase_database_ns }}` |
 | `firebase_performance` | `^{{ plugins.firebase_performance_ns }}` |
 |`firebase_remote_config`|`^{{ plugins.firebase_remote_config_ns }}`|
+|`firebase_dynamic_links`|`^{{ plugins.firebase_dynamic_links_ns }}`|
 
 
 ---


### PR DESCRIPTION
## Description

Add firebase_dynamic_links library to non-null-safe FlutterFire packages list. It was missing in the documentation.

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
