### PR TITLE
feat(messaging): android.tag property on Notification

### DIFF
--- a/packages/firebase_messaging/firebase_messaging/android/src/main/java/io/flutter/plugins/firebase/messaging/FlutterFirebaseMessagingUtils.java
+++ b/packages/firebase_messaging/firebase_messaging/android/src/main/java/io/flutter/plugins/firebase/messaging/FlutterFirebaseMessagingUtils.java
@@ -149,6 +149,10 @@ class FlutterFirebaseMessagingUtils {
       androidNotificationMap.put("visibility", notification.getVisibility());
     }
 
+    if(notification.getTag() != null){
+      androidNotificationMap.put("tag", notification.getTag());
+    }
+
     notificationMap.put("android", androidNotificationMap);
     return notificationMap;
   }

--- a/packages/firebase_messaging/firebase_messaging/android/src/main/java/io/flutter/plugins/firebase/messaging/FlutterFirebaseMessagingUtils.java
+++ b/packages/firebase_messaging/firebase_messaging/android/src/main/java/io/flutter/plugins/firebase/messaging/FlutterFirebaseMessagingUtils.java
@@ -149,7 +149,7 @@ class FlutterFirebaseMessagingUtils {
       androidNotificationMap.put("visibility", notification.getVisibility());
     }
 
-    if(notification.getTag() != null){
+    if (notification.getTag() != null) {
       androidNotificationMap.put("tag", notification.getTag());
     }
 

--- a/packages/firebase_messaging/firebase_messaging/example/lib/main.dart
+++ b/packages/firebase_messaging/firebase_messaging/example/lib/main.dart
@@ -127,8 +127,9 @@ class _Application extends State<Application> {
     FirebaseMessaging.onMessage.listen((RemoteMessage message) {
       RemoteNotification notification = message.notification;
       AndroidNotification android = message.notification?.android;
-
+  
       if (notification != null && android != null) {
+  print("NNNNN: " + notification.android.tag);
         flutterLocalNotificationsPlugin.show(
             notification.hashCode,
             notification.title,

--- a/packages/firebase_messaging/firebase_messaging/example/lib/main.dart
+++ b/packages/firebase_messaging/firebase_messaging/example/lib/main.dart
@@ -127,9 +127,7 @@ class _Application extends State<Application> {
     FirebaseMessaging.onMessage.listen((RemoteMessage message) {
       RemoteNotification notification = message.notification;
       AndroidNotification android = message.notification?.android;
-  
       if (notification != null && android != null) {
-  print("NNNNN: " + notification.android.tag);
         flutterLocalNotificationsPlugin.show(
             notification.hashCode,
             notification.title,

--- a/packages/firebase_messaging/firebase_messaging_platform_interface/lib/src/remote_notification.dart
+++ b/packages/firebase_messaging/firebase_messaging_platform_interface/lib/src/remote_notification.dart
@@ -39,6 +39,7 @@ class RemoteNotification {
         smallIcon: map['android']['smallIcon'],
         sound: map['android']['sound'],
         ticker: map['android']['ticker'],
+        tag: map['android']['tag'],
         visibility: convertToAndroidNotificationVisibility(
             map['android']['visibility']),
       );
@@ -112,6 +113,7 @@ class AndroidNotification {
       this.smallIcon,
       this.sound,
       this.ticker,
+      this.tag,
       this.visibility = AndroidNotificationVisibility.private});
 
   /// The channel the notification is delivered on.
@@ -153,6 +155,9 @@ class AndroidNotification {
 
   /// The visibility level of the notification.
   final AndroidNotificationVisibility visibility;
+
+  /// The tag of the notification
+  final String? tag;
 }
 
 /// Apple specific properties of a [RemoteNotification].

--- a/packages/firebase_messaging/firebase_messaging_platform_interface/lib/src/remote_notification.dart
+++ b/packages/firebase_messaging/firebase_messaging_platform_interface/lib/src/remote_notification.dart
@@ -156,7 +156,7 @@ class AndroidNotification {
   /// The visibility level of the notification.
   final AndroidNotificationVisibility visibility;
 
-  /// The tag of the notification
+  /// The tag of the notification.
   final String? tag;
 }
 


### PR DESCRIPTION
## Description

Users can send a tag with each RemoteNotification on android.

## Related Issues

fixes #5432

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
