### PR TITLE
fix(firebase_crashlytics): Add Flutter dependency to podspec

### DIFF
--- a/packages/firebase_crashlytics/firebase_crashlytics/ios/firebase_crashlytics.podspec
+++ b/packages/firebase_crashlytics/firebase_crashlytics/ios/firebase_crashlytics.podspec
@@ -30,6 +30,7 @@ Pod::Spec.new do |s|
 
   s.ios.deployment_target = '10.0'
 
+  s.dependency 'Flutter'
   s.dependency 'firebase_core'
   s.dependency 'Firebase/Crashlytics', firebase_sdk_version
 


### PR DESCRIPTION
## Description

https://github.com/flutter/flutter/pull/78592 stopped trying Flutter against pods that don't explicitly declare `Flutter` as a dependency (to fix a bitcode linking issue).  This means that all Flutter plugins rely on correct podspec dependencies set up, so either `s.dependency 'Flutter'` or  `s.dependency 'FlutterMacOS'`.

I don't see any other podspecs that are missing it.

## Related Issues

Fixes https://github.com/FirebaseExtended/flutterfire/issues/5440

## Checklist
- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change
- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.