### PR TITLE
fix(firebase_analytics): Change firebase_analytics example for tab subscribe invoke from didCh…

### DIFF
--- a/packages/firebase_analytics/firebase_analytics/example/lib/tabs_page.dart
+++ b/packages/firebase_analytics/firebase_analytics/example/lib/tabs_page.dart
@@ -34,7 +34,7 @@ class _TabsPageState extends State<TabsPage>
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
-    widget.observer.subscribe(this, ModalRoute.of(context));
+
   }
 
   @override
@@ -59,6 +59,7 @@ class _TabsPageState extends State<TabsPage>
         }
       });
     });
+    widget.observer.subscribe(this, ModalRoute.of(context));
   }
 
   @override


### PR DESCRIPTION
Change firebase_analytics example for tab subscribe invoke from didChangeDependencies() to initState()

## Description

*Currently didChangeDependencies() is called even when navigating away from TabController to another screen (Push) & also when back from the screen (Pop) to the TabController. 
Placing it in initState() avoids this scenario, as it is only called once, and there is no multiple subscription calls.
Any other reason why invoked from with in didChangeDependencies()? Correct me if wrong. Thanks !*

## Related Issues

*FirebaseAnalyticsObserver just subscribes multiple times.*

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
