### PR TITLE
fix(firestore): made `QueryDocumentSnapshot.data()` non-nullable

### DIFF
--- a/packages/cloud_firestore/cloud_firestore/lib/src/query_document_snapshot.dart
+++ b/packages/cloud_firestore/cloud_firestore/lib/src/query_document_snapshot.dart
@@ -16,4 +16,7 @@ class QueryDocumentSnapshot extends DocumentSnapshot {
 
   @override
   bool get exists => true;
+  
+  @override
+  Map<String, dynamic> data() => super.data()!;
 }

--- a/packages/cloud_firestore/cloud_firestore/lib/src/query_document_snapshot.dart
+++ b/packages/cloud_firestore/cloud_firestore/lib/src/query_document_snapshot.dart
@@ -16,7 +16,6 @@ class QueryDocumentSnapshot extends DocumentSnapshot {
 
   @override
   bool get exists => true;
-  
   @override
   Map<String, dynamic> data() => super.data()!;
 }

--- a/packages/cloud_firestore/cloud_firestore/lib/src/query_document_snapshot.dart
+++ b/packages/cloud_firestore/cloud_firestore/lib/src/query_document_snapshot.dart
@@ -16,6 +16,7 @@ class QueryDocumentSnapshot extends DocumentSnapshot {
 
   @override
   bool get exists => true;
+
   @override
   Map<String, dynamic> data() => super.data()!;
 }


### PR DESCRIPTION
QueryDocumentSnapshot, by definition, should always have data and therefore the `.data()` method can be non-null.

## Description

Adds an override that calls the super `.data()` method with the added `!`.

## Related Issues

FIxes #5475 

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
  **There was no existing test for `Query.get()`, but the change is just from nullable to non-nullable.**
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`). **Docs already had the correct info**
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
