### PR TITLE
fix(firestore, web): snapshotsInSync web fix

### DIFF
--- a/packages/cloud_firestore/cloud_firestore_web/lib/src/interop/firestore.dart
+++ b/packages/cloud_firestore/cloud_firestore_web/lib/src/interop/firestore.dart
@@ -60,7 +60,7 @@ class Firestore extends JsObjectWrapper<firestore_interop.FirestoreJsImpl> {
     late StreamController<void> controller;
     late ZoneCallback onSnapshotsInSyncUnsubscribe;
     var nextWrapper =
-        allowInterop((firestore_interop.DocumentSnapshotJsImpl snapshot) {
+        allowInterop((Null noValue) {
       controller.add(null);
     });
 


### PR DESCRIPTION
## Description

Current implementation of `snapshotsInSync` does not work on web, throws this error when used:

```dart
Error: Expected a value of type 'JSObject<tv>', but got one of type 'Null'
    at Object.throw_ [as throw] (http://localhost:65005/dart_sdk.js:5334:11)
    at Object.castError (http://localhost:65005/dart_sdk.js:5305:15)
    at dart.LazyJSType.new.as (http://localhost:65005/dart_sdk.js:7112:40)
    at Object._argumentErrors (http://localhost:65005/dart_sdk.js:5457:19)
    at Object._checkAndCall (http://localhost:65005/dart_sdk.js:5540:29)
    at Object.dcall (http://localhost:65005/dart_sdk.js:5549:17)
    at ret (http://localhost:65005/dart_sdk.js:60993:21)
    at https://www.gstatic.com/firebasejs/7.22.0/firebase-firestore.js:1:228488
```

Correcting the expected argument fixes the bug.

## Related Issues

*Replace this paragraph with a list of issues related to this PR from the [issue database](https://github.com/flutter/flutter/issues). Indicate, which of these issues are resolved or fixed by this PR. Note that you'll have to prefix the issue numbers with flutter/flutter#.*

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
