### PR TITLE
fix(firebase_messaging): fix getNotificationSettings for null safety

### DIFF
--- a/packages/firebase_messaging/firebase_messaging_platform_interface/lib/src/method_channel/method_channel_messaging.dart
+++ b/packages/firebase_messaging/firebase_messaging_platform_interface/lib/src/method_channel/method_channel_messaging.dart
@@ -235,12 +235,12 @@ class MethodChannelFirebaseMessaging extends FirebaseMessagingPlatform {
     }
 
     try {
-      Map<String, int> response = await (channel
+      Map<String, int>? response = await channel
           .invokeMapMethod<String, int>('Messaging#getNotificationSettings', {
         'appName': app.name,
-      }) as FutureOr<Map<String, int>>);
+      });
 
-      return convertToNotificationSettings(response);
+      return convertToNotificationSettings(response!);
     } catch (e) {
       throw convertPlatformException(e);
     }


### PR DESCRIPTION
## Description

There is a bug in the method `getNotificationSettings()` for Firebase Messaging after migrating to null safety. With the current stable an error appears when calling  `getNotificationSettings()`: 

```
> [VERBOSE-2:ui_dart_state.cc(186)] Unhandled Exception: type 'Future<Map<String, int>?>' is not a subtype of type 'FutureOr<Map<String, int>>' in type cast
> #0      convertPlatformException (package:firebase_messaging_platform_interface/src/method_channel/utils/exception.dart:12:5)
> #1      MethodChannelFirebaseMessaging.getNotificationSettings (package:firebase_messaging_platform_interface/src/method_channel/method_channel_messaging.dart:245:13)
> #2      FirebaseMessaging.getNotificationSettings (package:firebase_messaging/src/messaging.dart:154:22)
```

The reason for this error is the incorrect cast into `FutureOr<Map<String, int>>`. However, if the answer is nullable, it works again. The code is also more consistent this way, since this is exactly how it was done in `requestPermission()`.


## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [X] All existing and new tests are passing.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [X] I read and followed the [Flutter Style Guide].
- [X] I signed the [CLA].
- [X] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [X] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
