### PR TITLE
chore: add repository urls to pubspecs

### DIFF
--- a/packages/cloud_firestore/cloud_firestore/pubspec.yaml
+++ b/packages/cloud_firestore/cloud_firestore/pubspec.yaml
@@ -3,6 +3,7 @@ description:
   Flutter plugin for Cloud Firestore, a cloud-hosted, noSQL database with
   live synchronization and offline support on Android and iOS.
 homepage: https://firebase.flutter.dev/docs/firestore/overview
+repository: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/cloud_firestore/cloud_firestore
 version: 1.0.3
 
 environment:

--- a/packages/cloud_functions/cloud_functions/pubspec.yaml
+++ b/packages/cloud_functions/cloud_functions/pubspec.yaml
@@ -2,6 +2,7 @@ name: cloud_functions
 description: A Flutter plugin allowing you to use Firebase Cloud Functions.
 version: 1.0.2
 homepage: https://firebase.flutter.dev/docs/functions/overview
+repository: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/cloud_functions/cloud_functions
 
 environment:
   sdk: ">=2.12.0 <3.0.0"

--- a/packages/firebase_analytics/firebase_analytics/pubspec.yaml
+++ b/packages/firebase_analytics/firebase_analytics/pubspec.yaml
@@ -2,7 +2,8 @@ name: firebase_analytics
 description:
   Flutter plugin for Google Analytics for Firebase, an app measurement
   solution that provides insight on app usage and user engagement on Android and iOS.
-homepage: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/firebase_analytics/firebase_analytics
+homepage: https://firebase.flutter.dev/docs/analytics/overview
+repository: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/firebase_analytics/firebase_analytics
 version: 8.0.0-dev.0
 
 environment:

--- a/packages/firebase_auth/firebase_auth/pubspec.yaml
+++ b/packages/firebase_auth/firebase_auth/pubspec.yaml
@@ -3,6 +3,7 @@ description: Flutter plugin for Firebase Auth, enabling Android and iOS
   authentication using passwords, phone numbers and identity providers
   like Google, Facebook and Twitter.
 homepage: https://firebase.flutter.dev/docs/auth/overview
+repository: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/firebase_auth/firebase_auth
 version: 1.0.1
 
 environment:

--- a/packages/firebase_core/firebase_core/pubspec.yaml
+++ b/packages/firebase_core/firebase_core/pubspec.yaml
@@ -2,6 +2,7 @@ name: firebase_core
 description: Flutter plugin for Firebase Core, enabling connecting to multiple
   Firebase apps.
 homepage: https://firebase.flutter.dev/docs/core/usage
+repository: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/firebase_core/firebase_core
 version: 1.0.2
 
 environment:

--- a/packages/firebase_crashlytics/firebase_crashlytics/pubspec.yaml
+++ b/packages/firebase_crashlytics/firebase_crashlytics/pubspec.yaml
@@ -4,6 +4,7 @@ description:
   Firebase console.
 version: 1.0.0
 homepage: https://firebase.flutter.dev/docs/crashlytics/overview
+repository: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/firebase_crashlytics/firebase_crashlytics
 
 environment:
   sdk: ">=2.12.0 <3.0.0"

--- a/packages/firebase_database/pubspec.yaml
+++ b/packages/firebase_database/pubspec.yaml
@@ -1,7 +1,8 @@
 name: firebase_database
 description: Flutter plugin for Firebase Database, a cloud-hosted NoSQL database
   with realtime data syncing across Android and iOS clients, and offline access.
-homepage: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/firebase_database
+homepage: https://firebase.flutter.dev/docs/database/overview
+repository: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/firebase_database
 version: 6.1.1
 
 environment:

--- a/packages/firebase_messaging/firebase_messaging/pubspec.yaml
+++ b/packages/firebase_messaging/firebase_messaging/pubspec.yaml
@@ -2,6 +2,7 @@ name: firebase_messaging
 description: Flutter plugin for Firebase Cloud Messaging, a cross-platform
   messaging solution that lets you reliably deliver messages on Android and iOS.
 homepage: https://firebase.flutter.dev/docs/messaging/overview
+repository: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/firebase_messaging/firebase_messaging
 version: 9.1.0
 
 environment:

--- a/packages/firebase_performance/pubspec.yaml
+++ b/packages/firebase_performance/pubspec.yaml
@@ -3,7 +3,8 @@ description:
   Flutter plugin for Google Performance Monitoring for Firebase, an app
   measurement solution that monitors traces and HTTP/S network requests on Android and
   iOS.
-homepage: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/firebase_performance
+homepage: https://firebase.flutter.dev/docs/performance/overview
+repository: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/firebase_performance
 version: 0.6.0+1
 
 environment:

--- a/packages/firebase_remote_config/firebase_remote_config/pubspec.yaml
+++ b/packages/firebase_remote_config/firebase_remote_config/pubspec.yaml
@@ -2,7 +2,8 @@ name: firebase_remote_config
 description:
   Flutter plugin for Firebase Remote Config. Update your application look and feel and behaviour without
   re-releasing.
-homepage: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/firebase_remote_config
+homepage: https://firebase.flutter.dev/docs/remote-config/overview
+repository: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/firebase_remote_config/firebase_remote_config
 version: 0.9.0-dev.1
 
 environment:

--- a/packages/firebase_storage/firebase_storage/pubspec.yaml
+++ b/packages/firebase_storage/firebase_storage/pubspec.yaml
@@ -2,6 +2,7 @@ name: firebase_storage
 description: Flutter plugin for Firebase Cloud Storage, a powerful, simple, and
   cost-effective object storage service for Android and iOS.
 homepage: https://firebase.flutter.dev/docs/storage/overview
+repository: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/firebase_storage/firebase_storage
 version: 8.0.1
 
 environment:


### PR DESCRIPTION
## Description

Now there is a documentation website, the `homepage` url within the `pubspec.yaml` files can point the hub for the specific package. This PR then adds the `repository` url to the pubspecs where the `homepage` no longer points to the repo.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`flutter analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
