### PR TITLE
feat(firebase_auth): OAuthProvider.parameters is now non-nullable

### DIFF
--- a/packages/firebase_auth/firebase_auth_platform_interface/lib/src/providers/oauth.dart
+++ b/packages/firebase_auth/firebase_auth_platform_interface/lib/src/providers/oauth.dart
@@ -15,7 +15,7 @@ class OAuthProvider extends AuthProvider {
   OAuthProvider(String providerId) : super(providerId);
 
   List<String> _scopes = [];
-  Map<dynamic, dynamic>? _parameters;
+  Map<dynamic, dynamic> _parameters = {};
 
   /// Returns the currently assigned scopes to this provider instance.
   /// This is a Web only API.
@@ -25,7 +25,7 @@ class OAuthProvider extends AuthProvider {
 
   /// Returns the parameters for this provider instance.
   /// This is a Web only API.
-  Map<dynamic, dynamic>? get parameters {
+  Map<dynamic, dynamic> get parameters {
     return _parameters;
   }
 

--- a/packages/firebase_auth/firebase_auth_platform_interface/test/providers_tests/oauth_test.dart
+++ b/packages/firebase_auth/firebase_auth_platform_interface/test/providers_tests/oauth_test.dart
@@ -51,8 +51,8 @@ void main() {
         final result =
             oAuthProvider.setCustomParameters(kCustomOAuthParameters);
         expect(result, isA<OAuthProvider>());
-        expect(result.parameters!['allow_signup'], isA<String>());
-        expect(result.parameters!['allow_signup'], equals('false'));
+        expect(result.parameters['allow_signup'], isA<String>());
+        expect(result.parameters['allow_signup'], equals('false'));
       });
     });
 

--- a/packages/firebase_auth/firebase_auth_web/lib/firebase_auth_web.dart
+++ b/packages/firebase_auth/firebase_auth_web/lib/firebase_auth_web.dart
@@ -315,9 +315,9 @@ class FirebaseAuthWeb extends FirebaseAuthPlatform {
   Future<UserCredentialPlatform> signInWithPopup(AuthProvider provider) async {
     try {
       return UserCredentialWeb(
-          this,
-          await _webAuth!
-              .signInWithPopup(convertPlatformAuthProvider(provider)!));
+        this,
+        await _webAuth!.signInWithPopup(convertPlatformAuthProvider(provider)),
+      );
     } catch (e) {
       throw getFirebaseAuthException(e);
     }
@@ -327,7 +327,7 @@ class FirebaseAuthWeb extends FirebaseAuthPlatform {
   Future<void> signInWithRedirect(AuthProvider provider) async {
     try {
       return _webAuth!
-          .signInWithRedirect(convertPlatformAuthProvider(provider)!);
+          .signInWithRedirect(convertPlatformAuthProvider(provider));
     } catch (e) {
       throw getFirebaseAuthException(e);
     }

--- a/packages/firebase_auth/firebase_auth_web/lib/src/interop/auth.dart
+++ b/packages/firebase_auth/firebase_auth_web/lib/src/interop/auth.dart
@@ -697,9 +697,12 @@ class FacebookAuthProvider
   /// 'redirect_uri', 'scope', 'response_type' and 'state' are not allowed
   /// and ignored.
   FacebookAuthProvider setCustomParameters(
-          Map<String, dynamic> customOAuthParameters) =>
-      FacebookAuthProvider.fromJsObject(
-          jsObject.setCustomParameters(jsify(customOAuthParameters)));
+    Map<Object?, Object?> customOAuthParameters,
+  ) {
+    return FacebookAuthProvider.fromJsObject(
+      jsObject.setCustomParameters(jsify(customOAuthParameters)),
+    );
+  }
 
   /// Creates a credential for Facebook.
   static auth_interop.OAuthCredential credential(String token) =>
@@ -735,9 +738,12 @@ class GithubAuthProvider
   /// 'redirect_uri', 'scope', 'response_type' and 'state'
   /// are not allowed and ignored.
   GithubAuthProvider setCustomParameters(
-          Map<String, dynamic> customOAuthParameters) =>
-      GithubAuthProvider.fromJsObject(
-          jsObject.setCustomParameters(jsify(customOAuthParameters)));
+    Map<Object?, Object?> customOAuthParameters,
+  ) {
+    return GithubAuthProvider.fromJsObject(
+      jsObject.setCustomParameters(jsify(customOAuthParameters)),
+    );
+  }
 
   /// Creates a credential for GitHub.
   static auth_interop.OAuthCredential credential(String token) =>
@@ -774,9 +780,12 @@ class GoogleAuthProvider
   /// 'redirect_uri', 'scope', 'response_type' and 'state'
   /// are not allowed and ignored.
   GoogleAuthProvider setCustomParameters(
-          Map<String, dynamic> customOAuthParameters) =>
-      GoogleAuthProvider.fromJsObject(
-          jsObject.setCustomParameters(jsify(customOAuthParameters)));
+    Map<Object?, Object?> customOAuthParameters,
+  ) {
+    return GoogleAuthProvider.fromJsObject(
+      jsObject.setCustomParameters(jsify(customOAuthParameters)),
+    );
+  }
 
   /// Creates a credential for Google.
   /// At least one of [idToken] and [accessToken] is required.
@@ -807,9 +816,12 @@ class OAuthProvider extends AuthProvider<auth_interop.OAuthProviderJsImpl> {
   /// required OAuth 2.0 parameters such as client_id, redirect_uri, scope,
   /// response_type and state are not allowed and will be ignored.
   OAuthProvider setCustomParameters(
-          Map<String, dynamic> customOAuthParameters) =>
-      OAuthProvider.fromJsObject(
-          jsObject.setCustomParameters(jsify(customOAuthParameters)));
+    Map<Object?, Object?> customOAuthParameters,
+  ) {
+    return OAuthProvider.fromJsObject(
+      jsObject.setCustomParameters(jsify(customOAuthParameters)),
+    );
+  }
 
   /// Creates a credential for Google.
   /// At least one of [idToken] and [accessToken] is required.
@@ -841,9 +853,12 @@ class TwitterAuthProvider
   /// such as 'oauth_consumer_key', 'oauth_token', 'oauth_signature', etc
   /// are not allowed and will be ignored.
   TwitterAuthProvider setCustomParameters(
-          Map<String, dynamic> customOAuthParameters) =>
-      TwitterAuthProvider.fromJsObject(
-          jsObject.setCustomParameters(jsify(customOAuthParameters)));
+    Map<Object?, Object?> customOAuthParameters,
+  ) {
+    return TwitterAuthProvider.fromJsObject(
+      jsObject.setCustomParameters(jsify(customOAuthParameters)),
+    );
+  }
 
   /// Creates a credential for Twitter.
   static auth_interop.OAuthCredential credential(String token, String secret) =>

--- a/packages/firebase_auth/firebase_auth_web/lib/src/utils/web_utils.dart
+++ b/packages/firebase_auth/firebase_auth_web/lib/src/utils/web_utils.dart
@@ -123,8 +123,9 @@ String convertPlatformPersistence(Persistence persistence) {
 }
 
 /// Converts a [AuthProvider] into a [auth_interop.AuthProvider].
-auth_interop.AuthProvider? convertPlatformAuthProvider(
-    AuthProvider authProvider) {
+auth_interop.AuthProvider convertPlatformAuthProvider(
+  AuthProvider authProvider,
+) {
   if (authProvider is EmailAuthProvider) {
     return auth_interop.EmailAuthProvider();
   }
@@ -133,10 +134,8 @@ auth_interop.AuthProvider? convertPlatformAuthProvider(
     auth_interop.FacebookAuthProvider facebookAuthProvider =
         auth_interop.FacebookAuthProvider();
 
-    authProvider.scopes
-        .forEach((String scope) => facebookAuthProvider.addScope(scope));
-    facebookAuthProvider.setCustomParameters(
-        Map<String, dynamic>.from(authProvider.parameters));
+    authProvider.scopes.forEach(facebookAuthProvider.addScope);
+    facebookAuthProvider.setCustomParameters(authProvider.parameters);
     return facebookAuthProvider;
   }
 
@@ -144,10 +143,8 @@ auth_interop.AuthProvider? convertPlatformAuthProvider(
     auth_interop.GithubAuthProvider githubAuthProvider =
         auth_interop.GithubAuthProvider();
 
-    authProvider.scopes
-        .forEach((String scope) => githubAuthProvider.addScope(scope));
-    githubAuthProvider.setCustomParameters(
-        Map<String, dynamic>.from(authProvider.parameters));
+    authProvider.scopes.forEach(githubAuthProvider.addScope);
+    githubAuthProvider.setCustomParameters(authProvider.parameters);
     return githubAuthProvider;
   }
 
@@ -155,10 +152,8 @@ auth_interop.AuthProvider? convertPlatformAuthProvider(
     auth_interop.GoogleAuthProvider googleAuthProvider =
         auth_interop.GoogleAuthProvider();
 
-    authProvider.scopes
-        .forEach((String scope) => googleAuthProvider.addScope(scope));
-    googleAuthProvider.setCustomParameters(
-        Map<String, dynamic>.from(authProvider.parameters));
+    authProvider.scopes.forEach(googleAuthProvider.addScope);
+    googleAuthProvider.setCustomParameters(authProvider.parameters);
     return googleAuthProvider;
   }
 
@@ -166,8 +161,7 @@ auth_interop.AuthProvider? convertPlatformAuthProvider(
     auth_interop.TwitterAuthProvider twitterAuthProvider =
         auth_interop.TwitterAuthProvider();
 
-    twitterAuthProvider.setCustomParameters(
-        Map<String, dynamic>.from(authProvider.parameters));
+    twitterAuthProvider.setCustomParameters(authProvider.parameters);
     return twitterAuthProvider;
   }
 
@@ -179,15 +173,12 @@ auth_interop.AuthProvider? convertPlatformAuthProvider(
     auth_interop.OAuthProvider oAuthProvider =
         auth_interop.OAuthProvider(authProvider.providerId);
 
-    authProvider.scopes
-        .forEach((String scope) => oAuthProvider.addScope(scope));
-    oAuthProvider.setCustomParameters(
-      Map<String, dynamic>.from(authProvider.parameters),
-    );
+    authProvider.scopes.forEach(oAuthProvider.addScope);
+    oAuthProvider.setCustomParameters(authProvider.parameters);
     return oAuthProvider;
   }
 
-  return null;
+  throw FallThroughError();
 }
 
 /// Converts a [auth_interop.AuthCredential] into a [AuthCredential].

--- a/packages/firebase_auth/firebase_auth_web/lib/src/utils/web_utils.dart
+++ b/packages/firebase_auth/firebase_auth_web/lib/src/utils/web_utils.dart
@@ -182,7 +182,7 @@ auth_interop.AuthProvider? convertPlatformAuthProvider(
     authProvider.scopes
         .forEach((String scope) => oAuthProvider.addScope(scope));
     oAuthProvider.setCustomParameters(
-      Map<String, dynamic>.from(authProvider.parameters!),
+      Map<String, dynamic>.from(authProvider.parameters),
     );
     return oAuthProvider;
   }


### PR DESCRIPTION
## Description
Makes `OAuthProvider.parameters` non nullable. Alternatively, a null check could have been added to https://github.com/FirebaseExtended/flutterfire/blob/master/packages/firebase_auth/firebase_auth_web/lib/src/utils/web_utils.dart#L185

## Related Issues
Closes https://github.com/FirebaseExtended/flutterfire/issues/5654

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

**Is it a breaking change for implementations of `firebase_auth_platform_interface`?**
- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/


I attempted to add `web_utils_test.dart` to `firebase_auth_web/test/` but it's not running due to some loading errors:
```
../../../../../../../.pub-cache/hosted/pub.dartlang.org/js-0.6.3/lib/js.dart:8:1: Error: Not found: 'dart:js'
export 'dart:js' show allowInterop, allowInteropCaptureThis;
^

../../../../../../../.pub-cache/hosted/pub.dartlang.org/js-0.6.3/lib/js_util.dart:8:1: Error: Not found: 'dart:js_util'
export 'dart:js_util';
```
```dart
import 'package:firebase_auth_platform_interface/firebase_auth_platform_interface.dart';
import 'package:firebase_auth_web/src/utils/web_utils.dart';
import 'package:firebase_auth_web/src/interop/auth.dart' as auth_interop;
import 'package:flutter_test/flutter_test.dart';

void main() {
  TestWidgetsFlutterBinding.ensureInitialized();
  group('convertPlatformAuthProvider()', () {
    test('Converts OAuthProvider with unset parameters', () {
      //
      final oAuthProvider = OAuthProvider('');

      final auth_interop.AuthProvider<auth_interop.AuthProviderJsImpl>?
          webOAuthProvider = convertPlatformAuthProvider(oAuthProvider);

      expect(webOAuthProvider, isA<auth_interop.OAuthProvider>());
    });
  });
}
```
