### PR TITLE
docs(cloud_functions): update emulator usage instructions

### DIFF
--- a/docs/functions/usage.mdx
+++ b/docs/functions/usage.mdx
@@ -65,12 +65,11 @@ HttpsCallableResult callable = await FirebaseFunctions
 
 If you are using the local Cloud Functions emulators, then it is possible to connect to these using the `useFunctionsEmulator` method.
 Ensure you pass the correct port on which the Firebase emulator is running on.
-Ensure you have enabled network connections to the emulators in your apps following the emulator usage instructions in the general FlutterFire installation notes for each operating system.
+Ensure you have enabled network connections to the emulators in your apps following the emulator usage instructions in the general FlutterFire installation notes for each operating system. You only have to call `useFunctionsEmulator` once, so do it as early as possible.
 
 ```dart
 FirebaseFunctions.instance
-  .useFunctionsEmulator(origin: 'http://localhost:5000')
-  .httpsCallable('myCloudFunction');
+      .useFunctionsEmulator(origin: 'http://localhost:5001');
 ```
 
 


### PR DESCRIPTION
## Description

The instructions on how to use the emulator for functions were not in line with emulator usages from other packages (Auth, Firestore).

Also, the example code would not work if one needed to use the callable's return value.

This makes the instructions more clear and easier to follow.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
