### PR TITLE
feat: migrate in_app_messaging to sound null safety

### DIFF
--- a/packages/firebase_in_app_messaging/CHANGELOG.md
+++ b/packages/firebase_in_app_messaging/CHANGELOG.md
@@ -1,8 +1,3 @@
-## 1.0.0
-
- - **CHORE**: bump packages.
- - **BREAKING** **FEAT**: Migrate firebase_in_app_messaging to sound null safety
-
 ## 0.4.0+1
 
  - Update a dependency to the latest release.

--- a/packages/firebase_in_app_messaging/CHANGELOG.md
+++ b/packages/firebase_in_app_messaging/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.0.0
+
+ - **CHORE**: bump packages.
+ - **BREAKING** **FEAT**: Migrate firebase_in_app_messaging to sound null safety
+
 ## 0.4.0
 
  - This version is not null-safe but has been created to allow compatibility with other null-safe FlutterFire packages such as `firebase_core`.

--- a/packages/firebase_in_app_messaging/example/lib/main.dart
+++ b/packages/firebase_in_app_messaging/example/lib/main.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart=2.9
-
 import 'dart:async';
 
 import 'package:firebase_analytics/firebase_analytics.dart';

--- a/packages/firebase_in_app_messaging/example/pubspec.yaml
+++ b/packages/firebase_in_app_messaging/example/pubspec.yaml
@@ -6,7 +6,7 @@ environment:
   sdk: ">=2.12.0 <3.0.0"
 
 dependencies:
-  cupertino_icons: ^0.1.2
+  cupertino_icons: ^1.0.2
   firebase_analytics:
     path: ../../firebase_analytics/firebase_analytics
   firebase_core:
@@ -25,7 +25,7 @@ dependency_overrides:
     path: ../../firebase_core/firebase_core_web
 
 dev_dependencies:
-  e2e: ^0.6.1
+  e2e: ^0.7.0+1
   flutter_driver:
     sdk: flutter
   flutter_test:

--- a/packages/firebase_in_app_messaging/lib/firebase_in_app_messaging.dart
+++ b/packages/firebase_in_app_messaging/lib/firebase_in_app_messaging.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart=2.9
-
 import 'dart:async';
 
 import 'package:flutter/services.dart';
@@ -30,17 +28,11 @@ class FirebaseInAppMessaging {
 
   /// Enables or disables suppression of message displays.
   Future<void> setMessagesSuppressed(bool suppress) async {
-    if (suppress == null) {
-      throw ArgumentError.notNull('suppress');
-    }
     await channel.invokeMethod<void>('setMessagesSuppressed', suppress);
   }
 
   /// Disable data collection for the app.
   Future<void> setAutomaticDataCollectionEnabled(bool enabled) async {
-    if (enabled == null) {
-      throw ArgumentError.notNull('enabled');
-    }
     await channel.invokeMethod<void>(
         'setAutomaticDataCollectionEnabled', enabled);
   }

--- a/packages/firebase_in_app_messaging/pubspec.yaml
+++ b/packages/firebase_in_app_messaging/pubspec.yaml
@@ -1,6 +1,6 @@
 name: firebase_in_app_messaging
 description: Flutter plugin for Firebase In-App Messaging.
-version: 0.4.0
+version: 1.0.0
 homepage: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/firebase_in_app_messaging
 
 environment:
@@ -14,7 +14,7 @@ dependencies:
   meta: ^1.3.0
 
 dev_dependencies:
-  e2e: ^0.6.1
+  e2e: ^0.7.0+1
   flutter_driver:
     sdk: flutter
   flutter_test:

--- a/packages/firebase_in_app_messaging/pubspec.yaml
+++ b/packages/firebase_in_app_messaging/pubspec.yaml
@@ -1,6 +1,6 @@
 name: firebase_in_app_messaging
 description: Flutter plugin for Firebase In-App Messaging.
-version: 1.0.0
+version: 0.4.0+1
 homepage: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/firebase_in_app_messaging
 
 environment:

--- a/packages/firebase_in_app_messaging/test/firebase_in_app_messaging_e2e.dart
+++ b/packages/firebase_in_app_messaging/test/firebase_in_app_messaging_e2e.dart
@@ -1,12 +1,10 @@
-// @dart=2.9
-
 import 'package:flutter_test/flutter_test.dart';
 import 'package:e2e/e2e.dart';
 import 'package:firebase_in_app_messaging/firebase_in_app_messaging.dart';
 
 void main() {
   E2EWidgetsFlutterBinding.ensureInitialized();
-  FirebaseInAppMessaging fiam;
+  late FirebaseInAppMessaging fiam;
 
   setUp(() {
     fiam = FirebaseInAppMessaging();

--- a/packages/firebase_in_app_messaging/test/firebase_in_app_messaging_test.dart
+++ b/packages/firebase_in_app_messaging/test/firebase_in_app_messaging_test.dart
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart=2.9
-
 import 'package:firebase_in_app_messaging/firebase_in_app_messaging.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';


### PR DESCRIPTION
## Description

This migrates firebase_in_app_messaging to non-nullable types


## Related Issues

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [x] Yes, this is a breaking change.
- [ ] No, this is *not* a breaking change.

This is a "Breaking" Change because it is upgrading to null safety, the user code will not be needed to change as the dart lib was almost ready to be null safe already checking for null value and throwing error   