### PR TITLE
fix: improve refFromURL http regex

### DIFF
--- a/packages/firebase_storage/firebase_storage/example/test_driver/instance_e2e.dart
+++ b/packages/firebase_storage/firebase_storage/example/test_driver/instance_e2e.dart
@@ -81,6 +81,15 @@ void runInstanceTests() {
         expect(ref.fullPath, '1mbTestFile.gif');
       });
 
+      test('accepts a https url with special characters', () async {
+        const url =
+            'https://firebasestorage.googleapis.com/v0/b/react-native-firebase-testing.appspot.com/o/foo+bar/file with  spaces.png?alt=media';
+        Reference ref = storage.refFromURL(url);
+        expect(ref.bucket, 'react-native-firebase-testing.appspot.com');
+        expect(ref.name, 'file with  spaces.png');
+        expect(ref.fullPath, 'foo+bar/file with  spaces.png');
+      });
+
       test('accepts a https encoded url', () async {
         const url =
             'https%3A%2F%2Ffirebasestorage.googleapis.com%2Fv0%2Fb%2Freact-native-firebase-testing.appspot.com%2Fo%2F1mbTestFile.gif%3Falt%3Dmedia';

--- a/packages/firebase_storage/firebase_storage/lib/src/utils.dart
+++ b/packages/firebase_storage/firebase_storage/lib/src/utils.dart
@@ -31,7 +31,7 @@ Map<String, String?>? partsFromHttpUrl(String url) {
     return null;
   }
 
-  RegExp exp = RegExp(r'\/b\/(.*)\/o\/([a-zA-Z0-9.\/\-_]+)(.*)');
+  RegExp exp = RegExp(r'\/b\/(.*)\/o\/([a-zA-Z0-9.\/\-_\s\+]+)(.*)');
   Iterable<RegExpMatch> matches = exp.allMatches(decodedUrl);
 
   if (matches.isEmpty) {

--- a/packages/firebase_storage/firebase_storage/test/firebase_storage_test.dart
+++ b/packages/firebase_storage/firebase_storage/test/firebase_storage_test.dart
@@ -132,6 +132,32 @@ void main() {
         verify(kMockStoragePlatform.ref(testPath));
       });
 
+      test('verify delegate method is called for http urls with spaces', () {
+        const String customBucket = 'test.appspot.com';
+        const String testPath = 'file with  spaces   .gif';
+        const String url =
+            'https://firebasestorage.googleapis.com/v0/b/$customBucket/o/$testPath?alt=media';
+
+        final ref = storage.refFromURL(url);
+
+        expect(ref, isA<Reference>());
+        verify(kMockStoragePlatform.ref(testPath));
+      });
+
+      // https://github.com/FirebaseExtended/flutterfire/issues/5673
+      test('verify delegate method is called for http urls with + symbol', () {
+        const String customBucket = 'test.appspot.com';
+        const String testPath = 'foo+bar/file.gif';
+        const String url =
+            'https://firebasestorage.googleapis.com/v0/b/$customBucket/o/$testPath?alt=media';
+
+        final ref = storage.refFromURL(url);
+
+        expect(ref, isA<Reference>());
+        expect(ref.fullPath, testPath);
+        verify(kMockStoragePlatform.ref(testPath));
+      });
+
       test("verify delegate method when url starts with 'gs://'", () {
         const String testPath = 'bar/baz.png';
         const String url = 'gs://foo/$testPath';

--- a/packages/firebase_storage/firebase_storage/test/firebase_storage_test.dart
+++ b/packages/firebase_storage/firebase_storage/test/firebase_storage_test.dart
@@ -154,7 +154,6 @@ void main() {
         final ref = storage.refFromURL(url);
 
         expect(ref, isA<Reference>());
-        expect(ref.fullPath, testPath);
         verify(kMockStoragePlatform.ref(testPath));
       });
 

--- a/packages/firebase_storage/firebase_storage/test/utils_test.dart
+++ b/packages/firebase_storage/firebase_storage/test/utils_test.dart
@@ -83,6 +83,16 @@ void main() {
       expect(result['path'], '1mbTestFile.gif');
     });
 
+    test('parses a un-encoded https url with special characters', () {
+      String url =
+          'https://firebasestorage.googleapis.com/v0/b/valid-url.appspot.com/o/foo+bar/file with  spaces .png?alt=media';
+
+      final result = partsFromHttpUrl(url)!;
+
+      expect(result['bucket'], 'valid-url.appspot.com');
+      expect(result['path'], 'foo+bar/file with  spaces .png');
+    });
+
     // TODO(helenaford): regexp can't handle no paths
     // test('sets path to default if null', () {
     //   String url =


### PR DESCRIPTION
## Description

Allows storage references to be created via URLs with spaces and `+` symbols. 

## Related Issues

Fixes https://github.com/FirebaseExtended/flutterfire/issues/5673
Fixes https://github.com/FirebaseExtended/flutterfire/issues/4908

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
