### PR TITLE
fix(functions): return correct type on native

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -8,3 +8,4 @@ end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
+quote_type = single

--- a/.github/workflows/scripts/functions/src/index.ts
+++ b/.github/workflows/scripts/functions/src/index.ts
@@ -1,17 +1,17 @@
-import * as assert from "assert";
-import * as functions from "firebase-functions";
+import * as assert from 'assert';
+import * as functions from 'firebase-functions';
 
 // For example app.
 // noinspection JSUnusedGlobalSymbols
 export const listFruit = functions.https.onCall(() => {
-  return ["Apple", "Banana", "Cherry", "Date", "Fig", "Grapes"];
+  return ['Apple', 'Banana', 'Cherry', 'Date', 'Fig', 'Grapes'];
 });
 
 // For e2e testing a custom region.
 // noinspection JSUnusedGlobalSymbols
 export const testFunctionCustomRegion = functions
-  .region("europe-west1")
-  .https.onCall(() => "europe-west1");
+  .region('europe-west1')
+  .https.onCall(() => 'europe-west1');
 
 // For e2e testing timeouts.
 export const testFunctionTimeout = functions.https.onCall((data) => {
@@ -19,14 +19,14 @@ export const testFunctionTimeout = functions.https.onCall((data) => {
   return new Promise((resolve, reject) => {
     if (data && data.testTimeout) {
       setTimeout(
-        () => resolve({ timeLimit: "exceeded" }),
+        () => resolve({ timeLimit: 'exceeded' }),
         parseInt(data.testTimeout, 10)
       );
     } else {
       reject(
         new functions.https.HttpsError(
-          "invalid-argument",
-          "testTimeout must be provided."
+          'invalid-argument',
+          'testTimeout must be provided.'
         )
       );
     }
@@ -37,68 +37,68 @@ export const testFunctionTimeout = functions.https.onCall((data) => {
 // noinspection JSUnusedGlobalSymbols
 export const testFunctionDefaultRegion = functions.https.onCall((data) => {
   console.log(JSON.stringify({ data }));
-  if (typeof data === "undefined") {
-    return "undefined";
+  if (typeof data === 'undefined') {
+    return 'undefined';
   }
 
-  if (typeof data === "string") {
-    return "string";
+  if (typeof data === 'string') {
+    return 'string';
   }
 
-  if (typeof data === "number") {
-    return "number";
+  if (typeof data === 'number') {
+    return 'number';
   }
 
-  if (typeof data === "boolean") {
-    return "boolean";
+  if (typeof data === 'boolean') {
+    return 'boolean';
   }
 
   if (data === null) {
-    return "null";
+    return 'null';
   }
 
   if (Array.isArray(data)) {
-    return "array";
+    return 'array';
   }
 
   const sampleData: {
     [key: string]: any;
   } = {
     number: 1234,
-    string: "acde",
+    string: 'acde',
     boolean: true,
     null: null,
     map: {
       number: 1234,
-      string: "acde",
+      string: 'acde',
       boolean: true,
       null: null,
     },
-    list: [1234, "acde", true, null],
+    list: [1234, 'acde', true, null],
     deepMap: {
       number: 123,
-      string: "foo",
+      string: 'foo',
       booleanTrue: true,
       booleanFalse: false,
       null: null,
-      list: ["1", 2, true, false],
+      list: ['1', 2, true, false],
       map: {
         number: 123,
-        string: "foo",
+        string: 'foo',
         booleanTrue: true,
         booleanFalse: false,
         null: null,
       },
     },
     deepList: [
-      "1",
+      '1',
       2,
       true,
       false,
-      ["1", 2, true, false],
+      ['1', 2, true, false],
       {
         number: 123,
-        string: "foo",
+        string: 'foo',
         booleanTrue: true,
         booleanFalse: false,
         null: null,
@@ -117,8 +117,8 @@ export const testFunctionDefaultRegion = functions.https.onCall((data) => {
   } = data;
   if (!Object.hasOwnProperty.call(sampleData, type)) {
     throw new functions.https.HttpsError(
-      "invalid-argument",
-      "Invalid test requested."
+      'invalid-argument',
+      'Invalid test requested.'
     );
   }
 
@@ -129,8 +129,8 @@ export const testFunctionDefaultRegion = functions.https.onCall((data) => {
   } catch (e) {
     console.error(e);
     throw new functions.https.HttpsError(
-      "invalid-argument",
-      "Input and Output types did not match.",
+      'invalid-argument',
+      'Input and Output types did not match.',
       e.message
     );
   }
@@ -138,8 +138,8 @@ export const testFunctionDefaultRegion = functions.https.onCall((data) => {
   // all good
   if (asError) {
     throw new functions.https.HttpsError(
-      "cancelled",
-      "Response data was requested to be sent as part of an Error payload, so here we are!",
+      'cancelled',
+      'Response data was requested to be sent as part of an Error payload, so here we are!',
       outputData
     );
   }
@@ -148,5 +148,5 @@ export const testFunctionDefaultRegion = functions.https.onCall((data) => {
 });
 
 export const testMapConvertType = functions.https.onCall((data) => ({
-  foo: "bar",
+  foo: 'bar',
 }));

--- a/.github/workflows/scripts/functions/src/index.ts
+++ b/.github/workflows/scripts/functions/src/index.ts
@@ -1,105 +1,104 @@
 import * as assert from "assert";
-import * as functions from 'firebase-functions';
+import * as functions from "firebase-functions";
 
 // For example app.
 // noinspection JSUnusedGlobalSymbols
 export const listFruit = functions.https.onCall(() => {
-  return [
-    "Apple",
-    "Banana",
-    "Cherry",
-    "Date",
-    "Fig",
-    "Grapes"
-  ];
+  return ["Apple", "Banana", "Cherry", "Date", "Fig", "Grapes"];
 });
-
 
 // For e2e testing a custom region.
 // noinspection JSUnusedGlobalSymbols
 export const testFunctionCustomRegion = functions
-  .region('europe-west1')
-  .https.onCall(() => 'europe-west1');
+  .region("europe-west1")
+  .https.onCall(() => "europe-west1");
 
 // For e2e testing timeouts.
-export const testFunctionTimeout = functions
-  .https.onCall(data => {
-    console.log(JSON.stringify({data}));
-    return new Promise((resolve, reject) => {
-      if (data && data.testTimeout) {
-        setTimeout(() => resolve({timeLimit: 'exceeded'}), parseInt(data.testTimeout, 10));
-      } else {
-        reject(new functions.https.HttpsError(
-          'invalid-argument',
-          'testTimeout must be provided.'
-        ));
-      }
-    });
+export const testFunctionTimeout = functions.https.onCall((data) => {
+  console.log(JSON.stringify({ data }));
+  return new Promise((resolve, reject) => {
+    if (data && data.testTimeout) {
+      setTimeout(
+        () => resolve({ timeLimit: "exceeded" }),
+        parseInt(data.testTimeout, 10)
+      );
+    } else {
+      reject(
+        new functions.https.HttpsError(
+          "invalid-argument",
+          "testTimeout must be provided."
+        )
+      );
+    }
   });
+});
 
 // For e2e testing errors & return values.
 // noinspection JSUnusedGlobalSymbols
-export const testFunctionDefaultRegion = functions.https.onCall(data => {
-  console.log(JSON.stringify({data}));
-  if (typeof data === 'undefined') {
-    return 'undefined';
+export const testFunctionDefaultRegion = functions.https.onCall((data) => {
+  console.log(JSON.stringify({ data }));
+  if (typeof data === "undefined") {
+    return "undefined";
   }
 
-  if (typeof data === 'string') {
-    return 'string';
+  if (typeof data === "string") {
+    return "string";
   }
 
-  if (typeof data === 'number') {
-    return 'number';
+  if (typeof data === "number") {
+    return "number";
   }
 
-  if (typeof data === 'boolean') {
-    return 'boolean';
+  if (typeof data === "boolean") {
+    return "boolean";
   }
 
   if (data === null) {
-    return 'null';
+    return "null";
   }
 
   if (Array.isArray(data)) {
-    return 'array';
+    return "array";
   }
 
   const sampleData: {
-    [key: string]: any
+    [key: string]: any;
   } = {
     number: 1234,
-    string: 'acde',
+    string: "acde",
     boolean: true,
-    'null': null,
+    null: null,
     map: {
       number: 1234,
-      string: 'acde',
+      string: "acde",
       boolean: true,
       null: null,
     },
-    list: [1234, 'acde', true, null],
+    list: [1234, "acde", true, null],
     deepMap: {
       number: 123,
-      string: 'foo',
+      string: "foo",
       booleanTrue: true,
       booleanFalse: false,
       null: null,
-      'list': ['1', 2, true, false],
-      'map': {
+      list: ["1", 2, true, false],
+      map: {
         number: 123,
-        string: 'foo',
+        string: "foo",
         booleanTrue: true,
         booleanFalse: false,
         null: null,
       },
     },
     deepList: [
-      '1', 2, true, false,
-      ['1', 2, true, false],
+      "1",
+      2,
+      true,
+      false,
+      ["1", 2, true, false],
       {
         number: 123,
-        string: 'foo',
+        string: "foo",
         booleanTrue: true,
         booleanFalse: false,
         null: null,
@@ -107,15 +106,19 @@ export const testFunctionDefaultRegion = functions.https.onCall(data => {
     ],
   };
 
-  const {type, asError, inputData}: {
-    type: string,
-    asError?: boolean,
-    inputData?: any,
+  const {
+    type,
+    asError,
+    inputData,
+  }: {
+    type: string;
+    asError?: boolean;
+    inputData?: any;
   } = data;
   if (!Object.hasOwnProperty.call(sampleData, type)) {
     throw new functions.https.HttpsError(
-      'invalid-argument',
-      'Invalid test requested.'
+      "invalid-argument",
+      "Invalid test requested."
     );
   }
 
@@ -126,8 +129,8 @@ export const testFunctionDefaultRegion = functions.https.onCall(data => {
   } catch (e) {
     console.error(e);
     throw new functions.https.HttpsError(
-      'invalid-argument',
-      'Input and Output types did not match.',
+      "invalid-argument",
+      "Input and Output types did not match.",
       e.message
     );
   }
@@ -135,8 +138,8 @@ export const testFunctionDefaultRegion = functions.https.onCall(data => {
   // all good
   if (asError) {
     throw new functions.https.HttpsError(
-      'cancelled',
-      'Response data was requested to be sent as part of an Error payload, so here we are!',
+      "cancelled",
+      "Response data was requested to be sent as part of an Error payload, so here we are!",
       outputData
     );
   }
@@ -144,3 +147,6 @@ export const testFunctionDefaultRegion = functions.https.onCall(data => {
   return outputData;
 });
 
+export const testMapConvertType = functions.https.onCall((data) => ({
+  foo: "bar",
+}));

--- a/packages/cloud_functions/cloud_functions/example/test_driver/cloud_functions_e2e.dart
+++ b/packages/cloud_functions/cloud_functions/example/test_driver/cloud_functions_e2e.dart
@@ -87,7 +87,8 @@ void testsMain() {
     test(
         '[HttpsCallableResult.data] should return Map<String, dynamic> type for returned objects',
         () async {
-      callable = FirebaseFunctions.instance.httpsCallable(kTestMapConvertType);
+      HttpsCallable callable =
+          FirebaseFunctions.instance.httpsCallable(kTestMapConvertType);
 
       var result = await callable();
 

--- a/packages/cloud_functions/cloud_functions/example/test_driver/cloud_functions_e2e.dart
+++ b/packages/cloud_functions/cloud_functions/example/test_driver/cloud_functions_e2e.dart
@@ -83,7 +83,7 @@ void testsMain() {
       });
       expect(result.data, equals(data.deepList));
     });
-    
+
     test(
         '[HttpsCallableResult.data] should return Map<String, dynamic> type for returned objects',
         () async {

--- a/packages/cloud_functions/cloud_functions/example/test_driver/cloud_functions_e2e.dart
+++ b/packages/cloud_functions/cloud_functions/example/test_driver/cloud_functions_e2e.dart
@@ -16,6 +16,7 @@ import 'sample.dart' as data;
 String kTestFunctionDefaultRegion = 'testFunctionDefaultRegion';
 String kTestFunctionCustomRegion = 'testFunctionCustomRegion';
 String kTestFunctionTimeout = 'testFunctionTimeout';
+String kTestMapConvertType = 'testMapConvertType';
 
 void testsMain() {
   HttpsCallable callable;
@@ -81,6 +82,16 @@ void testsMain() {
         'inputData': data.deepList,
       });
       expect(result.data, equals(data.deepList));
+    });
+    
+    test(
+        '[HttpsCallableResult.data] should return Map<String, dynamic> type for returned objects',
+        () async {
+      callable = FirebaseFunctions.instance.httpsCallable(kTestMapConvertType);
+
+      var result = await callable();
+
+      expect(result.data, isA<Map<String, dynamic>>());
     });
   });
 

--- a/packages/cloud_functions/cloud_functions_platform_interface/lib/src/method_channel/method_channel_https_callable.dart
+++ b/packages/cloud_functions/cloud_functions_platform_interface/lib/src/method_channel/method_channel_https_callable.dart
@@ -17,8 +17,8 @@ class MethodChannelHttpsCallable extends HttpsCallablePlatform {
       : super(functions, origin, name, options);
 
   @override
-  Future<dynamic> call([dynamic parameters]) {
-    return MethodChannelFirebaseFunctions.channel
+  Future<dynamic> call([dynamic parameters]) async {
+    dynamic result = await MethodChannelFirebaseFunctions.channel
         .invokeMethod('FirebaseFunctions#call', <String, dynamic>{
       'appName': functions.app!.name,
       'functionName': name,
@@ -27,5 +27,11 @@ class MethodChannelHttpsCallable extends HttpsCallablePlatform {
       'timeout': options.timeout.inMilliseconds,
       'parameters': parameters,
     }).catchError(catchPlatformException);
+
+    if (result is Map<dynamic, dynamic>) {
+      return Map<String, dynamic>.from(result);
+    } else {
+      return result;
+    }
   }
 }

--- a/packages/cloud_functions/cloud_functions_platform_interface/lib/src/method_channel/method_channel_https_callable.dart
+++ b/packages/cloud_functions/cloud_functions_platform_interface/lib/src/method_channel/method_channel_https_callable.dart
@@ -17,8 +17,8 @@ class MethodChannelHttpsCallable extends HttpsCallablePlatform {
       : super(functions, origin, name, options);
 
   @override
-  Future<dynamic> call([dynamic parameters]) async {
-    dynamic result = await MethodChannelFirebaseFunctions.channel
+  Future<dynamic> call([Object? parameters]) async {
+    Object? result = await MethodChannelFirebaseFunctions.channel
         .invokeMethod('FirebaseFunctions#call', <String, dynamic>{
       'appName': functions.app!.name,
       'functionName': name,

--- a/packages/cloud_functions/cloud_functions_platform_interface/lib/src/method_channel/method_channel_https_callable.dart
+++ b/packages/cloud_functions/cloud_functions_platform_interface/lib/src/method_channel/method_channel_https_callable.dart
@@ -28,7 +28,7 @@ class MethodChannelHttpsCallable extends HttpsCallablePlatform {
       'parameters': parameters,
     }).catchError(catchPlatformException);
 
-    if (result is Map<dynamic, dynamic>) {
+    if (result is Map) {
       return Map<String, dynamic>.from(result);
     } else {
       return result;


### PR DESCRIPTION
## Description

If a cloud function returns an object, the return type ought to be `Map<String, dynamic>`, not `Map<dynamic, dynamic>` as per JSON spec. This problem affects `iOS` & `android`, `web` returns the correct type.

## Related Issues

fixes #4059

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
