### PR TITLE
fix: Handling padding present in some devices.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -53,3 +53,4 @@ Marko Devcic <madevcic@gmail.com>
 Akora Ing. DKB <akoraingdkb@gmail.com>
 Samay Bhattacharyya <contact@samay.dev>
 Kevin McGill <kevin@mcgilldevtech.com>
+Panmari <smmuzi@gmail.com>

--- a/packages/firebase_ml_vision/android/build.gradle
+++ b/packages/firebase_ml_vision/android/build.gradle
@@ -16,6 +16,7 @@ rootProject.allprojects {
     repositories {
         google()
         jcenter()
+        mavenCentral()
     }
 }
 

--- a/packages/firebase_ml_vision/android/src/main/java/io/flutter/plugins/firebasemlvision/FirebaseMlVisionHandler.java
+++ b/packages/firebase_ml_vision/android/src/main/java/io/flutter/plugins/firebasemlvision/FirebaseMlVisionHandler.java
@@ -14,6 +14,7 @@ import io.flutter.plugin.common.MethodCall;
 import io.flutter.plugin.common.MethodChannel;
 import java.io.File;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Map;
 
 class FirebaseMlVisionHandler implements MethodChannel.MethodCallHandler {
@@ -131,10 +132,16 @@ class FirebaseMlVisionHandler implements MethodChannel.MethodCallHandler {
       case "bytes":
         @SuppressWarnings("unchecked")
         Map<String, Object> metadataData = (Map<String, Object>) imageData.get("metadata");
-
+        ArrayList<Map<String, Object>> planeMetadata =
+            (ArrayList<Map<String, Object>>) metadataData.get("planeData");
+        int width = (int) (double) metadataData.get("width");
+        if (planeMetadata != null && planeMetadata.size() > 0) {
+          // Some devices add additional padding to width. This is properly represented in bytesPerRow.
+          width = (int) planeMetadata.get(0).get("bytesPerRow");
+        }
         FirebaseVisionImageMetadata metadata =
             new FirebaseVisionImageMetadata.Builder()
-                .setWidth((int) (double) metadataData.get("width"))
+                .setWidth(width)
                 .setHeight((int) (double) metadataData.get("height"))
                 .setFormat(FirebaseVisionImageMetadata.IMAGE_FORMAT_NV21)
                 .setRotation(getRotation((int) metadataData.get("rotation")))


### PR DESCRIPTION
## Description

Using width directly doesn't account for the additional padding that is
returned by some cameras. For further references, see e.g.
https://gist.github.com/Alby-o/fe87e35bc21d534c8220aed7df028e03#gistcomment-3218349

Image labeller started detecting real labels on my test devices (Pixel
3a and Pixel3) with this patch.

## Related Issues

* https://github.com/FirebaseExtended/flutterfire/issues/5501
* https://github.com/FirebaseExtended/flutterfire/issues/3798

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
