### PR TITLE
fix(firebase_crashlytics): Avoid duplicate prints

### DIFF
--- a/packages/firebase_crashlytics/firebase_crashlytics/lib/src/firebase_crashlytics.dart
+++ b/packages/firebase_crashlytics/firebase_crashlytics/lib/src/firebase_crashlytics.dart
@@ -135,12 +135,13 @@ class FirebaseCrashlytics extends FirebasePluginPlatform {
     FlutterError.dumpErrorToConsole(flutterErrorDetails, forceReport: true);
 
     return recordError(
-        flutterErrorDetails.exceptionAsString(), flutterErrorDetails.stack,
-        reason: flutterErrorDetails.context,
-        information: flutterErrorDetails.informationCollector == null
-            ? []
-            : flutterErrorDetails.informationCollector!(),
-        printDetails: false,
+      flutterErrorDetails.exceptionAsString(),
+      flutterErrorDetails.stack,
+      reason: flutterErrorDetails.context,
+      information: flutterErrorDetails.informationCollector == null
+          ? []
+          : flutterErrorDetails.informationCollector!(),
+      printDetails: false,
     );
   }
 

--- a/packages/firebase_crashlytics/firebase_crashlytics/lib/src/firebase_crashlytics.dart
+++ b/packages/firebase_crashlytics/firebase_crashlytics/lib/src/firebase_crashlytics.dart
@@ -139,7 +139,9 @@ class FirebaseCrashlytics extends FirebasePluginPlatform {
         reason: flutterErrorDetails.context,
         information: flutterErrorDetails.informationCollector == null
             ? []
-            : flutterErrorDetails.informationCollector!());
+            : flutterErrorDetails.informationCollector!(),
+        printDetails: false,
+    );
   }
 
   /// Logs a message that's included in the next fatal or non-fatal report.


### PR DESCRIPTION
## Description

Errors already printed with `FlutterError.dumpErrorToConsole` (L135). No need to print again with `recordError`.

## Related Issues

None

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
