### PR TITLE
docs: add unit test libraries to the list of plugins

### DIFF
--- a/website/plugins.js
+++ b/website/plugins.js
@@ -25,7 +25,7 @@ module.exports = [
     name: 'Authentication',
     pub: 'firebase_auth',
     firebase: 'auth',
-    documentation: 'https://pub.dev/documentation/firebase_auth_mocks',
+    documentation: 'https://firebase.flutter.dev/docs/auth/overview',
     support: {
       web: true,
       mobile: true,

--- a/website/plugins.js
+++ b/website/plugins.js
@@ -25,7 +25,19 @@ module.exports = [
     name: 'Authentication',
     pub: 'firebase_auth',
     firebase: 'auth',
-    documentation: 'https://firebase.flutter.dev/docs/auth/overview',
+    documentation: 'https://pub.dev/documentation/firebase_auth_mocks',
+    support: {
+      web: true,
+      mobile: true,
+      macos: true,
+    },
+  },
+  {
+    name: 'Authentication Mocks',
+    pub: 'firebase_auth_mocks',
+    firebase: 'auth',
+    documentation: 'https://pub.dev/documentation/firebase_auth_mocks',
+    remoteSource: 'https://github.com/atn832/firebase_auth_mocks',
     support: {
       web: true,
       mobile: true,
@@ -37,6 +49,18 @@ module.exports = [
     pub: 'cloud_firestore',
     firebase: 'firestore',
     documentation: 'https://firebase.flutter.dev/docs/firestore/overview',
+    support: {
+      web: true,
+      mobile: true,
+      macos: true,
+    },
+  },
+  {
+    name: 'Cloud Firestore Mocks',
+    pub: 'cloud_firestore_mocks',
+    firebase: 'firestore',
+    documentation: 'https://pub.dev/documentation/cloud_firestore_mocks',
+    remoteSource: 'https://github.com/atn832/cloud_firestore_mocks',
     support: {
       web: true,
       mobile: true,
@@ -70,6 +94,18 @@ module.exports = [
     pub: 'firebase_storage',
     firebase: 'storage',
     documentation: 'https://firebase.flutter.dev/docs/storage/overview',
+    support: {
+      web: true,
+      mobile: true,
+      macos: true,
+    },
+  },
+  {
+    name: 'Cloud Storage Mocks',
+    pub: 'firebase_storage_mocks',
+    firebase: 'storage',
+    documentation: 'https://pub.dev/packages/firebase_storage_mocks',
+    remoteSource: 'https://github.com/atn832/firebase_storage_mocks',
     support: {
       web: true,
       mobile: true,


### PR DESCRIPTION
## Description

Add the following unit test libraries to the list of plugins:
- [cloud_firestore_mocks](https://pub.dev/packages/cloud_firestore_mocks)
- [firebase_auth_mocks](https://pub.dev/packages/firebase_auth_mocks)
- [firebase_storage_mocks](https://pub.dev/packages/firebase_storage_mocks)

## Related Issues

As per https://github.com/FirebaseExtended/flutterfire/discussions/5550#discussioncomment-557644, I am adding documentation about the unit testing libraries onto the website.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
