### PR TITLE
fix(cloud_firestore): conditionally pass options to docChanges

### DIFF
--- a/packages/cloud_firestore/cloud_firestore_web/lib/src/interop/firestore.dart
+++ b/packages/cloud_firestore/cloud_firestore_web/lib/src/interop/firestore.dart
@@ -409,14 +409,18 @@ class QuerySnapshot
 
   // TODO: [SnapshotListenOptions options]
   List<DocumentChange> docChanges(
-          [firestore_interop.SnapshotListenOptions? options]) =>
-      jsObject
-          .docChanges(jsify(options))
-          // explicitly typing the param as dynamic to work-around
-          // https://github.com/dart-lang/sdk/issues/33537
-          // ignore: unnecessary_lambdas
-          .map((dynamic e) => DocumentChange.getInstance(e))
-          .toList();
+      [firestore_interop.SnapshotListenOptions? options]) {
+    List<firestore_interop.DocumentChangeJsImpl> changes = options != null
+        ? jsObject.docChanges(jsify(options))
+        : jsObject.docChanges();
+
+    return changes
+        // explicitly typing the param as dynamic to work-around
+        // https://github.com/dart-lang/sdk/issues/33537
+        // ignore: unnecessary_lambdas
+        .map((dynamic e) => DocumentChange.getInstance(e))
+        .toList();
+  }
 
   List<DocumentSnapshot?> get docs => jsObject.docs
       // explicitly typing the param as dynamic to work-around


### PR DESCRIPTION
## Description

Since version 8.0.2 of the Firestore web sdk, it seems passing `null` to `docChanges` causes the underlying SDK to assume the user passed options, which causes a "null pointer exception".

This change wraps the options check, and doesn't pass arguments (`undefined`) instead.

Line of code: https://github.com/firebase/firebase-js-sdk/blob/626c05b36cfe7f91ac9b6aad730c0f04d6bb8c01/packages/firestore/src/exp/snapshot.ts#L445

## Related Issues

Fixes https://github.com/FirebaseExtended/flutterfire/issues/4127

Unblocks https://github.com/FirebaseExtended/flutterfire/pull/5170

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
