### PR TITLE
feat(android,auth): make useEmualtor localhost mapping optional

### DIFF
--- a/packages/firebase_auth/firebase_auth/lib/src/firebase_auth.dart
+++ b/packages/firebase_auth/firebase_auth/lib/src/firebase_auth.dart
@@ -80,12 +80,12 @@ class FirebaseAuth extends FirebasePluginPlatform {
   ///
   /// Note: auth emulator is not supported for web yet. firebase-js-sdk does not support
   /// auth.useEmulator until v8.2.4, but FlutterFire does not support firebase-js-sdk v8+ yet
-  Future<void> useEmulator(String origin) async {
+  Future<void> useEmulator(String origin, {bool mapLocalhost = true}) async {
     assert(origin.isNotEmpty);
     String mappedOrigin = origin;
 
     // Android considers localhost as 10.0.2.2 - automatically handle this for users.
-    if (defaultTargetPlatform == TargetPlatform.android) {
+    if (defaultTargetPlatform == TargetPlatform.android && mapLocalhost) {
       if (mappedOrigin.startsWith('http://localhost')) {
         mappedOrigin =
             mappedOrigin.replaceFirst('http://localhost', 'http://10.0.2.2');


### PR DESCRIPTION
## Description

The mapping of localhost emulator to 10.0.2.2 prevents developers from using useEmulator with real devices (using adb forward to forward the firebase emualtor on the host to the device).

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [ ] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
