### PR TITLE
fix(cloud_firestore): Clear event listeners when firebase core is reinitialised 

### DIFF
--- a/packages/cloud_firestore/cloud_firestore/android/src/main/java/io/flutter/plugins/firebase/firestore/FlutterFirebaseFirestorePlugin.java
+++ b/packages/cloud_firestore/cloud_firestore/android/src/main/java/io/flutter/plugins/firebase/firestore/FlutterFirebaseFirestorePlugin.java
@@ -115,17 +115,7 @@ public class FlutterFirebaseFirestorePlugin
     channel.setMethodCallHandler(null);
     channel = null;
 
-    for (String identifier : eventChannels.keySet()) {
-      eventChannels.get(identifier).setStreamHandler(null);
-    }
-    eventChannels.clear();
-
-    for (String identifier : streamHandlers.keySet()) {
-      streamHandlers.get(identifier).onCancel(null);
-    }
-    streamHandlers.clear();
-
-    transactionHandlers.clear();
+    removeEventListeners();
 
     binaryMessenger = null;
   }
@@ -507,6 +497,9 @@ public class FlutterFirebaseFirestorePlugin
             FlutterFirebaseFirestorePlugin.destroyCachedFirebaseFirestoreInstanceForKey(
                 app.getName());
           }
+
+          removeEventListeners();
+
           return null;
         });
   }
@@ -551,5 +544,19 @@ public class FlutterFirebaseFirestorePlugin
     streamHandlers.put(identifier, handler);
 
     return identifier;
+  }
+
+  private void removeEventListeners() {
+    for (String identifier : eventChannels.keySet()) {
+      eventChannels.get(identifier).setStreamHandler(null);
+    }
+    eventChannels.clear();
+
+    for (String identifier : streamHandlers.keySet()) {
+      streamHandlers.get(identifier).onCancel(null);
+    }
+    streamHandlers.clear();
+
+    transactionHandlers.clear();
   }
 }


### PR DESCRIPTION
## Description

This part was missing int he cloud_firestore work previously.
Event listeners should be reset when firebase core is reinitialised.

## Related Issues

Discussed in #4416 

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
