### PR TITLE
fix(storage,web): secondary storage buckets now work as expected on Web

### DIFF
--- a/packages/firebase_storage/firebase_storage/example/test_driver/task_e2e.dart
+++ b/packages/firebase_storage/firebase_storage/example/test_driver/task_e2e.dart
@@ -169,7 +169,7 @@ void runTaskTests() {
 
         String url = await snapshot.ref.getDownloadURL();
 
-        expect(url, contains("/$secondaryBucket/"));
+        expect(url, contains('/$secondaryBucket/'));
       });
     });
 

--- a/packages/firebase_storage/firebase_storage/example/test_driver/task_e2e.dart
+++ b/packages/firebase_storage/firebase_storage/example/test_driver/task_e2e.dart
@@ -157,6 +157,20 @@ void runTaskTests() {
         expect(snapshot.totalBytes, completedSnapshot.totalBytes);
         expect(snapshot.metadata, isA<FullMetadata>());
       });
+
+      test('upload task to a custom bucket', () async {
+        String secondaryBucket = 'react-native-firebase-testing';
+        Reference storageReference =
+            FirebaseStorage.instanceFor(bucket: secondaryBucket).ref('/ok.txt');
+
+        UploadTask task = storageReference.putString('test second bucket');
+
+        TaskSnapshot snapshot = await task;
+
+        String url = await snapshot.ref.getDownloadURL();
+
+        expect(url, contains("/$secondaryBucket/"));
+      });
     });
 
     group('cancel()', () {

--- a/packages/firebase_storage/firebase_storage_web/lib/src/firebase_storage_web.dart
+++ b/packages/firebase_storage/firebase_storage_web/lib/src/firebase_storage_web.dart
@@ -21,7 +21,6 @@ typedef ReferenceBuilder = ReferencePlatform Function(
 /// The Web implementation of the FirebaseStoragePlatform.
 class FirebaseStorageWeb extends FirebaseStoragePlatform {
   /// Construct the plugin.
-  /// (Web doesn't use the `bucket`, since the init happens in index.html)
   FirebaseStorageWeb({FirebaseApp? app, required String bucket})
       : webStorage = storage_interop.getStorageInstance(
             core_interop.app(app?.name), bucket),

--- a/packages/firebase_storage/firebase_storage_web/lib/src/firebase_storage_web.dart
+++ b/packages/firebase_storage/firebase_storage_web/lib/src/firebase_storage_web.dart
@@ -90,7 +90,7 @@ class FirebaseStorageWeb extends FirebaseStoragePlatform {
     return guard(() {
       ReferenceBuilder refBuilderFunction = refBuilder ?? _createReference;
       ReferencePlatform ref = refBuilderFunction(this, path);
-      print("RRRRRR: " + ref.bucket.toString());
+
       return ref;
     });
   }

--- a/packages/firebase_storage/firebase_storage_web/lib/src/firebase_storage_web.dart
+++ b/packages/firebase_storage/firebase_storage_web/lib/src/firebase_storage_web.dart
@@ -23,8 +23,8 @@ class FirebaseStorageWeb extends FirebaseStoragePlatform {
   /// Construct the plugin.
   /// (Web doesn't use the `bucket`, since the init happens in index.html)
   FirebaseStorageWeb({FirebaseApp? app, required String bucket})
-      : webStorage =
-            storage_interop.getStorageInstance(core_interop.app(app?.name)),
+      : webStorage = storage_interop.getStorageInstance(
+            core_interop.app(app?.name), bucket),
         super(appInstance: app, bucket: bucket);
 
   // Empty constructor. This is only used by the registerWith method.
@@ -91,6 +91,7 @@ class FirebaseStorageWeb extends FirebaseStoragePlatform {
     return guard(() {
       ReferenceBuilder refBuilderFunction = refBuilder ?? _createReference;
       ReferencePlatform ref = refBuilderFunction(this, path);
+      print("RRRRRR: " + ref.bucket.toString());
       return ref;
     });
   }

--- a/packages/firebase_storage/firebase_storage_web/lib/src/interop/firebase_interop.dart
+++ b/packages/firebase_storage/firebase_storage_web/lib/src/interop/firebase_interop.dart
@@ -13,4 +13,9 @@ import 'package:js/js.dart';
 import 'storage_interop.dart';
 
 @JS()
-external StorageJsImpl storage([AppJsImpl? app]);
+abstract class AppStorageJsImpl extends AppJsImpl {
+  external StorageJsImpl storage([String? bucket]);
+}
+
+@JS()
+external AppStorageJsImpl app([String? name]);

--- a/packages/firebase_storage/firebase_storage_web/lib/src/interop/storage.dart
+++ b/packages/firebase_storage/firebase_storage_web/lib/src/interop/storage.dart
@@ -20,10 +20,12 @@ export 'storage_interop.dart';
 enum TaskState { RUNNING, PAUSED, SUCCESS, CANCELED, ERROR }
 
 /// Given an AppJSImp, return the Storage instance.
-Storage getStorageInstance([App? app]) {
-  return Storage.getInstance(app != null
-      ? firebase_interop.storage(app.jsObject)
-      : firebase_interop.storage());
+Storage getStorageInstance([App? app, String? bucket]) {
+  firebase_interop.AppStorageJsImpl appImpl =
+      app != null ? firebase_interop.app(app.name) : firebase_interop.app();
+
+  return Storage.getInstance(
+      bucket != null ? appImpl.storage(bucket) : appImpl.storage());
 }
 
 /// A service for uploading and downloading large objects to and from the


### PR DESCRIPTION
## Description

Web storage bucket was always default. This allows user to choose bucket for each Firebase project.

## Related Issues

fixes #5803

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
