### PR TITLE
fix: provide explicit types for StreamController(s).

### DIFF
--- a/packages/firebase_messaging/firebase_messaging/lib/src/messaging.dart
+++ b/packages/firebase_messaging/firebase_messaging/lib/src/messaging.dart
@@ -52,7 +52,8 @@ class FirebaseMessaging extends FirebasePluginPlatform {
   //
   // static final Map<String, FirebaseMessaging> _cachedInstances = {};
 
-  static final _onMessageController =
+  // ignore: close_sinks
+  static final StreamController<RemoteMessage> _onMessageController =
       StreamController<RemoteMessage>.broadcast(onListen: () {
     Stream<RemoteMessage> onMessageStream =
         FirebaseMessagingPlatform.onMessage.stream;
@@ -69,7 +70,8 @@ class FirebaseMessaging extends FirebasePluginPlatform {
   /// see [onBackgroundMessage].
   static Stream<RemoteMessage> get onMessage => _onMessageController.stream;
 
-  static final _onMessageOpenedAppController =
+  // ignore: close_sinks
+  static final StreamController<RemoteMessage> _onMessageOpenedAppController =
       StreamController<RemoteMessage>.broadcast(onListen: () {
     Stream<RemoteMessage> onMessageOpenedAppStream =
         FirebaseMessagingPlatform.onMessageOpenedApp.stream;


### PR DESCRIPTION
IMHO it is better to have explicit types of fields, and it seems that other fields have them.
The real reason is that we are making a small change to the analyzer inference that makes it an error when there is a cycle in the references during inference. Specifically, here `_onMessageController` references itself in its initializer, so potentially its type depends on itself. It could be improved, but for now a less sophisticated way it is.