### PR TITLE
fix(cloud_functions): bubble exceptions

### DIFF
--- a/packages/cloud_functions/cloud_functions_platform_interface/lib/src/method_channel/method_channel_https_callable.dart
+++ b/packages/cloud_functions/cloud_functions_platform_interface/lib/src/method_channel/method_channel_https_callable.dart
@@ -18,20 +18,24 @@ class MethodChannelHttpsCallable extends HttpsCallablePlatform {
 
   @override
   Future<dynamic> call([Object? parameters]) async {
-    Object? result = await MethodChannelFirebaseFunctions.channel
-        .invokeMethod('FirebaseFunctions#call', <String, dynamic>{
-      'appName': functions.app!.name,
-      'functionName': name,
-      'origin': origin,
-      'region': functions.region,
-      'timeout': options.timeout.inMilliseconds,
-      'parameters': parameters,
-    }).catchError(catchPlatformException);
+    try {
+      Object? result = await MethodChannelFirebaseFunctions.channel
+          .invokeMethod('FirebaseFunctions#call', <String, dynamic>{
+        'appName': functions.app!.name,
+        'functionName': name,
+        'origin': origin,
+        'region': functions.region,
+        'timeout': options.timeout.inMilliseconds,
+        'parameters': parameters,
+      });
 
-    if (result is Map) {
-      return Map<String, dynamic>.from(result);
-    } else {
-      return result;
+      if (result is Map) {
+        return Map<String, dynamic>.from(result);
+      } else {
+        return result;
+      }
+    } catch (e, s) {
+      throw convertPlatformException(e, s);
     }
   }
 }

--- a/packages/cloud_functions/cloud_functions_platform_interface/lib/src/method_channel/utils/exception.dart
+++ b/packages/cloud_functions/cloud_functions_platform_interface/lib/src/method_channel/utils/exception.dart
@@ -2,23 +2,20 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'dart:async';
-
 import 'package:firebase_core/firebase_core.dart';
 import 'package:flutter/services.dart';
+
 import '../../../cloud_functions_platform_interface.dart';
 
-/// Catches a [PlatformException] and converts it into a [FirebaseFunctionsException]
-/// if it was intentionally caught on the native platform.
-FutureOr<Map<String, dynamic>> catchPlatformException(Object exception,
-    [StackTrace? stackTrace]) async {
+/// Catches a [PlatformException] and returns an [Exception].
+///
+/// If the [Exception] is a [PlatformException], a [FirebaseFunctionsException] is returned.
+Exception convertPlatformException(Object exception, [StackTrace? stackTrace]) {
   if (exception is! Exception || exception is! PlatformException) {
-    // TODO(Salakar): Is this dead code?
-    // ignore: only_throw_errors
     throw exception;
   }
 
-  throw platformExceptionToFirebaseFunctionsException(exception, stackTrace);
+  return platformExceptionToFirebaseFunctionsException(exception, stackTrace);
 }
 
 /// Converts a [PlatformException] into a [FirebaseFunctionsException].
@@ -43,5 +40,8 @@ FirebaseException platformExceptionToFirebaseFunctionsException(
   }
 
   return FirebaseFunctionsException(
-      code: code, message: message!, details: additionalData);
+      code: code,
+      message: message!,
+      details: additionalData,
+      stackTrace: stackTrace);
 }

--- a/packages/cloud_functions/cloud_functions_platform_interface/test/method_channel/utils/exception_test.dart
+++ b/packages/cloud_functions/cloud_functions_platform_interface/test/method_channel/utils/exception_test.dart
@@ -3,93 +3,71 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:cloud_functions_platform_interface/src/firebase_functions_exception.dart';
-import 'package:flutter_test/flutter_test.dart';
 import 'package:cloud_functions_platform_interface/src/method_channel/utils/exception.dart';
 import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   final Map<String, dynamic> testAdditionalData = <String, dynamic>{
     'foo': 'bar',
   };
   const String testMessage = 'PlatformException Message';
-  group('catchPlatformException()', () {
+  group('convertPlatformException()', () {
     test('should throw any exception', () async {
       AssertionError assertionError = AssertionError();
 
-      try {
-        await catchPlatformException(assertionError);
-      } on FirebaseFunctionsException catch (_) {
-        fail('should have thrown the original exception');
-        // ignore: avoid_catching_errors, in this instance we want to do this
-      } on AssertionError catch (_) {
-        return;
-      } catch (e) {
-        fail('should have thrown an Exception and not a ${e.runtimeType}');
-      }
-
-      fail('should have thrown an exception');
+      expect(() => convertPlatformException(assertionError),
+          throwsA(isA<AssertionError>()));
     });
 
-    test('should catch a [PlatformException] and throw a [FirebaseException]',
+    test(
+        'should catch a [PlatformException] and throw a [FirebaseFunctionsException]',
         () async {
+      PlatformException platformException = PlatformException(
+        code: 'foo',
+        message: testMessage,
+      );
+
+      expect(
+          convertPlatformException(platformException),
+          isA<FirebaseFunctionsException>()
+              .having((e) => e.code, 'code', 'unknown')
+              .having((e) => e.message, 'message', testMessage)
+              .having((e) => e.details, 'details', isNull));
+    });
+
+    test('should override code and message if provided to additional details',
+        () async {
+      String code = 'baz';
+      PlatformException platformException = PlatformException(
+          code: 'foo',
+          message: 'bar',
+          details: {'code': code, 'message': testMessage});
+
+      expect(
+          convertPlatformException(platformException),
+          isA<FirebaseFunctionsException>()
+              .having((e) => e.code, 'code', code)
+              .having((e) => e.message, 'message', testMessage)
+              .having((e) => e.details, 'details', isNull));
+    });
+
+    test('should provide additionalData as details', () async {
       PlatformException platformException = PlatformException(
           code: 'UNKNOWN',
           message: testMessage,
           details: {'additionalData': testAdditionalData});
-      try {
-        await catchPlatformException(platformException);
-      } on FirebaseFunctionsException catch (_) {
-        return;
-      } catch (e) {
-        fail(
-            'should have thrown an FirebaseFunctionsException and not a ${e.runtimeType}');
-      }
 
-      fail('should have thrown an exception');
-    });
-  });
-
-  group('platformExceptionToFirebaseFunctionsException()', () {
-    test('sets code to default value', () {
-      PlatformException platformException = PlatformException(
-          code: 'native',
-          message: testMessage,
-          details: {'additionalData': testAdditionalData});
-
-      FirebaseFunctionsException result =
-          platformExceptionToFirebaseFunctionsException(platformException)
-              as FirebaseFunctionsException;
-      expect(result.code, 'unknown');
-      expect(result.message, testMessage);
-
-      expect(result.details, isA<Map<String, dynamic>>());
-      expect(result.details['foo'], testAdditionalData['foo']);
-    });
-
-    test('details = null', () {
-      PlatformException platformException =
-          PlatformException(code: 'native', message: testMessage);
-
-      FirebaseFunctionsException result =
-          platformExceptionToFirebaseFunctionsException(platformException)
-              as FirebaseFunctionsException;
-      expect(result.code, 'unknown');
-      expect(result.message, testMessage);
-      expect(result.details, isNull);
-    });
-
-    test('additionalData = null', () {
-      PlatformException platformException = PlatformException(
-          code: 'native',
-          message: testMessage,
-          details: {'additionalData': null});
-
-      FirebaseFunctionsException result =
-          platformExceptionToFirebaseFunctionsException(platformException)
-              as FirebaseFunctionsException;
-      expect(result.code, 'unknown');
-      expect(result.message, testMessage);
-      expect(result.details, isNull);
+      expect(
+          convertPlatformException(platformException),
+          isA<FirebaseFunctionsException>()
+              .having((e) => e.code, 'code', 'unknown')
+              .having((e) => e.message, 'message', testMessage)
+              .having(
+                  (e) => e.details,
+                  'details',
+                  isA<Map<String, dynamic>>()
+                      .having((e) => e['foo'], 'additionalData', 'bar')));
     });
   });
 }

--- a/packages/cloud_functions/cloud_functions_web/lib/https_callable_web.dart
+++ b/packages/cloud_functions/cloud_functions_web/lib/https_callable_web.dart
@@ -7,6 +7,7 @@ import 'dart:js_util' as util;
 
 import 'package:cloud_functions_platform_interface/cloud_functions_platform_interface.dart';
 import 'package:firebase_core_web/firebase_core_web_interop.dart' show dartify;
+
 import 'interop/functions.dart' as functions_interop;
 import 'utils.dart';
 
@@ -41,7 +42,7 @@ class HttpsCallableWeb extends HttpsCallablePlatform {
     try {
       response = await util.promiseToFuture(jsPromise);
     } catch (e, s) {
-      throw throwFirebaseFunctionsException(e, s);
+      throw convertFirebaseFunctionsException(e, s);
     }
 
     return dartify(util.getProperty(response, 'data'));

--- a/packages/cloud_functions/cloud_functions_web/lib/utils.dart
+++ b/packages/cloud_functions/cloud_functions_web/lib/utils.dart
@@ -8,7 +8,7 @@ import 'package:cloud_functions_platform_interface/cloud_functions_platform_inte
 import 'package:firebase_core_web/firebase_core_web_interop.dart' show dartify;
 
 /// Given a web error, a [FirebaseFunctionsException] is returned.
-FirebaseFunctionsException throwFirebaseFunctionsException(Object exception,
+FirebaseFunctionsException convertFirebaseFunctionsException(Object exception,
     [StackTrace? stackTrace]) {
   String originalCode = util.getProperty(exception, 'code');
   String code = originalCode.replaceFirst('functions/', '');


### PR DESCRIPTION
## Description

Replacement of https://github.com/FirebaseExtended/flutterfire/pull/4420

When debugging on VSCode, exceptions aren't bubbled up the chain back to the user if using try/catch with a Future .catchError. This changes that behaviour, along with improving some tests and naming of functions.

## Related Issues

Issue for context: https://github.com/FirebaseExtended/flutterfire/issues/3475

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
