### PR TITLE
docs:  use Flutter specific iOS plist file location

### DIFF
--- a/docs/installation/ios.mdx
+++ b/docs/installation/ios.mdx
@@ -38,7 +38,7 @@ The [Firebase Emulator Suite](https://firebase.google.com/docs/emulator-suite) u
 
 To allow insecure connections, we recommend adding the [`NSAllowsLocalNetworking`](https://developer.apple.com/documentation/bundleresources/information_property_list/nsapptransportsecurity/nsallowslocalnetworking) key to the [`NSAppTransportSecurity`](https://developer.apple.com/documentation/bundleresources/information_property_list/nsapptransportsecurity) dictionary in your application's plist file.
 
-Specifically if your app is named 'MyApp', you might add these keys in `ios/MyApp/Info.plist`:
+Add these keys in `ios/Runner/Info.plist`:
 
 ```xml
 <key>NSAppTransportSecurity</key>

--- a/docs/installation/ios.mdx
+++ b/docs/installation/ios.mdx
@@ -38,7 +38,7 @@ The [Firebase Emulator Suite](https://firebase.google.com/docs/emulator-suite) u
 
 To allow insecure connections, we recommend adding the [`NSAllowsLocalNetworking`](https://developer.apple.com/documentation/bundleresources/information_property_list/nsapptransportsecurity/nsallowslocalnetworking) key to the [`NSAppTransportSecurity`](https://developer.apple.com/documentation/bundleresources/information_property_list/nsapptransportsecurity) dictionary in your application's plist file.
 
-Add these keys in `ios/Runner/Info.plist`:
+Add these keys to your `ios/Runner/Info.plist` file:
 
 ```xml
 <key>NSAppTransportSecurity</key>


### PR DESCRIPTION
## Description

There is no any file located at `ios/MyApp/Info.plist`. You have to change `Info.plist` in Runner folder.

## Related Issues

Type in Documentation

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
