### PR TITLE
docs: Start to listen once.

### DIFF
--- a/docs/firestore/usage.mdx
+++ b/docs/firestore/usage.mdx
@@ -140,13 +140,24 @@ Once returned, you can subscribe to updates via the `listen()` method. The below
 which helps automatically manage the streams state and disposal of the stream when it's no longer used within your app:
 
 ```dart
-class UserInformation extends StatelessWidget {
+class UserInformation extends StatefulWidget {
+  @override
+    _UsetInfomation createState() => _UserInfomationState();
+}
+
+class _UserInformationState extends State<UserInformation> {
+  Stream<QuerySnapshot> _subscribe;
+  
+  @override
+  initState() {
+    super.initState();
+    _subscribe = FirebaseFirestore.instance.collection('users').snapshots();
+  }
+
   @override
   Widget build(BuildContext context) {
-    CollectionReference users = FirebaseFirestore.instance.collection('users');
-
     return StreamBuilder<QuerySnapshot>(
-      stream: users.snapshots(),
+      stream: _subscribe,
       builder: (BuildContext context, AsyncSnapshot<QuerySnapshot> snapshot) {
         if (snapshot.hasError) {
           return Text('Something went wrong');

--- a/docs/firestore/usage.mdx
+++ b/docs/firestore/usage.mdx
@@ -157,7 +157,7 @@ class _UserInformationState extends State<UserInformation> {
   @override
   Widget build(BuildContext context) {
     return StreamBuilder<QuerySnapshot>(
-      stream: _subscribe,
+      stream: _usersStream,
       builder: (BuildContext context, AsyncSnapshot<QuerySnapshot> snapshot) {
         if (snapshot.hasError) {
           return Text('Something went wrong');

--- a/docs/firestore/usage.mdx
+++ b/docs/firestore/usage.mdx
@@ -146,13 +146,7 @@ class UserInformation extends StatefulWidget {
 }
 
 class _UserInformationState extends State<UserInformation> {
-  Stream<QuerySnapshot> _subscribe;
-  
-  @override
-  initState() {
-    super.initState();
-    _subscribe = FirebaseFirestore.instance.collection('users').snapshots();
-  }
+  final Stream<QuerySnapshot> _usersStream = FirebaseFirestore.instance.collection('users').snapshots();
 
   @override
   Widget build(BuildContext context) {


### PR DESCRIPTION
In the current source code, a subscription starts at every build, which leads a bad user experience with the screen blinking or flashing at every build.

## Description
Fix example source code about Firestore subscription. Current source code has a problem. It starts to listen to Firestore at every build. It has to start to listen to Firestore once in `initState()`. `.snapshots()` should be in `initState()`

## Related Issues

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [ ] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
