### PR TITLE
docs: fcm iOS background handler

### DIFF
--- a/docs/messaging/usage.mdx
+++ b/docs/messaging/usage.mdx
@@ -192,7 +192,7 @@ it's possible to align these flows.
 <TabItem value="native">
 
 Handling messages whilst your application is in the background is a little different. Messages can
-be handled via the [`onBackgroundMessage`](!firebase_messaging.FirebaseMessaging.onBackgroundMessage) handler (only Android supports background handler) When received, an isolate is spawned (Android only, iOS/macOS does not require a separate isolate) allowing you to handle messages even when your application is not running.
+be handled via the [`onBackgroundMessage`](!firebase_messaging.FirebaseMessaging.onBackgroundMessage) handler (only Android supports `onBackgroundMessage` Handler) When received, an isolate is spawned (Android only, iOS/macOS does not require a separate isolate) allowing you to handle messages even when your application is not running.
 
 There are a few things to keep in mind about your background message handler:
 

--- a/docs/messaging/usage.mdx
+++ b/docs/messaging/usage.mdx
@@ -192,8 +192,7 @@ it's possible to align these flows.
 <TabItem value="native">
 
 Handling messages whilst your application is in the background is a little different. Messages can
-be handled via the [`onBackgroundMessage`](!firebase_messaging.FirebaseMessaging.onBackgroundMessage) handler. When received, an
-isolate is spawned (Android only, iOS/macOS does not require a separate isolate) allowing you to handle messages even when your application is not running.
+be handled via the [`onBackgroundMessage`](!firebase_messaging.FirebaseMessaging.onBackgroundMessage) handler (only Android supports background handler) When received, an isolate is spawned (Android only, iOS/macOS does not require a separate isolate) allowing you to handle messages even when your application is not running.
 
 There are a few things to keep in mind about your background message handler:
 


### PR DESCRIPTION
## Description

Add comment that explains  `onBackgroundMessage handler`. Currently, if the platform is not Android, `Background Message Handler` cannot be registered. However, it is not reflected in the document, so I think it may cause misunderstandings.

method_channel/method_channel_messaging.dart
```dart
  @override
  Future<void> registerBackgroundMessageHandler(
      BackgroundMessageHandler handler) async {
    if (defaultTargetPlatform != TargetPlatform.android) {
      return;
    }
   ... 
  }
```

## Related Issues

#6112 

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
