### PR TITLE
docs: Update class name from FirebaseRemoteConfig to RemoteConfig.

### DIFF
--- a/docs/remote-config/usage.mdx
+++ b/docs/remote-config/usage.mdx
@@ -12,25 +12,25 @@ import 'package:firebase_remote_config/firebase_remote_config.dart';
 
 Before using Firebase Remote Config, you must first have ensured you have [initialized FlutterFire](../overview.mdx#initializing-flutterfire).
 
-To create a new Firebase Remote Config instance, call the [`instance`](!firebase_remote_config.FirebaseRemoteConfig.instance)
-getter on [`FirebaseRemoteConfig`](!firebase_remote_config.FirebaseRemoteConfig):
+To create a new Firebase Remote Config instance, call the [`instance`](!firebase_remote_config.RemoteConfig.instance)
+getter on [`RemoteConfig`](!firebase_remote_config.RemoteConfig):
 
 ```dart
-FirebaseRemoteConfig remoteConfig = FirebaseRemoteConfig.instance;
+RemoteConfig remoteConfig = RemoteConfig.instance;
 ```
 
 By default, this allows you to interact with Firebase Remote Config using the default Firebase App used whilst installing FlutterFire on your
-platform. If however you'd like to use a secondary Firebase App, use the [`instanceFor`](!firebase_remote_config.FirebaseRemoteConfig.instanceFor) method:
+platform. If however you'd like to use a secondary Firebase App, use the [`instanceFor`](!firebase_remote_config.RemoteConfig.instanceFor) method:
 
 ```dart
 FirebaseApp secondaryApp = Firebase.app('SecondaryApp');
-FirebaseRemoteConfig remoteConfig = FirebaseRemoteConfig.instanceFor(app: secondaryApp);
+RemoteConfig remoteConfig = RemoteConfig.instanceFor(app: secondaryApp);
 ```
 
 ## Defaults
 
 Firebase Remote Config default parameters allows your application to startup without the need to make a
-network call. To set the default parameters call the `setDefaults()` method on your [`FirebaseRemoteConfig`](!firebase_remote_config.FirebaseRemoteConfig) instance:
+network call. To set the default parameters call the `setDefaults()` method on your [`RemoteConfig`](!firebase_remote_config.RemoteConfig) instance:
 
 ```dart
 remoteConfig.setDefaults(<String, dynamic>{
@@ -42,7 +42,7 @@ remoteConfig.setDefaults(<String, dynamic>{
 ## Fetching and activating
 
 Only when default parameters are no longer sufficient updates to the Remote Config template should be made
-in the Firebase console or via the Admin SDK. Use the `fetchAndActivate()` method on your [`FirebaseRemoteConfig`](!firebase_remote_config.FirebaseRemoteConfig) instance:
+in the Firebase console or via the Admin SDK. Use the `fetchAndActivate()` method on your [`RemoteConfig`](!firebase_remote_config.RemoteConfig) instance:
 
 ```dart
 bool updated = await remoteConfig.fetchAndActivate();
@@ -70,7 +70,7 @@ Other getters include: `getBool()`, `getInt()`, `getDouble()`, `getValue()`.
 
 Since fetching involves network calls Remote Config allows you to specify how long cached parameters are valid and
 how long a fetch should wait before timing out. These settings can be specified using the `setConfigSettings()`
-method on your [`FirebaseRemoteConfig`](!firebase_remote_config.FirebaseRemoteConfig) instance:
+method on your [`RemoteConfig`](!firebase_remote_config.RemoteConfig) instance:
 
 ```dart
 await remoteConfig.setConfigSettings(RemoteConfigSettings(


### PR DESCRIPTION
## Description

RemoteConfig class changed from FirebaseRemoteConfig, but documents wrong yet.

```shell
~/ghq/github.com/saku/flutterfire master
❯ grep -r "FlutterRemoteConfig" ./packages/firebase_remote_config | wc -l
       0

~/ghq/github.com/saku/flutterfire master
❯ grep -r "RemoteConfig" ./packages/firebase_remote_config | wc -l
     379
```

## Related Issues

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
