### PR TITLE
feat: firebase_analytics plugin with AnalyticsWithoutAdIdSupport pod

### DIFF
--- a/packages/firebase_analytics/firebase_analytics/README.md
+++ b/packages/firebase_analytics/firebase_analytics/README.md
@@ -11,7 +11,7 @@ To use this plugin, add `firebase_analytics` as a [dependency in your pubspec.ya
 
 ## iOS [App Tracking Transparency](https://developer.apple.com/documentation/apptrackingtransparency)
 
-In order to avoid any user tracking you should add following line into ios/Podfile
+If you wish to use Firebase Analytics without IDFA collection capability, open your `/ios/Podfile` and add the following global variable to the top of the file:
 
 ```
 $FirebaseAnalyticsWithoutAdIdSupport = true

--- a/packages/firebase_analytics/firebase_analytics/README.md
+++ b/packages/firebase_analytics/firebase_analytics/README.md
@@ -9,6 +9,14 @@ For Flutter plugins for other Firebase products, see [README.md](https://github.
 ## Usage
 To use this plugin, add `firebase_analytics` as a [dependency in your pubspec.yaml file](https://flutter.io/platform-plugins/). You must also configure firebase analytics for each platform project: Android and iOS (see the example folder for details).
 
+## iOS [App Tracking Transparency](https://developer.apple.com/documentation/apptrackingtransparency)
+
+In order to avoid any user tracking you should add following line into ios/Podfile
+
+```
+$FirebaseAnalyticsWithoutAdIdSupport = true
+```
+
 ## Track PageRoute Transitions
 
 To track `PageRoute` transitions, add a `FirebaseAnalyticsObserver` to the list of `NavigatorObservers` on your

--- a/packages/firebase_analytics/firebase_analytics/README.md
+++ b/packages/firebase_analytics/firebase_analytics/README.md
@@ -13,7 +13,7 @@ To use this plugin, add `firebase_analytics` as a [dependency in your pubspec.ya
 
 If you wish to use Firebase Analytics without IDFA collection capability, open your `/ios/Podfile` and add the following global variable to the top of the file:
 
-```
+```ruby
 $FirebaseAnalyticsWithoutAdIdSupport = true
 ```
 

--- a/packages/firebase_analytics/firebase_analytics/ios/firebase_analytics.podspec
+++ b/packages/firebase_analytics/firebase_analytics/ios/firebase_analytics.podspec
@@ -2,6 +2,11 @@ require 'yaml'
 
 pubspec = YAML.load_file(File.join('..', 'pubspec.yaml'))
 library_version = pubspec['version'].gsub('+', '-')
+firebase_analytics = 'Firebase/Analytics'
+
+if defined?($FirebaseAnalytics)
+firebase_analytics = $FirebaseAnalytics
+end
 
 if defined?($FirebaseSDKVersion)
   Pod::UI.puts "#{pubspec['name']}: Using user specified Firebase SDK version '#{$FirebaseSDKVersion}'"
@@ -33,7 +38,7 @@ Pod::Spec.new do |s|
   s.dependency 'Flutter'
 
   s.dependency 'firebase_core'
-  s.dependency 'Firebase/AnalyticsWithoutAdIdSupport', firebase_sdk_version
+  s.dependency firebase_analytics, firebase_sdk_version
   
   s.static_framework = true
   s.pod_target_xcconfig = { 

--- a/packages/firebase_analytics/firebase_analytics/ios/firebase_analytics.podspec
+++ b/packages/firebase_analytics/firebase_analytics/ios/firebase_analytics.podspec
@@ -33,7 +33,7 @@ Pod::Spec.new do |s|
   s.dependency 'Flutter'
 
   s.dependency 'firebase_core'
-  s.dependency 'Firebase/Analytics', firebase_sdk_version
+  s.dependency 'Firebase/AnalyticsWithoutAdIdSupport', firebase_sdk_version
   
   s.static_framework = true
   s.pod_target_xcconfig = { 

--- a/packages/firebase_analytics/firebase_analytics/ios/firebase_analytics.podspec
+++ b/packages/firebase_analytics/firebase_analytics/ios/firebase_analytics.podspec
@@ -4,8 +4,8 @@ pubspec = YAML.load_file(File.join('..', 'pubspec.yaml'))
 library_version = pubspec['version'].gsub('+', '-')
 firebase_analytics = 'Firebase/Analytics'
 
-if defined?($FirebaseAnalytics)
-firebase_analytics = $FirebaseAnalytics
+if defined?($FirebaseAnalyticsWithoutAdIdSupport)
+firebase_analytics = 'Firebase/AnalyticsWithoutAdIdSupport'
 end
 
 if defined?($FirebaseSDKVersion)


### PR DESCRIPTION
As a part of Analytics 7.11.0 SDK there is a special analytics pod to follow AppTrackingTransparency. As mentioned at https://github.com/FirebaseExtended/flutterfire/discussions/6030 there is no solution to use this pod in a flutter. 

This pull request involve the new FirebaseAnalyticsWithoutAdIdSupport variable and it can be used to ovveride the default pod the same way as FirebaseSDKVersion used to [override sdk version](https://firebase.flutter.dev/docs/overview/#iosmacos)

Just add following line somewere in the head of your ios/Podfile  and  got the flutter app with AnalyticsWithoutAdIdSupport

`$FirebaseAnalyticsWithoutAdIdSupport = true`

Closes #6030 