### PR TITLE
fix(firebase_messaging): Fix FirebaseMessaging.onMessage and onMessageOpenedApp potentially throwing

### DIFF
--- a/packages/firebase_messaging/firebase_messaging/example/test_driver/instance_e2e.dart
+++ b/packages/firebase_messaging/firebase_messaging/example/test_driver/instance_e2e.dart
@@ -1,10 +1,8 @@
-// @dart = 2.9
-
 // Copyright 2020, the Chromium project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-// @dart=2.9
+import 'dart:async';
 
 import 'package:firebase_core/firebase_core.dart';
 import 'package:firebase_messaging/firebase_messaging.dart';
@@ -16,8 +14,8 @@ const bool SKIP_MANUAL_TESTS = bool.fromEnvironment('CI');
 
 void runInstanceTests() {
   group('$FirebaseMessaging.instance', () {
-    FirebaseApp app;
-    FirebaseMessaging messaging;
+    late FirebaseApp app;
+    late FirebaseMessaging messaging;
 
     setUpAll(() async {
       app = await Firebase.initializeApp();
@@ -36,6 +34,29 @@ void runInstanceTests() {
       test('accessible from messaging.app', () {
         expect(messaging.app, isA<FirebaseApp>());
         expect(messaging.app.name, app.name);
+      });
+    });
+
+    group('onMessage', () {
+      test('can listen multiple times', () async {
+        // regresion test for https://github.com/FirebaseExtended/flutterfire/issues/6009
+
+        StreamSubscription<RemoteMessage> _onMessageSubscription;
+        StreamSubscription<RemoteMessage> _onMessageOpenedAppSubscription;
+
+        _onMessageSubscription = FirebaseMessaging.onMessage.listen((_) {});
+        _onMessageOpenedAppSubscription =
+            FirebaseMessaging.onMessageOpenedApp.listen((_) {});
+
+        await _onMessageSubscription.cancel();
+        await _onMessageOpenedAppSubscription.cancel();
+
+        _onMessageSubscription = FirebaseMessaging.onMessage.listen((_) {});
+        _onMessageOpenedAppSubscription =
+            FirebaseMessaging.onMessageOpenedApp.listen((_) {});
+
+        await _onMessageSubscription.cancel();
+        await _onMessageOpenedAppSubscription.cancel();
       });
     });
 

--- a/packages/firebase_messaging/firebase_messaging/lib/src/messaging.dart
+++ b/packages/firebase_messaging/firebase_messaging/lib/src/messaging.dart
@@ -52,15 +52,6 @@ class FirebaseMessaging extends FirebasePluginPlatform {
   //
   // static final Map<String, FirebaseMessaging> _cachedInstances = {};
 
-  // ignore: close_sinks
-  static final StreamController<RemoteMessage> _onMessageController =
-      StreamController<RemoteMessage>.broadcast(onListen: () {
-    Stream<RemoteMessage> onMessageStream =
-        FirebaseMessagingPlatform.onMessage.stream;
-
-    onMessageStream.pipe(_onMessageController);
-  });
-
   /// Returns a Stream that is called when an incoming FCM payload is received whilst
   /// the Flutter instance is in the foreground.
   ///
@@ -68,16 +59,8 @@ class FirebaseMessaging extends FirebasePluginPlatform {
   ///
   /// To handle messages whilst the app is in the background or terminated,
   /// see [onBackgroundMessage].
-  static Stream<RemoteMessage> get onMessage => _onMessageController.stream;
-
-  // ignore: close_sinks
-  static final StreamController<RemoteMessage> _onMessageOpenedAppController =
-      StreamController<RemoteMessage>.broadcast(onListen: () {
-    Stream<RemoteMessage> onMessageOpenedAppStream =
-        FirebaseMessagingPlatform.onMessageOpenedApp.stream;
-
-    onMessageOpenedAppStream.pipe(_onMessageOpenedAppController);
-  });
+  static Stream<RemoteMessage> get onMessage =>
+      FirebaseMessagingPlatform.onMessage.stream;
 
   /// Returns a [Stream] that is called when a user presses a notification message displayed
   /// via FCM.
@@ -88,7 +71,7 @@ class FirebaseMessaging extends FirebasePluginPlatform {
   /// If your app is opened via a notification whilst the app is terminated,
   /// see [getInitialMessage].
   static Stream<RemoteMessage> get onMessageOpenedApp =>
-      _onMessageOpenedAppController.stream;
+      FirebaseMessagingPlatform.onMessageOpenedApp.stream;
 
   // ignore: use_setters_to_change_properties
   /// Set a message handler function which is called when the app is in the

--- a/packages/firebase_messaging/firebase_messaging_platform_interface/lib/src/platform_interface/platform_interface_messaging.dart
+++ b/packages/firebase_messaging/firebase_messaging_platform_interface/lib/src/platform_interface/platform_interface_messaging.dart
@@ -13,12 +13,24 @@ import '../method_channel/method_channel_messaging.dart';
 
 /// Defines an interface to work with Messaging on web and mobile.
 abstract class FirebaseMessagingPlatform extends PlatformInterface {
+  /// Create an instance using [app].
+  FirebaseMessagingPlatform({this.appInstance}) : super(token: _token);
+
+  /// Create an instance with a [FirebaseApp] using an existing instance.
+  factory FirebaseMessagingPlatform.instanceFor({
+    required FirebaseApp app,
+    required Map<dynamic, dynamic> pluginConstants,
+  }) {
+    return FirebaseMessagingPlatform.instance
+        .delegateFor(app: app)
+        .setInitialValues(
+          isAutoInitEnabled: pluginConstants['AUTO_INIT_ENABLED'],
+        );
+  }
+
   /// The [FirebaseApp] this instance was initialized with.
   @protected
   final FirebaseApp? appInstance;
-
-  /// Create an instance using [app].
-  FirebaseMessagingPlatform({this.appInstance}) : super(token: _token);
 
   /// Returns the [FirebaseApp] for the current instance.
   FirebaseApp get app {
@@ -30,17 +42,6 @@ abstract class FirebaseMessagingPlatform extends PlatformInterface {
   }
 
   static final Object _token = Object();
-
-  /// Create an instance with a [FirebaseApp] using an existing instance.
-  factory FirebaseMessagingPlatform.instanceFor(
-      {required FirebaseApp app,
-      required Map<dynamic, dynamic> pluginConstants}) {
-    return FirebaseMessagingPlatform.instance
-        .delegateFor(app: app)
-        .setInitialValues(
-          isAutoInitEnabled: pluginConstants['AUTO_INIT_ENABLED'],
-        );
-  }
 
   static FirebaseMessagingPlatform? _instance;
 
@@ -58,21 +59,14 @@ abstract class FirebaseMessagingPlatform extends PlatformInterface {
     _instance = instance;
   }
 
-  // ignore: close_sinks
-  static StreamController<RemoteMessage>? _onMessageStreamController;
-
   /// Returns a Stream that is called when an incoming FCM payload is received whilst
   /// the Flutter instance is in the foreground.
   ///
   /// To handle messages whilst the app is in the background or terminated,
   /// see [onBackgroundMessage].
-  static StreamController<RemoteMessage> get onMessage {
-    return _onMessageStreamController ??=
-        StreamController<RemoteMessage>.broadcast();
-  }
-
-  // ignore: close_sinks
-  static StreamController<RemoteMessage>? _onMessageOpenedAppStreamController;
+  // ignore: close_sinks, never closed
+  static final StreamController<RemoteMessage> onMessage =
+      StreamController<RemoteMessage>.broadcast();
 
   /// Returns a [Stream] that is called when a user presses a notification displayed
   /// via FCM.
@@ -82,10 +76,9 @@ abstract class FirebaseMessagingPlatform extends PlatformInterface {
   ///
   /// If your app is opened via a notification whilst the app is terminated,
   /// see [getInitialMessage].
-  static StreamController<RemoteMessage> get onMessageOpenedApp {
-    return _onMessageOpenedAppStreamController ??=
-        StreamController<RemoteMessage>.broadcast();
-  }
+  // ignore: close_sinks, never closed
+  static final StreamController<RemoteMessage> onMessageOpenedApp =
+      StreamController<RemoteMessage>.broadcast();
 
   static BackgroundMessageHandler? _onBackgroundMessageHandler;
 


### PR DESCRIPTION

## Description

## Related Issues

fixes #6009

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [ ] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
