### PR TITLE
fix(cloud_firestore): pass GetOptions to web Query.get

### DIFF
--- a/packages/cloud_firestore/cloud_firestore/example/test_driver/query_e2e.dart
+++ b/packages/cloud_firestore/cloud_firestore/example/test_driver/query_e2e.dart
@@ -2,12 +2,11 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'dart:math';
 import 'dart:async';
+import 'dart:math';
 
-import 'package:flutter/foundation.dart';
-import 'package:flutter_test/flutter_test.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:flutter_test/flutter_test.dart';
 
 void runQueryTests() {
   group('$Query', () {
@@ -76,7 +75,7 @@ void runQueryTests() {
             await collection.get(const GetOptions(source: Source.cache));
         expect(qs, isA<QuerySnapshot<Map<String, dynamic>>>());
         expect(qs.metadata.isFromCache, isTrue);
-      }, skip: kIsWeb);
+      });
 
       test('uses [GetOptions] server', () async {
         CollectionReference<Map<String, dynamic>> collection =

--- a/packages/cloud_firestore/cloud_firestore_web/lib/src/interop/firestore.dart
+++ b/packages/cloud_firestore/cloud_firestore_web/lib/src/interop/firestore.dart
@@ -167,9 +167,9 @@ class DocumentReference
   Future<Null> delete() => handleThenable(jsObject.delete());
 
   Future<DocumentSnapshot> get([firestore_interop.GetOptions? options]) {
-    var jsObjectSet =
+    var jsObjectGet =
         (options != null) ? jsObject.get(options) : jsObject.get();
-    return handleThenable(jsObjectSet).then(DocumentSnapshot.getInstance);
+    return handleThenable(jsObjectGet).then(DocumentSnapshot.getInstance);
   }
 
   /// Attaches a listener for [DocumentSnapshot] events.
@@ -239,9 +239,12 @@ class Query<T extends firestore_interop.QueryJsImpl>
       Query.fromJsObject(
           _wrapPaginatingFunctionCall('endBefore', snapshot, fieldValues));
 
-  Future<QuerySnapshot> get([firestore_interop.GetOptions? options]) =>
-      handleThenable<firestore_interop.QuerySnapshotJsImpl>(jsObject.get())
-          .then(QuerySnapshot.getInstance);
+  Future<QuerySnapshot> get([firestore_interop.GetOptions? options]) {
+    var jsObjectGet =
+        (options != null) ? jsObject.get(options) : jsObject.get();
+    return handleThenable<firestore_interop.QuerySnapshotJsImpl>(jsObjectGet)
+        .then(QuerySnapshot.getInstance);
+  }
 
   Query limit(num limit) => Query.fromJsObject(jsObject.limit(limit));
 

--- a/packages/cloud_firestore/cloud_firestore_web/lib/src/interop/firestore_interop.dart
+++ b/packages/cloud_firestore/cloud_firestore_web/lib/src/interop/firestore_interop.dart
@@ -309,7 +309,7 @@ abstract class QueryJsImpl {
       /*DocumentSnapshot|List<dynamic>*/
       dynamic snapshotOrFieldValues);
 
-  external PromiseJsImpl<QuerySnapshotJsImpl> get();
+  external PromiseJsImpl<QuerySnapshotJsImpl> get([GetOptions? options]);
 
   external QueryJsImpl limit(num? limit);
 


### PR DESCRIPTION
## Description

`GetOptions` were not being passed to `Query.get`. Also the test for this was commented out for web.

## Related Issues

Fixes #6076

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
