### PR TITLE
fix: podspec osx version checking script should use a version range instead of a single fixed version

### DIFF
--- a/packages/cloud_firestore/cloud_firestore/macos/cloud_firestore.podspec
+++ b/packages/cloud_firestore/cloud_firestore/macos/cloud_firestore.podspec
@@ -15,15 +15,15 @@ else
   end
 end
 
-# TODO(Salakar): Remove deployment target check once default Flutter osx minimum updated to 10.12.
 begin
+  required_macos_version = "10.12"
   current_target_definition = Pod::Config.instance.podfile.send(:current_target_definition)
   user_osx_target = current_target_definition.to_hash["platform"]["osx"]
-  if user_osx_target == "10.11"
-    error_message = "The FlutterFire plugin #{pubspec['name']} for macOS requires a macOS deployment target of 10.12 or later."
+  if (Gem::Version.new(user_osx_target) < Gem::Version.new(required_macos_version))
+    error_message = "The FlutterFire plugin #{pubspec['name']} for macOS requires a macOS deployment target of #{required_macos_version} or later."
     Pod::UI.warn error_message, [
-      "Update the `platform :osx, '10.11'` line in your macOS/Podfile to version `10.12` and ensure you commit this file.",
-      "Open your `macos/Runner.xcodeproj` Xcode project and under the 'Runner' target General tab set your Deployment Target to 10.12 or later."
+      "Update the `platform :osx, '#{user_osx_target}'` line in your macOS/Podfile to version `#{required_macos_version}` and ensure you commit this file.",
+      "Open your `macos/Runner.xcodeproj` Xcode project and under the 'Runner' target General tab set your Deployment Target to #{required_macos_version} or later."
     ]
     raise Pod::Informative, error_message
   end

--- a/packages/cloud_functions/cloud_functions/macos/cloud_functions.podspec
+++ b/packages/cloud_functions/cloud_functions/macos/cloud_functions.podspec
@@ -14,15 +14,15 @@ else
   end
 end
 
-# TODO(Salakar): Remove deployment target check once default Flutter osx minimum updated to 10.12.
 begin
+  required_macos_version = "10.12"
   current_target_definition = Pod::Config.instance.podfile.send(:current_target_definition)
   user_osx_target = current_target_definition.to_hash["platform"]["osx"]
-  if user_osx_target == "10.11"
-    error_message = "The FlutterFire plugin #{pubspec['name']} for macOS requires a macOS deployment target of 10.12 or later."
+  if (Gem::Version.new(user_osx_target) < Gem::Version.new(required_macos_version))
+    error_message = "The FlutterFire plugin #{pubspec['name']} for macOS requires a macOS deployment target of #{required_macos_version} or later."
     Pod::UI.warn error_message, [
-      "Update the `platform :osx, '10.11'` line in your macOS/Podfile to version `10.12` and ensure you commit this file.",
-      "Open your `macos/Runner.xcodeproj` Xcode project and under the 'Runner' target General tab set your Deployment Target to 10.12 or later."
+      "Update the `platform :osx, '#{user_osx_target}'` line in your macOS/Podfile to version `#{required_macos_version}` and ensure you commit this file.",
+      "Open your `macos/Runner.xcodeproj` Xcode project and under the 'Runner' target General tab set your Deployment Target to #{required_macos_version} or later."
     ]
     raise Pod::Informative, error_message
   end

--- a/packages/firebase_auth/firebase_auth/macos/firebase_auth.podspec
+++ b/packages/firebase_auth/firebase_auth/macos/firebase_auth.podspec
@@ -15,15 +15,15 @@ else
   end
 end
 
-# TODO(Salakar): Remove deployment target check once default Flutter osx minimum updated to 10.12.
 begin
+  required_macos_version = "10.12"
   current_target_definition = Pod::Config.instance.podfile.send(:current_target_definition)
   user_osx_target = current_target_definition.to_hash["platform"]["osx"]
-  if user_osx_target == "10.11"
-    error_message = "The FlutterFire plugin #{pubspec['name']} for macOS requires a macOS deployment target of 10.12 or later."
+  if (Gem::Version.new(user_osx_target) < Gem::Version.new(required_macos_version))
+    error_message = "The FlutterFire plugin #{pubspec['name']} for macOS requires a macOS deployment target of #{required_macos_version} or later."
     Pod::UI.warn error_message, [
-      "Update the `platform :osx, '10.11'` line in your macOS/Podfile to version `10.12` and ensure you commit this file.",
-      "Open your `macos/Runner.xcodeproj` Xcode project and under the 'Runner' target General tab set your Deployment Target to 10.12 or later."
+      "Update the `platform :osx, '#{user_osx_target}'` line in your macOS/Podfile to version `#{required_macos_version}` and ensure you commit this file.",
+      "Open your `macos/Runner.xcodeproj` Xcode project and under the 'Runner' target General tab set your Deployment Target to #{required_macos_version} or later."
     ]
     raise Pod::Informative, error_message
   end

--- a/packages/firebase_core/firebase_core/macos/firebase_core.podspec
+++ b/packages/firebase_core/firebase_core/macos/firebase_core.podspec
@@ -15,15 +15,15 @@ else
   end
 end
 
-# TODO(Salakar): Remove deployment target check once default Flutter osx minimum updated to 10.12.
 begin
+  required_macos_version = "10.12"
   current_target_definition = Pod::Config.instance.podfile.send(:current_target_definition)
   user_osx_target = current_target_definition.to_hash["platform"]["osx"]
-  if user_osx_target == "10.11"
-    error_message = "The FlutterFire plugin #{pubspec['name']} for macOS requires a macOS deployment target of 10.12 or later."
+  if (Gem::Version.new(user_osx_target) < Gem::Version.new(required_macos_version))
+    error_message = "The FlutterFire plugin #{pubspec['name']} for macOS requires a macOS deployment target of #{required_macos_version} or later."
     Pod::UI.warn error_message, [
-      "Update the `platform :osx, '10.11'` line in your macOS/Podfile to version `10.12` and ensure you commit this file.",
-      "Open your `macos/Runner.xcodeproj` Xcode project and under the 'Runner' target General tab set your Deployment Target to 10.12 or later."
+      "Update the `platform :osx, '#{user_osx_target}'` line in your macOS/Podfile to version `#{required_macos_version}` and ensure you commit this file.",
+      "Open your `macos/Runner.xcodeproj` Xcode project and under the 'Runner' target General tab set your Deployment Target to #{required_macos_version} or later."
     ]
     raise Pod::Informative, error_message
   end

--- a/packages/firebase_crashlytics/firebase_crashlytics/macos/firebase_crashlytics.podspec
+++ b/packages/firebase_crashlytics/firebase_crashlytics/macos/firebase_crashlytics.podspec
@@ -15,15 +15,15 @@ else
   end
 end
 
-# TODO(Salakar): Remove deployment target check once default Flutter osx minimum updated to 10.12.
 begin
+  required_macos_version = "10.12"
   current_target_definition = Pod::Config.instance.podfile.send(:current_target_definition)
   user_osx_target = current_target_definition.to_hash["platform"]["osx"]
-  if user_osx_target == "10.11"
-    error_message = "The FlutterFire plugin #{pubspec['name']} for macOS requires a macOS deployment target of 10.12 or later."
+  if (Gem::Version.new(user_osx_target) < Gem::Version.new(required_macos_version))
+    error_message = "The FlutterFire plugin #{pubspec['name']} for macOS requires a macOS deployment target of #{required_macos_version} or later."
     Pod::UI.warn error_message, [
-      "Update the `platform :osx, '10.11'` line in your macOS/Podfile to version `10.12` and ensure you commit this file.",
-      "Open your `macos/Runner.xcodeproj` Xcode project and under the 'Runner' target General tab set your Deployment Target to 10.12 or later."
+      "Update the `platform :osx, '#{user_osx_target}'` line in your macOS/Podfile to version `#{required_macos_version}` and ensure you commit this file.",
+      "Open your `macos/Runner.xcodeproj` Xcode project and under the 'Runner' target General tab set your Deployment Target to #{required_macos_version} or later."
     ]
     raise Pod::Informative, error_message
   end

--- a/packages/firebase_database/firebase_database/macos/firebase_database.podspec
+++ b/packages/firebase_database/firebase_database/macos/firebase_database.podspec
@@ -15,15 +15,15 @@ else
   end
 end
 
-# TODO(Salakar): Remove deployment target check once default Flutter osx minimum updated to 10.12.
 begin
+  required_macos_version = "10.12"
   current_target_definition = Pod::Config.instance.podfile.send(:current_target_definition)
   user_osx_target = current_target_definition.to_hash["platform"]["osx"]
-  if user_osx_target == "10.11"
-    error_message = "The FlutterFire plugin #{pubspec['name']} for macOS requires a macOS deployment target of 10.12 or later."
+  if (Gem::Version.new(user_osx_target) < Gem::Version.new(required_macos_version))
+    error_message = "The FlutterFire plugin #{pubspec['name']} for macOS requires a macOS deployment target of #{required_macos_version} or later."
     Pod::UI.warn error_message, [
-      "Update the `platform :osx, '10.11'` line in your macOS/Podfile to version `10.12` and ensure you commit this file.",
-      "Open your `macos/Runner.xcodeproj` Xcode project and under the 'Runner' target General tab set your Deployment Target to 10.12 or later."
+      "Update the `platform :osx, '#{user_osx_target}'` line in your macOS/Podfile to version `#{required_macos_version}` and ensure you commit this file.",
+      "Open your `macos/Runner.xcodeproj` Xcode project and under the 'Runner' target General tab set your Deployment Target to #{required_macos_version} or later."
     ]
     raise Pod::Informative, error_message
   end

--- a/packages/firebase_messaging/firebase_messaging/macos/firebase_messaging.podspec
+++ b/packages/firebase_messaging/firebase_messaging/macos/firebase_messaging.podspec
@@ -15,15 +15,15 @@ else
   end
 end
 
-# TODO(Salakar): Remove deployment target check once default Flutter osx minimum updated to 10.12.
 begin
+  required_macos_version = "10.12"
   current_target_definition = Pod::Config.instance.podfile.send(:current_target_definition)
   user_osx_target = current_target_definition.to_hash["platform"]["osx"]
-  if user_osx_target == "10.11"
-    error_message = "The FlutterFire plugin #{pubspec['name']} for macOS requires a macOS deployment target of 10.12 or later."
+  if (Gem::Version.new(user_osx_target) < Gem::Version.new(required_macos_version))
+    error_message = "The FlutterFire plugin #{pubspec['name']} for macOS requires a macOS deployment target of #{required_macos_version} or later."
     Pod::UI.warn error_message, [
-      "Update the `platform :osx, '10.11'` line in your macOS/Podfile to version `10.12` and ensure you commit this file.",
-      "Open your `macos/Runner.xcodeproj` Xcode project and under the 'Runner' target General tab set your Deployment Target to 10.12 or later."
+      "Update the `platform :osx, '#{user_osx_target}'` line in your macOS/Podfile to version `#{required_macos_version}` and ensure you commit this file.",
+      "Open your `macos/Runner.xcodeproj` Xcode project and under the 'Runner' target General tab set your Deployment Target to #{required_macos_version} or later."
     ]
     raise Pod::Informative, error_message
   end

--- a/packages/firebase_remote_config/firebase_remote_config/macos/firebase_remote_config.podspec
+++ b/packages/firebase_remote_config/firebase_remote_config/macos/firebase_remote_config.podspec
@@ -15,15 +15,15 @@ else
   end
 end
 
-# TODO(Salakar): Remove deployment target check once default Flutter osx minimum updated to 10.12.
 begin
+  required_macos_version = "10.12"
   current_target_definition = Pod::Config.instance.podfile.send(:current_target_definition)
   user_osx_target = current_target_definition.to_hash["platform"]["osx"]
-  if user_osx_target == "10.11"
-    error_message = "The FlutterFire plugin #{pubspec['name']} for macOS requires a macOS deployment target of 10.12 or later."
+  if (Gem::Version.new(user_osx_target) < Gem::Version.new(required_macos_version))
+    error_message = "The FlutterFire plugin #{pubspec['name']} for macOS requires a macOS deployment target of #{required_macos_version} or later."
     Pod::UI.warn error_message, [
-      "Update the `platform :osx, '10.11'` line in your macOS/Podfile to version `10.12` and ensure you commit this file.",
-      "Open your `macos/Runner.xcodeproj` Xcode project and under the 'Runner' target General tab set your Deployment Target to 10.12 or later."
+      "Update the `platform :osx, '#{user_osx_target}'` line in your macOS/Podfile to version `#{required_macos_version}` and ensure you commit this file.",
+      "Open your `macos/Runner.xcodeproj` Xcode project and under the 'Runner' target General tab set your Deployment Target to #{required_macos_version} or later."
     ]
     raise Pod::Informative, error_message
   end

--- a/packages/firebase_storage/firebase_storage/macos/firebase_storage.podspec
+++ b/packages/firebase_storage/firebase_storage/macos/firebase_storage.podspec
@@ -15,15 +15,15 @@ else
   end
 end
 
-# TODO(Salakar): Remove deployment target check once default Flutter osx minimum updated to 10.12.
 begin
+  required_macos_version = "10.12"
   current_target_definition = Pod::Config.instance.podfile.send(:current_target_definition)
   user_osx_target = current_target_definition.to_hash["platform"]["osx"]
-  if user_osx_target == "10.11"
-    error_message = "The FlutterFire plugin #{pubspec['name']} for macOS requires a macOS deployment target of 10.12 or later."
+  if (Gem::Version.new(user_osx_target) < Gem::Version.new(required_macos_version))
+    error_message = "The FlutterFire plugin #{pubspec['name']} for macOS requires a macOS deployment target of #{required_macos_version} or later."
     Pod::UI.warn error_message, [
-      "Update the `platform :osx, '10.11'` line in your macOS/Podfile to version `10.12` and ensure you commit this file.",
-      "Open your `macos/Runner.xcodeproj` Xcode project and under the 'Runner' target General tab set your Deployment Target to 10.12 or later."
+      "Update the `platform :osx, '#{user_osx_target}'` line in your macOS/Podfile to version `#{required_macos_version}` and ensure you commit this file.",
+      "Open your `macos/Runner.xcodeproj` Xcode project and under the 'Runner' target General tab set your Deployment Target to #{required_macos_version} or later."
     ]
     raise Pod::Informative, error_message
   end


### PR DESCRIPTION
## Description

The previous ruby scripts would error if the user had a deployment target greater than `10.12` due to the explicit `user_osx_target == "10.11"` - this PR updates the script to check the version is less than the required minimum version rather than a explicit equals comparison.

## Related Issues

N/A

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
