### PR TITLE
chore(messaging, web): fix broken messaging example

### DIFF
--- a/docs/messaging/usage.mdx
+++ b/docs/messaging/usage.mdx
@@ -126,7 +126,7 @@ String token = await messaging.getToken(
 and registered as a `serviceWorker` as demonstrated below:
 
 ```html
-...other html setup.
+  <!-- ...other html setup. -->
   <script>
     if ("serviceWorker" in navigator) {
       window.addEventListener("load", function () {
@@ -134,7 +134,7 @@ and registered as a `serviceWorker` as demonstrated below:
       });
     }
   </script>
-  ...put the script at the bottom of the enclosing body tags.
+  <!-- ...put the script at the bottom of the enclosing body tags. -->
 </body>
 ```
 

--- a/docs/messaging/usage.mdx
+++ b/docs/messaging/usage.mdx
@@ -108,8 +108,9 @@ FCM payloads.
 
 ### Web Tokens
 
-On the web, before a message can be sent to the browser you must have first created an initial handshake with Firebase. This can be carried out via the
-`getToken` method, passing in the public `vapidKey`. Head over to the [Firebase Console](https://console.firebase.google.com/project/_/settings/cloudmessaging) and create a new "Web Push Certificate". A key will be
+On the web, before a message can be sent to the browser you must do two things.
+
+1. Create an initial handshake with Firebase by passing in the public `vapidKey` to `messaging.getToken(vapidKey: 'KEY')` method. Head over to the [Firebase Console](https://console.firebase.google.com/project/_/settings/cloudmessaging) and create a new "Web Push Certificate". A key will be
 provided, which you can provide to the method:
 
 ```dart
@@ -119,6 +120,22 @@ FirebaseMessaging messaging = FirebaseMessaging.instance;
 String token = await messaging.getToken(
   vapidKey: "BGpdLRs......",
 );
+```
+
+2. Create a `firebase-messaging-sw.js` file inside the `web/` directory in the root of your project. In your `web/index.html` file, please ensure this file is referenced
+and registered as a `serviceWorker` as demonstrated below:
+
+```html
+...other html setup.
+  <script>
+    if ("serviceWorker" in navigator) {
+      window.addEventListener("load", function () {
+        navigator.serviceWorker.register("/firebase-messaging-sw.js");
+      });
+    }
+  </script>
+  ...put the script at the bottom of the enclosing body tags.
+</body>
 ```
 
 ### Message types

--- a/packages/firebase_messaging/firebase_messaging/example/lib/main.dart
+++ b/packages/firebase_messaging/firebase_messaging/example/lib/main.dart
@@ -31,16 +31,10 @@ Future<void> _firebaseMessagingBackgroundHandler(RemoteMessage message) async {
 }
 
 /// Create a [AndroidNotificationChannel] for heads up notifications
-const AndroidNotificationChannel channel = AndroidNotificationChannel(
-  'high_importance_channel', // id
-  'High Importance Notifications', // title
-  'This channel is used for important notifications.', // description
-  importance: Importance.high,
-);
+AndroidNotificationChannel channel;
 
 /// Initialize the [FlutterLocalNotificationsPlugin] package.
-final FlutterLocalNotificationsPlugin flutterLocalNotificationsPlugin =
-    FlutterLocalNotificationsPlugin();
+FlutterLocalNotificationsPlugin flutterLocalNotificationsPlugin;
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -49,6 +43,15 @@ Future<void> main() async {
   // Set the background messaging handler early on, as a named top-level function
   FirebaseMessaging.onBackgroundMessage(_firebaseMessagingBackgroundHandler);
 
+  if (!kIsWeb) {
+    channel = AndroidNotificationChannel(
+      'high_importance_channel', // id
+      'High Importance Notifications', // title
+      'This channel is used for important notifications.', // description
+      importance: Importance.high,
+    );
+
+    flutterLocalNotificationsPlugin = FlutterLocalNotificationsPlugin();
   /// Create an Android Notification Channel.
   ///
   /// We use this channel in the `AndroidManifest.xml` file to override the
@@ -65,6 +68,7 @@ Future<void> main() async {
     badge: true,
     sound: true,
   );
+  }
 
   runApp(MessagingExampleApp());
 }
@@ -127,7 +131,7 @@ class _Application extends State<Application> {
     FirebaseMessaging.onMessage.listen((RemoteMessage message) {
       RemoteNotification notification = message.notification;
       AndroidNotification android = message.notification?.android;
-      if (notification != null && android != null) {
+      if (notification != null && android != null && !kIsWeb) {
         flutterLocalNotificationsPlugin.show(
             notification.hashCode,
             notification.title,

--- a/packages/firebase_messaging/firebase_messaging/example/lib/main.dart
+++ b/packages/firebase_messaging/firebase_messaging/example/lib/main.dart
@@ -52,22 +52,24 @@ Future<void> main() async {
     );
 
     flutterLocalNotificationsPlugin = FlutterLocalNotificationsPlugin();
-  /// Create an Android Notification Channel.
-  ///
-  /// We use this channel in the `AndroidManifest.xml` file to override the
-  /// default FCM channel to enable heads up notifications.
-  await flutterLocalNotificationsPlugin
-      .resolvePlatformSpecificImplementation<
-          AndroidFlutterLocalNotificationsPlugin>()
-      ?.createNotificationChannel(channel);
 
-  /// Update the iOS foreground notification presentation options to allow
-  /// heads up notifications.
-  await FirebaseMessaging.instance.setForegroundNotificationPresentationOptions(
-    alert: true,
-    badge: true,
-    sound: true,
-  );
+    /// Create an Android Notification Channel.
+    ///
+    /// We use this channel in the `AndroidManifest.xml` file to override the
+    /// default FCM channel to enable heads up notifications.
+    await flutterLocalNotificationsPlugin
+        .resolvePlatformSpecificImplementation<
+            AndroidFlutterLocalNotificationsPlugin>()
+        ?.createNotificationChannel(channel);
+
+    /// Update the iOS foreground notification presentation options to allow
+    /// heads up notifications.
+    await FirebaseMessaging.instance
+        .setForegroundNotificationPresentationOptions(
+      alert: true,
+      badge: true,
+      sound: true,
+    );
   }
 
   runApp(MessagingExampleApp());

--- a/packages/firebase_messaging/firebase_messaging/example/lib/main.dart
+++ b/packages/firebase_messaging/firebase_messaging/example/lib/main.dart
@@ -44,7 +44,7 @@ Future<void> main() async {
   FirebaseMessaging.onBackgroundMessage(_firebaseMessagingBackgroundHandler);
 
   if (!kIsWeb) {
-    channel = AndroidNotificationChannel(
+    channel = const AndroidNotificationChannel(
       'high_importance_channel', // id
       'High Importance Notifications', // title
       'This channel is used for important notifications.', // description

--- a/packages/firebase_messaging/firebase_messaging/example/lib/message_list.dart
+++ b/packages/firebase_messaging/firebase_messaging/example/lib/message_list.dart
@@ -37,8 +37,10 @@ class _MessageList extends State<MessageList> {
           RemoteMessage message = _messages[index];
 
           return ListTile(
-            title: Text(message.messageId),
-            subtitle: Text(message.sentTime?.toString() ?? 'N/A'),
+            title: Text(
+                message.messageId ?? 'no RemoteMessage.messageId available'),
+            subtitle:
+                Text(message.sentTime?.toString() ?? DateTime.now().toString()),
             onTap: () => Navigator.pushNamed(context, '/message',
                 arguments: MessageArguments(message, false)),
           );

--- a/packages/firebase_messaging/firebase_messaging/example/lib/token_monitor.dart
+++ b/packages/firebase_messaging/firebase_messaging/example/lib/token_monitor.dart
@@ -30,7 +30,11 @@ class _TokenMonitor extends State<TokenMonitor> {
   @override
   void initState() {
     super.initState();
-    FirebaseMessaging.instance.getToken().then(setToken);
+    FirebaseMessaging.instance
+        .getToken(
+            vapidKey:
+                'BGpdLRsMJKvFDD9odfPk92uBg-JbQbyoiZdah0XlUyrjG4SDgUsE1iC_kdRgt4Kn0CO7K3RTswPZt61NNuO0XoA')
+        .then(setToken);
     _tokenStream = FirebaseMessaging.instance.onTokenRefresh;
     _tokenStream.listen(setToken);
   }


### PR DESCRIPTION
## Description

- only show local notifications for native.
- list of messages received was throwing error as `messageId` is not part of web `RemoteMessage` API.
- update docs to show web requires serviceWorker registration to stop error being thrown on initialisation.
- pass vapidKey in messaging example for web messaging.

## Related Issues

closes https://github.com/FirebaseExtended/flutterfire/issues/5975
closes https://github.com/FirebaseExtended/flutterfire/issues/5515

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
