### PR TITLE
feat: add User.updateDisplayName and User.updatePhotoURL

### DIFF
--- a/packages/firebase_auth/firebase_auth/android/src/main/java/io/flutter/plugins/firebase/auth/FlutterFirebaseAuthPlugin.java
+++ b/packages/firebase_auth/firebase_auth/android/src/main/java/io/flutter/plugins/firebase/auth/FlutterFirebaseAuthPlugin.java
@@ -944,7 +944,6 @@ public class FlutterFirebaseAuthPlugin
               (Map<String, String>) Objects.requireNonNull(arguments.get(Constants.PROFILE));
           UserProfileChangeRequest.Builder builder = new UserProfileChangeRequest.Builder();
 
-
           if (profile.containsKey(Constants.DISPLAY_NAME)) {
             String displayName = profile.get(Constants.DISPLAY_NAME);
             builder.setDisplayName(displayName);

--- a/packages/firebase_auth/firebase_auth/android/src/main/java/io/flutter/plugins/firebase/auth/FlutterFirebaseAuthPlugin.java
+++ b/packages/firebase_auth/firebase_auth/android/src/main/java/io/flutter/plugins/firebase/auth/FlutterFirebaseAuthPlugin.java
@@ -944,12 +944,19 @@ public class FlutterFirebaseAuthPlugin
               (Map<String, String>) Objects.requireNonNull(arguments.get(Constants.PROFILE));
           UserProfileChangeRequest.Builder builder = new UserProfileChangeRequest.Builder();
 
-          if (profile.get(Constants.DISPLAY_NAME) != null) {
-            builder.setDisplayName(profile.get(Constants.DISPLAY_NAME));
+
+          if (profile.containsKey(Constants.DISPLAY_NAME)) {
+            String displayName = profile.get(Constants.DISPLAY_NAME);
+            builder.setDisplayName(displayName);
           }
 
-          if (profile.get(Constants.PHOTO_URL) != null) {
-            builder.setPhotoUri(Uri.parse(profile.get(Constants.PHOTO_URL)));
+          if (profile.containsKey(Constants.PHOTO_URL)) {
+            String photoURL = profile.get(Constants.PHOTO_URL);
+            if (photoURL != null) {
+              builder.setPhotoUri(Uri.parse(photoURL));
+            } else {
+              builder.setPhotoUri(null);
+            }
           }
 
           Tasks.await(firebaseUser.updateProfile(builder.build()));

--- a/packages/firebase_auth/firebase_auth/example/test_driver/instance_e2e.dart
+++ b/packages/firebase_auth/firebase_auth/example/test_driver/instance_e2e.dart
@@ -122,6 +122,7 @@ void runInstanceTests() {
       tearDown(() async {
         await subscription.cancel();
       });
+
       test('calls callback with the current user and when user state changes',
           () async {
         await ensureSignedIn(testEmail);
@@ -141,11 +142,14 @@ void runInstanceTests() {
         }, count: 2, reason: 'Stream should only have been called 2 times'));
 
         await FirebaseAuth.instance.currentUser
-            .updateProfile(displayName: 'updatedName');
+            .updateDisplayName('updatedName');
 
         await FirebaseAuth.instance.currentUser.reload();
-        expect(FirebaseAuth.instance.currentUser.displayName,
-            equals('updatedName'));
+
+        expect(
+          FirebaseAuth.instance.currentUser.displayName,
+          equals('updatedName'),
+        );
       });
     });
 

--- a/packages/firebase_auth/firebase_auth/example/test_driver/user_e2e.dart
+++ b/packages/firebase_auth/firebase_auth/example/test_driver/user_e2e.dart
@@ -5,6 +5,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'dart:async';
+import 'dart:io';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -619,7 +620,7 @@ void runUserTests() {
           isNull,
         );
         // blocked by https://github.com/firebase/firebase-ios-sdk/issues/8149
-      }, skip: true);
+      }, skip: Platform.isIOS);
     });
 
     group('updatePhotoURL', () {

--- a/packages/firebase_auth/firebase_auth/example/test_driver/user_e2e.dart
+++ b/packages/firebase_auth/firebase_auth/example/test_driver/user_e2e.dart
@@ -560,6 +560,135 @@ void runUserTests() {
       });
     });
 
+    group('updateDisplayName', () {
+      test('updates the user displayName without impacting the photoURL',
+          () async {
+        // First create a user with a photo
+        await FirebaseAuth.instance.createUserWithEmailAndPassword(
+          email: email,
+          password: testPassword,
+        );
+        await FirebaseAuth.instance.currentUser.updateDisplayName('Mona Lisa');
+        await FirebaseAuth.instance.currentUser.updatePhotoURL(
+          'http://photo.url/test.jpg',
+          // await Future.wait([
+        );
+        // ]);
+        await FirebaseAuth.instance.currentUser.reload();
+
+        expect(
+          FirebaseAuth.instance.currentUser.photoURL,
+          'http://photo.url/test.jpg',
+        );
+        expect(
+          FirebaseAuth.instance.currentUser.displayName,
+          'Mona Lisa',
+        );
+
+        await FirebaseAuth.instance.currentUser.updateDisplayName('John Smith');
+        await FirebaseAuth.instance.currentUser.reload();
+
+        expect(
+          FirebaseAuth.instance.currentUser.photoURL,
+          'http://photo.url/test.jpg',
+        );
+        expect(
+          FirebaseAuth.instance.currentUser.displayName,
+          'John Smith',
+        );
+      });
+
+      test('can set the displayName to null', () async {
+        // First create a user with a photo
+        await FirebaseAuth.instance.createUserWithEmailAndPassword(
+          email: email,
+          password: testPassword,
+        );
+        await FirebaseAuth.instance.currentUser.updateDisplayName('Mona Lisa');
+        await FirebaseAuth.instance.currentUser.reload();
+
+        // Just checking that the user indeed had a name before we set it to null
+        expect(
+          FirebaseAuth.instance.currentUser.displayName,
+          isNotNull,
+        );
+
+        await FirebaseAuth.instance.currentUser.updateDisplayName(null);
+        await FirebaseAuth.instance.currentUser.reload();
+
+        expect(
+          FirebaseAuth.instance.currentUser.displayName,
+          isNull,
+        );
+      });
+    });
+
+    group('updatePhotoURL', () {
+      test('updates the photoURL without impacting the displayName', () async {
+        // First create a user with a photo
+        await FirebaseAuth.instance.createUserWithEmailAndPassword(
+          email: email,
+          password: testPassword,
+        );
+        await Future.wait([
+          FirebaseAuth.instance.currentUser.updateDisplayName('Mona Lisa'),
+          FirebaseAuth.instance.currentUser.updatePhotoURL(
+            'http://photo.url/test.jpg',
+          ),
+        ]);
+        await FirebaseAuth.instance.currentUser.reload();
+
+        expect(
+          FirebaseAuth.instance.currentUser.photoURL,
+          'http://photo.url/test.jpg',
+        );
+        expect(
+          FirebaseAuth.instance.currentUser.displayName,
+          'Mona Lisa',
+        );
+
+        await FirebaseAuth.instance.currentUser.updatePhotoURL(
+          'http://photo.url/dash.jpg',
+        );
+        await FirebaseAuth.instance.currentUser.reload();
+
+        expect(
+          FirebaseAuth.instance.currentUser.photoURL,
+          'http://photo.url/dash.jpg',
+        );
+        expect(
+          FirebaseAuth.instance.currentUser.displayName,
+          'Mona Lisa',
+        );
+      });
+
+      test('can set the photoURL to null', () async {
+        // First create a user with a photo
+        await FirebaseAuth.instance.createUserWithEmailAndPassword(
+          email: email,
+          password: testPassword,
+        );
+        await FirebaseAuth.instance.currentUser.updatePhotoURL(
+          'http://photo.url/test.jpg',
+        );
+        await FirebaseAuth.instance.currentUser.reload();
+
+        // Just checking that the user indeed had a photo before we set it to null
+        expect(
+          FirebaseAuth.instance.currentUser.photoURL,
+          isNotNull,
+        );
+
+        await FirebaseAuth.instance.currentUser.updatePhotoURL(null);
+        await FirebaseAuth.instance.currentUser.reload();
+
+        expect(
+          FirebaseAuth.instance.currentUser.photoURL,
+          isNull,
+        );
+      });
+    });
+
     group('updateProfile()', () {
       test('should update the profile', () async {
         String displayName = 'testName';
@@ -567,9 +696,12 @@ void runUserTests() {
 
         // Setup
         await FirebaseAuth.instance.createUserWithEmailAndPassword(
-            email: email, password: testPassword);
+          email: email,
+          password: testPassword,
+        );
 
         // Update user profile
+        // ignore: deprecated_member_use
         await FirebaseAuth.instance.currentUser.updateProfile(
           displayName: displayName,
           photoURL: photoURL,

--- a/packages/firebase_auth/firebase_auth/example/test_driver/user_e2e.dart
+++ b/packages/firebase_auth/firebase_auth/example/test_driver/user_e2e.dart
@@ -618,7 +618,8 @@ void runUserTests() {
           FirebaseAuth.instance.currentUser.displayName,
           isNull,
         );
-      });
+        // blocked by https://github.com/firebase/firebase-ios-sdk/issues/8149
+      }, skip: true);
     });
 
     group('updatePhotoURL', () {

--- a/packages/firebase_auth/firebase_auth/example/test_driver/user_e2e.dart
+++ b/packages/firebase_auth/firebase_auth/example/test_driver/user_e2e.dart
@@ -620,7 +620,7 @@ void runUserTests() {
           isNull,
         );
         // blocked by https://github.com/firebase/firebase-ios-sdk/issues/8149
-      }, skip: Platform.isIOS);
+      }, skip: Platform.isIOS || Platform.isMacOS);
     });
 
     group('updatePhotoURL', () {

--- a/packages/firebase_auth/firebase_auth/example/test_driver/user_e2e.dart
+++ b/packages/firebase_auth/firebase_auth/example/test_driver/user_e2e.dart
@@ -619,8 +619,9 @@ void runUserTests() {
           FirebaseAuth.instance.currentUser.displayName,
           isNull,
         );
-        // blocked by https://github.com/firebase/firebase-ios-sdk/issues/8149
-      }, skip: Platform.isIOS || Platform.isMacOS);
+        // Skip apple CI because of https://github.com/firebase/firebase-ios-sdk/issues/8149
+        // Using `kIsWeb` because `Platform` is not available on web
+      }, skip: !kIsWeb && (Platform.isIOS || Platform.isMacOS));
     });
 
     group('updatePhotoURL', () {

--- a/packages/firebase_auth/firebase_auth/example/test_driver/user_e2e.dart
+++ b/packages/firebase_auth/firebase_auth/example/test_driver/user_e2e.dart
@@ -571,9 +571,7 @@ void runUserTests() {
         await FirebaseAuth.instance.currentUser.updateDisplayName('Mona Lisa');
         await FirebaseAuth.instance.currentUser.updatePhotoURL(
           'http://photo.url/test.jpg',
-          // await Future.wait([
         );
-        // ]);
         await FirebaseAuth.instance.currentUser.reload();
 
         expect(

--- a/packages/firebase_auth/firebase_auth/ios/Classes/FLTFirebaseAuthPlugin.m
+++ b/packages/firebase_auth/firebase_auth/ios/Classes/FLTFirebaseAuthPlugin.m
@@ -839,13 +839,12 @@ NSString *const kErrMsgInvalidCredential =
   NSDictionary *profileUpdates = arguments[@"profile"];
   FIRUserProfileChangeRequest *changeRequest = [currentUser profileChangeRequest];
 
-  if (profileUpdates[@"displayName"] != nil &&
-      ![profileUpdates[@"displayName"] isEqual:[NSNull null]]) {
-    changeRequest.displayName = profileUpdates[@"displayName"];
+  if ([profileUpdates objectForKey:@"displayName"]) {
+     changeRequest.displayName = profileUpdates[@"displayName"];
   }
 
-  if (profileUpdates[@"photoURL"] != nil && ![profileUpdates[@"photoURL"] isEqual:[NSNull null]]) {
-    changeRequest.photoURL = [NSURL URLWithString:profileUpdates[@"photoURL"]];
+  if ([profileUpdates objectForKey:@"photoURL"]) {
+     changeRequest.photoURL = profileUpdates[@"photoURL"];
   }
 
   [changeRequest commitChangesWithCompletion:^(NSError *error) {

--- a/packages/firebase_auth/firebase_auth/ios/Classes/FLTFirebaseAuthPlugin.m
+++ b/packages/firebase_auth/firebase_auth/ios/Classes/FLTFirebaseAuthPlugin.m
@@ -842,7 +842,7 @@ NSString *const kErrMsgInvalidCredential =
   if (profileUpdates[@"displayName"] != nil) {
     if ([profileUpdates[@"displayName"] isEqual:[NSNull null]]) {
       changeRequest.displayName = nil;
-    } else {  
+    } else {
       changeRequest.displayName = profileUpdates[@"displayName"];
     }
   }
@@ -850,10 +850,10 @@ NSString *const kErrMsgInvalidCredential =
   if (profileUpdates[@"photoURL"] != nil) {
     if ([profileUpdates[@"photoURL"] isEqual:[NSNull null]]) {
       // We apparently cannot set photoURL to nil/NULL to remove it.
-      // Instead, setting it to empty string appears to work. 
+      // Instead, setting it to empty string appears to work.
       // When doing so, Dart will properly receive `null` anyway.
       changeRequest.photoURL = [NSURL URLWithString:@""];
-    } else {  
+    } else {
       changeRequest.photoURL = [NSURL URLWithString:profileUpdates[@"photoURL"]];
     }
   }

--- a/packages/firebase_auth/firebase_auth/ios/Classes/FLTFirebaseAuthPlugin.m
+++ b/packages/firebase_auth/firebase_auth/ios/Classes/FLTFirebaseAuthPlugin.m
@@ -839,12 +839,12 @@ NSString *const kErrMsgInvalidCredential =
   NSDictionary *profileUpdates = arguments[@"profile"];
   FIRUserProfileChangeRequest *changeRequest = [currentUser profileChangeRequest];
 
-  if ([profileUpdates objectForKey:@"displayName"]) {
-     changeRequest.displayName = profileUpdates[@"displayName"];
+  if (profileUpdates[@"displayName"] != nil) {
+    changeRequest.displayName = profileUpdates[@"displayName"];
   }
 
-  if ([profileUpdates objectForKey:@"photoURL"]) {
-     changeRequest.photoURL = profileUpdates[@"photoURL"];
+  if (profileUpdates[@"photoURL"] != nil) {
+    changeRequest.photoURL = profileUpdates[@"photoURL"];
   }
 
   [changeRequest commitChangesWithCompletion:^(NSError *error) {

--- a/packages/firebase_auth/firebase_auth/ios/Classes/FLTFirebaseAuthPlugin.m
+++ b/packages/firebase_auth/firebase_auth/ios/Classes/FLTFirebaseAuthPlugin.m
@@ -840,11 +840,22 @@ NSString *const kErrMsgInvalidCredential =
   FIRUserProfileChangeRequest *changeRequest = [currentUser profileChangeRequest];
 
   if (profileUpdates[@"displayName"] != nil) {
-    changeRequest.displayName = profileUpdates[@"displayName"];
+    if ([profileUpdates[@"displayName"] isEqual:[NSNull null]]) {
+      changeRequest.displayName = nil;
+    } else {  
+      changeRequest.displayName = profileUpdates[@"displayName"];
+    }
   }
 
   if (profileUpdates[@"photoURL"] != nil) {
-    changeRequest.photoURL = profileUpdates[@"photoURL"];
+    if ([profileUpdates[@"photoURL"] isEqual:[NSNull null]]) {
+      // We apparently cannot set photoURL to nil/NULL to remove it.
+      // Instead, setting it to empty string appears to work. 
+      // When doing so, Dart will properly receive `null` anyway.
+      changeRequest.photoURL = [NSURL URLWithString:@""];
+    } else {  
+      changeRequest.photoURL = [NSURL URLWithString:profileUpdates[@"photoURL"]];
+    }
   }
 
   [changeRequest commitChangesWithCompletion:^(NSError *error) {

--- a/packages/firebase_auth/firebase_auth/lib/src/user.dart
+++ b/packages/firebase_auth/firebase_auth/lib/src/user.dart
@@ -250,9 +250,12 @@ class User {
   ///  - Thrown if the credential is a [PhoneAuthProvider.credential] and the
   ///    verification ID of the credential is not valid.
   Future<UserCredential> reauthenticateWithCredential(
-      AuthCredential credential) async {
+    AuthCredential credential,
+  ) async {
     return UserCredential._(
-        _auth, await _delegate.reauthenticateWithCredential(credential));
+      _auth,
+      await _delegate.reauthenticateWithCredential(credential),
+    );
   }
 
   /// Refreshes the current user, if signed in.
@@ -332,9 +335,24 @@ class User {
     await _delegate.updatePhoneNumber(phoneCredential);
   }
 
+  /// Update the user name.
+  Future<void> updateDisplayName(String? displayName) {
+    return _delegate
+        .updateProfile(<String, String?>{'displayName': displayName});
+  }
+
+  /// Update the user's profile picture.
+  Future<void> updatePhotoURL(String? photoURL) {
+    return _delegate.updateProfile(<String, String?>{'photoURL': photoURL});
+  }
+
   /// Updates a user's profile data.
-  Future<void> updateProfile({String? displayName, String? photoURL}) async {
-    await _delegate.updateProfile(<String, String?>{
+  @Deprecated(
+    'Will be removed in version 2.0.0. '
+    'Use updatePhotoURL and updateDisplayName instead.',
+  )
+  Future<void> updateProfile({String? displayName, String? photoURL}) {
+    return _delegate.updateProfile(<String, String?>{
       'displayName': displayName,
       'photoURL': photoURL,
     });

--- a/packages/firebase_auth/firebase_auth/test/user_test.dart
+++ b/packages/firebase_auth/firebase_auth/test/user_test.dart
@@ -295,6 +295,7 @@ void main() {
       };
 
       await auth!.currentUser!
+          // ignore: deprecated_member_use_from_same_package
           .updateProfile(displayName: displayName, photoURL: photoURL);
 
       verify(mockUserPlatform!.updateProfile(data));

--- a/packages/firebase_auth/firebase_auth_web/lib/src/firebase_auth_web_user.dart
+++ b/packages/firebase_auth/firebase_auth_web/lib/src/firebase_auth_web_user.dart
@@ -206,10 +206,25 @@ class UserWeb extends UserPlatform {
     _assertIsSignedOut(auth);
 
     try {
-      await _webUser.updateProfile(auth_interop.UserProfile(
-        displayName: profile['displayName'],
-        photoURL: profile['photoURL'],
-      ));
+      auth_interop.UserProfile newProfile;
+
+      if (profile.containsKey('displayName') &&
+          profile.containsKey('photoURL')) {
+        newProfile = auth_interop.UserProfile(
+          displayName: profile['displayName'],
+          photoURL: profile['photoURL'],
+        );
+      } else if (profile.containsKey('displayName')) {
+        newProfile = auth_interop.UserProfile(
+          displayName: profile['displayName'],
+        );
+      } else {
+        newProfile = auth_interop.UserProfile(
+          photoURL: profile['photoURL'],
+        );
+      }
+
+      await _webUser.updateProfile(newProfile);
       await _webUser.reload();
       auth.sendAuthChangesEvent(auth.app.name, auth.currentUser);
     } catch (e) {


### PR DESCRIPTION
## Description

User.updateProfile is now deprecated in favor of these new methods.
This change is to fix an issue where it was not possible to set a displayName/photoURL to null.


## Related Issues

fixes #6199
fixes #6194

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
