### PR TITLE
fix(firebase_firestore): fix typo on firebase_firestore real time example

### DIFF
--- a/docs/firestore/usage.mdx
+++ b/docs/firestore/usage.mdx
@@ -142,7 +142,7 @@ which helps automatically manage the streams state and disposal of the stream wh
 ```dart
 class UserInformation extends StatefulWidget {
   @override
-    _UsetInfomation createState() => _UserInfomationState();
+    _UserInformationState createState() => _UserInfomationState();
 }
 
 class _UserInformationState extends State<UserInformation> {


### PR DESCRIPTION
## Description

i found some code example typo on firebase_firestore when i am doing integration with my flutter project, so here i try to fix the typo with the correct one. 

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.
