### PR TITLE
fix(firebase_firestore): Update Cloud Firestore Usage.mx 

### DIFF
--- a/docs/firestore/usage.mdx
+++ b/docs/firestore/usage.mdx
@@ -405,7 +405,7 @@ class Movie {
 We can then use `withConverter` to manipulate a collection of movies like so:
 
 ```dart
-final moviesRef = FirebaseFirestore.instance.collection('movies').withConverter(
+final moviesRef = FirebaseFirestore.instance.collection('movies').withConverter<Movie>(
       fromFirestore: (snapshot, _) => Movie.fromJson(snapshot.data()!),
       toFirestore: (movie, _) => movie.toJson(),
     );


### PR DESCRIPTION
## Description

The withConverter example needed to specify the type in angle brackets because toJson() can not be called on Object class. This is also how the code is written on the pub.dev example page.

## Related Issues

I didn't raise an issue, I discovered the example was wrong and solved it after some searching. Figured I'd pass on the fix. 

## Checklist

- All I did edit one line in the documentation. 

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ no Only changed docs] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ only changed docs] All existing and new tests are passing.
- [x ] I updated/added relevant documentation (doc comments with `///`).
- [only changed docs] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ x] I read and followed the [Flutter Style Guide].
- [x ] I signed the [CLA].
- [ x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [ x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
