### PR TITLE
test(firestore): update and assert documentId field & isNotEqualTo filter test

### DIFF
--- a/packages/cloud_firestore/cloud_firestore/lib/src/query.dart
+++ b/packages/cloud_firestore/cloud_firestore/lib/src/query.dart
@@ -675,8 +675,10 @@ class _JsonQuery implements Query<Map<String, dynamic>> {
       }
 
       if (field == FieldPath.documentId) {
-        assert(!hasNotEqualTo,
-            "You cannot use '!=' filters with a FieldPath.documentId field.");
+        assert(
+          !hasNotEqualTo,
+          "You cannot use '!=' filters with a FieldPath.documentId field.",
+        );
         hasDocumentIdField = true;
       }
 

--- a/packages/cloud_firestore/cloud_firestore/lib/src/query.dart
+++ b/packages/cloud_firestore/cloud_firestore/lib/src/query.dart
@@ -654,6 +654,7 @@ class _JsonQuery implements Query<Map<String, dynamic>> {
     bool hasNotEqualTo = false;
     bool hasArrayContains = false;
     bool hasArrayContainsAny = false;
+    bool hasDocumentIdField = false;
 
     // Once all conditions have been set, we must now check them to ensure the
     // query is valid.
@@ -671,6 +672,12 @@ class _JsonQuery implements Query<Map<String, dynamic>> {
           "The initial orderBy() field '$orders[0][0]' has to be the same as "
           "the where() field parameter '$field' when an inequality operator is invoked.",
         );
+      }
+
+      if (field == FieldPath.documentId) {
+        assert(!hasNotEqualTo,
+            "You cannot use '!=' filters with a FieldPath.documentId field.");
+        hasDocumentIdField = true;
       }
 
       if (value == null) {
@@ -702,6 +709,8 @@ class _JsonQuery implements Query<Map<String, dynamic>> {
       if (operator == '!=') {
         assert(!hasNotEqualTo, "You cannot use '!=' filters more than once.");
         assert(!hasNotIn, "You cannot use '!=' filters with 'not-in' filters.");
+        assert(!hasDocumentIdField,
+            "You cannot use a FieldPath.documentId field with '!=' filters.");
         hasNotEqualTo = true;
       }
 

--- a/packages/cloud_firestore/cloud_firestore/test/query_test.dart
+++ b/packages/cloud_firestore/cloud_firestore/test/query_test.dart
@@ -152,16 +152,18 @@ void main() {
           'throws if FieldPath.documentId field is used in conjunction with isNotEqualTo filter',
           () {
         expect(
-            () => query!
-                .where(FieldPath.documentId, isEqualTo: 'fake-id')
-                .where('foo', isNotEqualTo: 'bar'),
-            throwsAssertionError);
+          () => query!
+              .where(FieldPath.documentId, isEqualTo: 'fake-id')
+              .where('foo', isNotEqualTo: 'bar'),
+          throwsAssertionError,
+        );
 
         expect(
-            () => query!
-                .where('foo', isNotEqualTo: 'bar')
-                .where(FieldPath.documentId, whereIn: [2, 3]),
-            throwsAssertionError);
+          () => query!
+              .where('foo', isNotEqualTo: 'bar')
+              .where(FieldPath.documentId, whereIn: [2, 3]),
+          throwsAssertionError,
+        );
       });
 
       test('allows arrayContains with whereIn filter', () {

--- a/packages/cloud_firestore/cloud_firestore/test/query_test.dart
+++ b/packages/cloud_firestore/cloud_firestore/test/query_test.dart
@@ -148,6 +148,22 @@ void main() {
             throwsAssertionError);
       });
 
+      test(
+          'throws if FieldPath.documentId field is used in conjunction with isNotEqualTo filter',
+          () {
+        expect(
+            () => query!
+                .where(FieldPath.documentId, isEqualTo: 'fake-id')
+                .where('foo', isNotEqualTo: 'bar'),
+            throwsAssertionError);
+
+        expect(
+            () => query!
+                .where('foo', isNotEqualTo: 'bar')
+                .where(FieldPath.documentId, whereIn: [2, 3]),
+            throwsAssertionError);
+      });
+
       test('allows arrayContains with whereIn filter', () {
         query!.where('foo', arrayContains: 1).where('foo', whereIn: [2, 3]);
         query!.where('foo', whereIn: [2, 3]).where('foo', arrayContains: 1);


### PR DESCRIPTION
## Description

Not possible to use a `isNotEqualTo` filter with another `where()` query that uses a `FieldPath.documentId` field.

## Related Issues

closes #6174

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
