### PR TITLE
docs(auth): codeSent doc update

### DIFF
--- a/docs/auth/phone.mdx
+++ b/docs/auth/phone.mdx
@@ -106,7 +106,8 @@ await auth.verifyPhoneNumber(
 
 #### codeSent
 
-When Firebase sends an SMS code to the device, this handler is triggered with a `verificationId` and `resendToken`.
+When Firebase sends an SMS code to the device, this handler is triggered with a `verificationId` and `resendToken` (A `resendToken`
+is only supported on Android devices, iOS devices will _always_ return a `null` value).
 
 Once triggered, it would be a good time to update your application UI to prompt the user to enter the SMS code they're expecting.
 Once the SMS code has been entered, you can combine the verification ID with the SMS code to create a new `PhoneAuthCredential`:


### PR DESCRIPTION
## Description

iOS does not support the `resendToken` in the codeSent callback.

## Related Issues

closes #4542

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
