### PR TITLE
test(firestore): improve query assertions

### DIFF
--- a/packages/cloud_firestore/cloud_firestore/lib/src/query.dart
+++ b/packages/cloud_firestore/cloud_firestore/lib/src/query.dart
@@ -477,8 +477,7 @@ class _JsonQuery implements Query<Map<String, dynamic>> {
         // inequality or 'not-in' operator is invoked
         if (_isInequality(operator) || operator == 'not-in') {
           assert(
-            conditionField == orders[0][0] ||
-                field == FieldPath.documentId && field == conditionField,
+            conditionField == orders[0][0],
             'The initial orderBy() field "$orders[0][0]" has to be the same as '
             'the where() field parameter "$conditionField" when an inequality operator is invoked.',
           );

--- a/packages/cloud_firestore/cloud_firestore/lib/src/query.dart
+++ b/packages/cloud_firestore/cloud_firestore/lib/src/query.dart
@@ -232,6 +232,10 @@ class _JsonQuery implements Query<Map<String, dynamic>> {
         operator == '!=';
   }
 
+  bool isNotIn(String operator){
+    return operator == 'not-in';
+  }
+
   /// Asserts that a [DocumentSnapshot] can be used within the current
   /// query.
   ///
@@ -475,7 +479,7 @@ class _JsonQuery implements Query<Map<String, dynamic>> {
 
         // Initial orderBy() parameter has to match every where() fieldPath parameter when
         // inequality or 'not-in' operator is invoked
-        if (_isInequality(operator) || operator == 'not-in') {
+        if (_isInequality(operator) || isNotIn(operator)) {
           assert(
             conditionField == orders[0][0],
             'The initial orderBy() field "$orders[0][0]" has to be the same as '
@@ -680,7 +684,7 @@ class _JsonQuery implements Query<Map<String, dynamic>> {
 
       if (operator == 'in' ||
           operator == 'array-contains-any' ||
-          operator == 'not-in') {
+          isNotIn(operator)) {
         assert(
           value is List,
           "A non-empty [List] is required for '$operator' filters.",
@@ -705,7 +709,7 @@ class _JsonQuery implements Query<Map<String, dynamic>> {
         hasNotEqualTo = true;
       }
 
-      if (operator == 'not-in') {
+      if (isNotIn(operator)) {
         assert(!hasNotIn, "You cannot use 'not-in' filters more than once.");
         assert(
           !hasNotEqualTo,

--- a/packages/cloud_firestore/cloud_firestore/lib/src/query.dart
+++ b/packages/cloud_firestore/cloud_firestore/lib/src/query.dart
@@ -232,7 +232,7 @@ class _JsonQuery implements Query<Map<String, dynamic>> {
         operator == '!=';
   }
 
-  bool isNotIn(String operator){
+  bool isNotIn(String operator) {
     return operator == 'not-in';
   }
 

--- a/packages/cloud_firestore/cloud_firestore/lib/src/query.dart
+++ b/packages/cloud_firestore/cloud_firestore/lib/src/query.dart
@@ -470,16 +470,17 @@ class _JsonQuery implements Query<Map<String, dynamic>> {
 
     if (conditions.isNotEmpty) {
       for (final dynamic condition in conditions) {
-        dynamic field = condition[0];
+        dynamic conditionField = condition[0];
         String operator = condition[1];
 
         // Initial orderBy() parameter has to match every where() fieldPath parameter when
-        // inequality operator is invoked
-        if (_isInequality(operator)) {
+        // inequality or 'not-in' operator is invoked
+        if (_isInequality(operator) || operator == 'not-in') {
           assert(
-            field == orders[0][0],
+            conditionField == orders[0][0] ||
+                field == FieldPath.documentId && field == conditionField,
             'The initial orderBy() field "$orders[0][0]" has to be the same as '
-            'the where() field parameter "$field" when an inequality operator is invoked.',
+            'the where() field parameter "$conditionField" when an inequality operator is invoked.',
           );
         }
 
@@ -490,12 +491,12 @@ class _JsonQuery implements Query<Map<String, dynamic>> {
           // '==' operand is invoked
           if (operator == '==') {
             assert(
-              field != orderField,
-              "The '$orderField' cannot be the same as your where() field parameter '$field'.",
+              conditionField != orderField,
+              "The '$orderField' cannot be the same as your where() field parameter '$conditionField'.",
             );
           }
 
-          if (field == FieldPath.documentId) {
+          if (conditionField == FieldPath.documentId) {
             assert(
               orderField == FieldPath.documentId,
               "'[FieldPath.documentId]' cannot be used in conjunction with a different orderBy() parameter.",

--- a/packages/cloud_firestore/cloud_firestore/test/query_test.dart
+++ b/packages/cloud_firestore/cloud_firestore/test/query_test.dart
@@ -61,44 +61,58 @@ void main() {
       });
 
       test('throws if inequality is different to first orderBy', () {
-        expect(() => query!.where('foo', isGreaterThan: 123).orderBy('bar'),
-            throwsAssertionError);
-        expect(() => query!.orderBy('bar').where('foo', isGreaterThan: 123),
-            throwsAssertionError);
         expect(
-            () => query!
-                .where('foo', isGreaterThan: 123)
-                .orderBy('bar')
-                .orderBy('foo'),
-            throwsAssertionError);
+          () => query!.where('foo', isGreaterThan: 123).orderBy('bar'),
+          throwsAssertionError,
+        );
         expect(
-            () => query!
-                .orderBy('bar')
-                .orderBy('foo')
-                .where('foo', isGreaterThan: 123),
-            throwsAssertionError);
+          () => query!.orderBy('bar').where('foo', isGreaterThan: 123),
+          throwsAssertionError,
+        );
+        expect(
+          () => query!
+              .where('foo', isGreaterThan: 123)
+              .orderBy('bar')
+              .orderBy('foo'),
+          throwsAssertionError,
+        );
+        expect(
+          () => query!
+              .orderBy('bar')
+              .orderBy('foo')
+              .where('foo', isGreaterThan: 123),
+          throwsAssertionError,
+        );
 
         expect(
-            () => query!.where(FieldPath.documentId,
-                whereNotIn: ['bar']).orderBy('foo'),
-            throwsAssertionError);
+          () => query!
+              .where(FieldPath.documentId, whereNotIn: ['bar']).orderBy('foo'),
+          throwsAssertionError,
+        );
         expect(
-            () => query!
-                .where(FieldPath.documentId, isLessThan: 3)
-                .orderBy('foo'),
-            throwsAssertionError);
+          () =>
+              query!.where(FieldPath.documentId, isLessThan: 3).orderBy('foo'),
+          throwsAssertionError,
+        );
         expect(
-            () => query!
-                .where(FieldPath.documentId, isGreaterThan: 3)
-                .orderBy('foo'),
-            throwsAssertionError);
+          () => query!
+              .where(FieldPath.documentId, isGreaterThan: 3)
+              .orderBy('foo'),
+          throwsAssertionError,
+        );
 
-        expect(() => query!.where('foo', whereNotIn: ['bar']).orderBy('baz'),
-            throwsAssertionError);
-        expect(() => query!.where('foo', isLessThan: 3).orderBy('bar'),
-            throwsAssertionError);
-        expect(() => query!.where('foo', isGreaterThan: 3).orderBy('bar'),
-            throwsAssertionError);
+        expect(
+          () => query!.where('foo', whereNotIn: ['bar']).orderBy('baz'),
+          throwsAssertionError,
+        );
+        expect(
+          () => query!.where('foo', isLessThan: 3).orderBy('bar'),
+          throwsAssertionError,
+        );
+        expect(
+          () => query!.where('foo', isGreaterThan: 3).orderBy('bar'),
+          throwsAssertionError,
+        );
       });
 
       test('throws if whereIn query length is greater than 10', () {

--- a/packages/cloud_firestore/cloud_firestore/test/query_test.dart
+++ b/packages/cloud_firestore/cloud_firestore/test/query_test.dart
@@ -77,6 +77,28 @@ void main() {
                 .orderBy('foo')
                 .where('foo', isGreaterThan: 123),
             throwsAssertionError);
+
+        expect(
+            () => query!.where(FieldPath.documentId,
+                whereNotIn: ['bar']).orderBy('foo'),
+            throwsAssertionError);
+        expect(
+            () => query!
+                .where(FieldPath.documentId, isLessThan: 3)
+                .orderBy('foo'),
+            throwsAssertionError);
+        expect(
+            () => query!
+                .where(FieldPath.documentId, isGreaterThan: 3)
+                .orderBy('foo'),
+            throwsAssertionError);
+
+        expect(() => query!.where('foo', whereNotIn: ['bar']).orderBy('baz'),
+            throwsAssertionError);
+        expect(() => query!.where('foo', isLessThan: 3).orderBy('bar'),
+            throwsAssertionError);
+        expect(() => query!.where('foo', isGreaterThan: 3).orderBy('bar'),
+            throwsAssertionError);
       });
 
       test('throws if whereIn query length is greater than 10', () {


### PR DESCRIPTION
## Description

cannot use orderBy on `not-in` operators as well as inequality operators.

## Related Issues

closes https://github.com/FirebaseExtended/flutterfire/issues/4906

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [X] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
