### PR TITLE
Bump Andriod BoM to version 28.1.0

### DIFF
--- a/packages/firebase_core/firebase_core/android/gradle.properties
+++ b/packages/firebase_core/firebase_core/android/gradle.properties
@@ -1,2 +1,2 @@
 # https://firebase.google.com/support/release-notes/android
-FirebaseSDKVersion=28.0.1
+FirebaseSDKVersion=28.1.0


### PR DESCRIPTION
## Description

Update the Andriod SDK to Version 28.1.0. The updated Andriod Firebase SDK contains a fix that skips backoff when App enters Foreground

## Related Issues


## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [ ] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
