### PR TITLE
fix(storage): refFromUrl parse url

### DIFF
--- a/packages/firebase_storage/firebase_storage/lib/src/utils.dart
+++ b/packages/firebase_storage/firebase_storage/lib/src/utils.dart
@@ -31,21 +31,21 @@ Map<String, String?>? partsFromHttpUrl(String url) {
     return null;
   }
 
-  RegExp exp = RegExp(r'\/b\/(.*)\/o\/([a-zA-Z0-9.\/\-_\s\+]+)(.*)');
-  Iterable<RegExpMatch> matches = exp.allMatches(decodedUrl);
+  Uri uri = Uri.parse(decodedUrl);
 
-  if (matches.isEmpty) {
+  if (uri.pathSegments.length <= 3 ||
+      uri.pathSegments[0] != 'v0' ||
+      uri.pathSegments[1] != 'b') {
     return null;
   }
 
-  RegExpMatch firstElement = matches.first;
-  if (firstElement.groupCount < 1) {
-    return null;
-  }
+  String bucketName = uri.pathSegments[2];
+  String path =
+      "${uri.pathSegments.getRange(4, uri.pathSegments.length).join('/')}";
 
   return {
-    'bucket': firstElement.group(1),
-    'path': firstElement.group(2) ?? '/',
+    'bucket': bucketName,
+    'path': path,
   };
 }
 

--- a/packages/firebase_storage/firebase_storage/lib/src/utils.dart
+++ b/packages/firebase_storage/firebase_storage/lib/src/utils.dart
@@ -40,8 +40,7 @@ Map<String, String?>? partsFromHttpUrl(String url) {
   }
 
   String bucketName = uri.pathSegments[2];
-  String path =
-      "${uri.pathSegments.getRange(4, uri.pathSegments.length).join('/')}";
+  String path = uri.pathSegments.getRange(4, uri.pathSegments.length).join('/');
 
   return {
     'bucket': bucketName,

--- a/packages/firebase_storage/firebase_storage/test/firebase_storage_test.dart
+++ b/packages/firebase_storage/firebase_storage/test/firebase_storage_test.dart
@@ -166,6 +166,18 @@ void main() {
         expect(ref, isA<Reference>());
         verify(kMockStoragePlatform.ref(testPath));
       });
+
+      test('verify special characters are allowed in http path', () {
+        const String customBucket = 'test.appspot.com';
+        const String testPath = '[!@+= ^&*_+-= {};,.<> ].jpg';
+        const String url =
+            'https://firebasestorage.googleapis.com/v0/b/$customBucket/o/$testPath?alt=media';
+
+        final ref = storage.refFromURL(url);
+
+        expect(ref, isA<Reference>());
+        verify(kMockStoragePlatform.ref(testPath));
+      });
     });
 
     group('useEmulator', () {


### PR DESCRIPTION
## Description

When allowed special characters are in the url, they can often truncate the path due to a buggy regex. This PR removes the regex implementation for something more straight forward.

## Related Issues

closes #5965
## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
