### PR TITLE
chore(*): peg android-build for CI until build fixed

### DIFF
--- a/.github/workflows/firebase_analytics.yaml
+++ b/.github/workflows/firebase_analytics.yaml
@@ -44,6 +44,7 @@ jobs:
           target: default
           profile: Nexus 5X
           script: ./.github/workflows/scripts/drive-example.sh android
+          emulator-build: 6110076
 
   ios:
     runs-on: macos-latest

--- a/.github/workflows/firebase_app_check.yaml
+++ b/.github/workflows/firebase_app_check.yaml
@@ -32,6 +32,7 @@ jobs:
           target: google_apis
           profile: Nexus 5X
           script: ./.github/workflows/scripts/drive-example.sh android
+          emulator-build: 6110076
 
   apple:
     runs-on: macos-latest

--- a/.github/workflows/firebase_auth.yaml
+++ b/.github/workflows/firebase_auth.yaml
@@ -47,6 +47,7 @@ jobs:
           target: google_apis
           profile: Nexus 5X
           script: ./.github/workflows/scripts/drive-example.sh android
+          emulator-build: 6110076
 
   apple:
     runs-on: macos-latest

--- a/.github/workflows/firebase_core.yaml
+++ b/.github/workflows/firebase_core.yaml
@@ -40,6 +40,7 @@ jobs:
           target: default
           profile: Nexus 5X
           script: ./.github/workflows/scripts/drive-example.sh android
+          emulator-build: 6110076
 
   apple:
     runs-on: macos-latest

--- a/.github/workflows/firebase_crashlytics.yaml
+++ b/.github/workflows/firebase_crashlytics.yaml
@@ -45,6 +45,7 @@ jobs:
           target: default
           profile: Nexus 5X
           script: ./.github/workflows/scripts/drive-example.sh android
+          emulator-build: 6110076
 
   apple:
     runs-on: macos-latest

--- a/.github/workflows/firebase_database.yaml
+++ b/.github/workflows/firebase_database.yaml
@@ -47,7 +47,7 @@ jobs:
           target: default
           profile: Nexus 5X
           script: ./.github/workflows/scripts/drive-example.sh android
-          emulator-build: 6110076
+          emulator-build: 7024830
 
   apple:
     runs-on: macos-latest

--- a/.github/workflows/firebase_database.yaml
+++ b/.github/workflows/firebase_database.yaml
@@ -47,6 +47,7 @@ jobs:
           target: default
           profile: Nexus 5X
           script: ./.github/workflows/scripts/drive-example.sh android
+          emulator-build: 6110076
 
   apple:
     runs-on: macos-latest

--- a/.github/workflows/firebase_dynamic_links.yaml
+++ b/.github/workflows/firebase_dynamic_links.yaml
@@ -47,6 +47,7 @@ jobs:
           target: default
           profile: Nexus 5X
           script: ./.github/workflows/scripts/drive-example.sh android
+          emulator-build: 6110076
 
   apple:
     runs-on: macos-latest

--- a/.github/workflows/firebase_firestore.yaml
+++ b/.github/workflows/firebase_firestore.yaml
@@ -45,6 +45,7 @@ jobs:
           target: default
           profile: Nexus 5X
           script: ./.github/workflows/scripts/drive-example.sh android
+          emulator-build: 6110076
 
   apple:
     runs-on: macos-latest

--- a/.github/workflows/firebase_functions.yaml
+++ b/.github/workflows/firebase_functions.yaml
@@ -48,6 +48,7 @@ jobs:
           target: default
           profile: Nexus 5X
           script: ./.github/workflows/scripts/drive-example.sh android
+          emulator-build: 6110076
 
   apple:
     runs-on: macos-latest

--- a/.github/workflows/firebase_messaging.yaml
+++ b/.github/workflows/firebase_messaging.yaml
@@ -42,6 +42,7 @@ jobs:
           target: google_apis
           profile: Nexus 5X
           script: ./.github/workflows/scripts/drive-example.sh android
+          emulator-build: 6110076
 
   apple:
     runs-on: macos-latest

--- a/.github/workflows/firebase_ml_custom.yaml
+++ b/.github/workflows/firebase_ml_custom.yaml
@@ -42,6 +42,7 @@ jobs:
           target: default
           profile: Nexus 5X
           script: ./.github/workflows/scripts/drive-example.sh android
+          emulator-build: 6110076
 
   apple:
     runs-on: macos-latest

--- a/.github/workflows/firebase_performance.yaml
+++ b/.github/workflows/firebase_performance.yaml
@@ -43,6 +43,7 @@ jobs:
           target: google_apis
           profile: Nexus 5X
           script: ./.github/workflows/scripts/drive-example.sh android
+          emulator-build: 6110076
 
   ios:
     runs-on: macos-latest

--- a/.github/workflows/firebase_remote_config.yaml
+++ b/.github/workflows/firebase_remote_config.yaml
@@ -41,6 +41,7 @@ jobs:
           target: google_apis
           profile: Nexus 5X
           script: ./.github/workflows/scripts/drive-example.sh android
+          emulator-build: 6110076
 
   apple:
     runs-on: macos-latest

--- a/.github/workflows/firebase_storage.yaml
+++ b/.github/workflows/firebase_storage.yaml
@@ -56,6 +56,7 @@ jobs:
           target: default
           profile: Nexus 5X
           script: ./.github/workflows/scripts/drive-example.sh android
+          emulator-build: 6110076
 
   apple:
     runs-on: macos-latest


### PR DESCRIPTION
## Description

peg android build to fix CI. 

### Edit 
Apparent fix is still not working, track this issue: https://github.com/ReactiveCircus/android-emulator-runner/issues/160 and upstream issue tracker for potential solution: https://issuetracker.google.com/issues/191799887.


## Related Issues


## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
