### PR TITLE
docs(auth): phone provider account linking update

### DIFF
--- a/packages/firebase_auth/firebase_auth/lib/src/user.dart
+++ b/packages/firebase_auth/firebase_auth/lib/src/user.dart
@@ -148,9 +148,10 @@ class User {
   ///    user. The fields `email`, `phoneNumber`, and `credential`
   ///    ([AuthCredential]) may be provided, depending on the type of
   ///    credential. You can recover from this error by signing in with
-  ///    `credential` directly via [signInWithCredential]. Please note, you will not recover from this error
-  ///    if you're using a [PhoneAuthCredential] to link a provider to an account. Once an attempt to
-  ///    link an account has been made, a new sms code is required to sign in the user.
+  ///    `credential` directly via [signInWithCredential]. Please note, you will
+  ///    not recover from this error if you're using a [PhoneAuthCredential] to link
+  ///    a provider to an account. Once an attempt to link an account has been made,
+  ///    a new sms code is required to sign in the user.
   /// - **email-already-in-use**:
   ///  - Thrown if the email corresponding to the credential already exists
   ///    among your users. When thrown while linking a credential to an existing

--- a/packages/firebase_auth/firebase_auth/lib/src/user.dart
+++ b/packages/firebase_auth/firebase_auth/lib/src/user.dart
@@ -148,8 +148,8 @@ class User {
   ///    user. The fields `email`, `phoneNumber`, and `credential`
   ///    ([AuthCredential]) may be provided, depending on the type of
   ///    credential. You can recover from this error by signing in with
-  ///    `credential` directly via [signInWithCredential] as long as you're not using
-  ///    a [PhoneAuthCredential] to link a provider to an account. Once an attempt to
+  ///    `credential` directly via [signInWithCredential]. Please note, you will not recover from this error
+  ///    if you're using a [PhoneAuthCredential] to link a provider to an account. Once an attempt to
   ///    link an account has been made, a new sms code is required to sign in the user.
   /// - **email-already-in-use**:
   ///  - Thrown if the email corresponding to the credential already exists

--- a/packages/firebase_auth/firebase_auth/lib/src/user.dart
+++ b/packages/firebase_auth/firebase_auth/lib/src/user.dart
@@ -148,7 +148,9 @@ class User {
   ///    user. The fields `email`, `phoneNumber`, and `credential`
   ///    ([AuthCredential]) may be provided, depending on the type of
   ///    credential. You can recover from this error by signing in with
-  ///    `credential` directly via [signInWithCredential].
+  ///    `credential` directly via [signInWithCredential] as long as you're not using
+  ///    a [PhoneAuthCredential] to link a provider to an account. Once an attempt to
+  ///    link an account has been made, a new sms code is required to sign in the user.
   /// - **email-already-in-use**:
   ///  - Thrown if the email corresponding to the credential already exists
   ///    among your users. When thrown while linking a credential to an existing


### PR DESCRIPTION
## Description

Update documentation relating to behaviour of Firebase auth once a `PhoneAuthCredential` has been used to attempt to link `PhoneAuthCredential` to Firebase auth account.

## Related Issues

closes https://github.com/FirebaseExtended/flutterfire/issues/6006

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
