### PR TITLE
fix(firebase_storage): Use `mappedHost` instead of `host`

### DIFF
--- a/packages/firebase_storage/firebase_storage/lib/src/firebase_storage.dart
+++ b/packages/firebase_storage/firebase_storage/lib/src/firebase_storage.dart
@@ -174,7 +174,7 @@ class FirebaseStorage extends FirebasePluginPlatform {
       }
     }
 
-    await _delegate.useStorageEmulator(host, port);
+    await _delegate.useStorageEmulator(mappedHost, port);
   }
 
   @override


### PR DESCRIPTION
## Description

Use `mappedHost` instead of `host` for `useStorageEmulator` implementation.
Before this change, `mappedHost` wasn't used mistakenly.
It should be used like this: https://github.com/FirebaseExtended/flutterfire/blob/73f1eeae137ea466c4b5776f627738bb323c3616/packages/firebase_auth/firebase_auth/lib/src/firebase_auth.dart#L92

## Related Issues

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
  - Not tests added because there are no exiting tests about it. 
- [x] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
