### PR TITLE
fix(firestore): export PersistenceSettings

### DIFF
--- a/packages/cloud_firestore/cloud_firestore/lib/cloud_firestore.dart
+++ b/packages/cloud_firestore/cloud_firestore/lib/cloud_firestore.dart
@@ -25,6 +25,7 @@ export 'package:cloud_firestore_platform_interface/cloud_firestore_platform_inte
         GetOptions,
         SetOptions,
         DocumentChangeType,
+        PersistenceSettings,
         Settings;
 export 'package:firebase_core_platform_interface/firebase_core_platform_interface.dart'
     show FirebaseException;

--- a/packages/cloud_firestore/cloud_firestore_web/lib/cloud_firestore_web.dart
+++ b/packages/cloud_firestore/cloud_firestore_web/lib/cloud_firestore_web.dart
@@ -133,6 +133,14 @@ class FirebaseFirestoreWeb extends FirebaseFirestorePlatform {
   /// Enable persistence of Firestore data.
   @override
   Future<void> enablePersistence([PersistenceSettings? settings]) {
+    if (settings != null) {
+      firestore_interop.PersistenceSettings interopSettings =
+          firestore_interop.PersistenceSettings(
+              synchronizeTabs: settings.synchronizeTabs);
+
+      return guard(() => _webFirestore.enablePersistence(interopSettings));
+    }
+
     return guard(_webFirestore.enablePersistence);
   }
 


### PR DESCRIPTION
## Description

export `PersistenceSettings` & also pass settings to Firebase JS SDK. There is an [additional property](https://firebase.google.com/docs/reference/js/firebase.firestore.PersistenceSettings#optional-experimentalforceowningtab) on `FirebaseSettings` which is experimental and will possibly be removed, therefore, it hasn't been implemented.

## Related Issues

none.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
