### PR TITLE
fix(*): reinstate deprecated emulator apis

### DIFF
--- a/docs/migration-guide.mdx
+++ b/docs/migration-guide.mdx
@@ -367,6 +367,7 @@ Firestore specific errors now return a `FirebaseException` (see Core changes), a
 
 - **`FirebaseFirestore`**:
 
+    - **NEW**: Add `useFirestoreEmulator(String host, int port)` support.
     - **BREAKING**: Calling `settings()` now accepts a `Settings` instance.
     - **DEPRECATED**: Calling `document()` is deprecated in favor of `doc()`.
     - **DEPRECATED**: Calling `Firestore(app: app)` is now deprecated. Use `FirebaseFirestore.instance`
@@ -456,6 +457,8 @@ Firestore specific errors now return a `FirebaseException` (see Core changes), a
 
 - **`FirebaseFunctions`**:
 
+    - **DEPRECATED**: `useFunctionsEmulator({required String origin})` parameters have been changed in line with every
+      other package emulator API; `useFunctionsEmulator(String host, int port)`.
     - **DEPRECATED**: Class `CloudFunctions` is now deprecated. Use `FirebaseFunctions` instead.
     - **DEPRECATED**: Calling `CloudFunctions.instance` or `CloudFunctions(app: app, region: region)` is now deprecated.
       Use `FirebaseFunctions.instance` or `FirebaseFunctions.instanceFor(app: app, region: region)` instead.

--- a/packages/firebase_auth/firebase_auth/lib/src/firebase_auth.dart
+++ b/packages/firebase_auth/firebase_auth/lib/src/firebase_auth.dart
@@ -81,7 +81,7 @@ class FirebaseAuth extends FirebasePluginPlatform {
   /// Note: auth emulator is not supported for web yet. firebase-js-sdk does not support
   /// auth.useEmulator until v8.2.4, but FlutterFire does not support firebase-js-sdk v8+ yet
   @Deprecated(
-    'Will be removed in version 3.0.0. '
+    'Will be removed in future release. '
     'Use useAuthEmulator().',
   )
   Future<void> useEmulator(String origin) async {

--- a/packages/firebase_auth/firebase_auth/lib/src/firebase_auth.dart
+++ b/packages/firebase_auth/firebase_auth/lib/src/firebase_auth.dart
@@ -73,6 +73,47 @@ class FirebaseAuth extends FirebasePluginPlatform {
 
   /// Changes this instance to point to an Auth emulator running locally.
   ///
+  /// Set the [origin] of the local emulator, such as "http://localhost:9099"
+  ///
+  /// Note: Must be called immediately, prior to accessing auth methods.
+  /// Do not use with production credentials as emulator traffic is not encrypted.
+  ///
+  /// Note: auth emulator is not supported for web yet. firebase-js-sdk does not support
+  /// auth.useEmulator until v8.2.4, but FlutterFire does not support firebase-js-sdk v8+ yet
+  @Deprecated(
+    'Will be removed in version 3.0.0. '
+    'Use useAuthEmulator().',
+  )
+  Future<void> useEmulator(String origin) async {
+    assert(origin.isNotEmpty);
+    String mappedOrigin = origin;
+
+    // Android considers localhost as 10.0.2.2 - automatically handle this for users.
+    if (defaultTargetPlatform == TargetPlatform.android && !kIsWeb) {
+      if (mappedOrigin.startsWith('http://localhost')) {
+        mappedOrigin =
+            mappedOrigin.replaceFirst('http://localhost', 'http://10.0.2.2');
+      } else if (mappedOrigin.startsWith('http://127.0.0.1')) {
+        mappedOrigin =
+            mappedOrigin.replaceFirst('http://127.0.0.1', 'http://10.0.2.2');
+      }
+    }
+
+    // Native calls take the host and port split out
+    final hostPortRegex = RegExp(r'^http:\/\/([\w\d.]+):(\d+)$');
+    final RegExpMatch? match = hostPortRegex.firstMatch(mappedOrigin);
+    if (match == null) {
+      throw ArgumentError('firebase.auth().useEmulator() origin format error');
+    }
+    // Two non-empty groups in RegExp match - which is null-tested - these are non-null now
+    final String host = match.group(1)!;
+    final int port = int.parse(match.group(2)!);
+
+    await useAuthEmulator(host, port);
+  }
+
+  /// Changes this instance to point to an Auth emulator running locally.
+  ///
   /// Set the [host] of the local emulator, such as "localhost"
   /// Set the [port] of the local emulator, such as "9099" (port 9099 is default for auth package)
   ///

--- a/packages/firebase_storage/firebase_storage/lib/src/firebase_storage.dart
+++ b/packages/firebase_storage/firebase_storage/lib/src/firebase_storage.dart
@@ -151,6 +151,36 @@ class FirebaseStorage extends FirebasePluginPlatform {
 
   /// Changes this instance to point to a Storage emulator running locally.
   ///
+  /// Set the [host] (ex: localhost) and [port] (ex: 9199) of the local emulator.
+  ///
+  /// Note: Must be called immediately, prior to accessing storage methods.
+  /// Do not use with production credentials as emulator traffic is not encrypted.
+  ///
+  /// Note: storage emulator is not supported for web yet. firebase-js-sdk does not support
+  /// storage.useStorageEmulator until v9
+  @Deprecated(
+    'Will be removed in version 10.0.0. '
+    'Use useStorageEmulator().',
+  )
+  Future<void> useEmulator({required String host, required int port}) async {
+    assert(host.isNotEmpty);
+    assert(!port.isNegative);
+
+    String mappedHost = host;
+    // Android considers localhost as 10.0.2.2 - automatically handle this for users.
+    if (defaultTargetPlatform == TargetPlatform.android && !kIsWeb) {
+      if (mappedHost == 'localhost' || mappedHost == '127.0.0.1') {
+        // ignore: avoid_print
+        print('Mapping Storage Emulator host "$mappedHost" to "10.0.2.2".');
+        mappedHost = '10.0.2.2';
+      }
+    }
+
+    await useStorageEmulator(host, port);
+  }
+
+  /// Changes this instance to point to a Storage emulator running locally.
+  ///
   /// Set the [host] of the local emulator, such as "localhost"
   /// Set the [port] of the local emulator, such as "9199" (port 9199 is default for storage package)
   ///

--- a/packages/firebase_storage/firebase_storage/lib/src/firebase_storage.dart
+++ b/packages/firebase_storage/firebase_storage/lib/src/firebase_storage.dart
@@ -155,9 +155,6 @@ class FirebaseStorage extends FirebasePluginPlatform {
   ///
   /// Note: Must be called immediately, prior to accessing storage methods.
   /// Do not use with production credentials as emulator traffic is not encrypted.
-  ///
-  /// Note: storage emulator is not supported for web yet. firebase-js-sdk does not support
-  /// storage.useStorageEmulator until v9
   @Deprecated(
     'Will be removed in future release. '
     'Use useStorageEmulator().',
@@ -186,9 +183,6 @@ class FirebaseStorage extends FirebasePluginPlatform {
   ///
   /// Note: Must be called immediately, prior to accessing storage methods.
   /// Do not use with production credentials as emulator traffic is not encrypted.
-  ///
-  /// Note: storage emulator is not supported for web yet. firebase-js-sdk does not support
-  /// storage.useStorageEmulator until v9
   Future<void> useStorageEmulator(String host, int port) async {
     assert(host.isNotEmpty);
     assert(!port.isNegative);

--- a/packages/firebase_storage/firebase_storage/lib/src/firebase_storage.dart
+++ b/packages/firebase_storage/firebase_storage/lib/src/firebase_storage.dart
@@ -159,7 +159,7 @@ class FirebaseStorage extends FirebasePluginPlatform {
   /// Note: storage emulator is not supported for web yet. firebase-js-sdk does not support
   /// storage.useStorageEmulator until v9
   @Deprecated(
-    'Will be removed in version 10.0.0. '
+    'Will be removed in future release. '
     'Use useStorageEmulator().',
   )
   Future<void> useEmulator({required String host, required int port}) async {


### PR DESCRIPTION
## Description

Reinstate deprecated API for `auth` & `storage` packages for ease of use. 

Cannot reinstate `functions` because the `useFunctionsEmulator` has been reused and arguments have changed. No change to `firestore` as it didn't have a specific API in the first place. 

## Related Issues

none.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
