### PR TITLE
docs(crashlytics): Move `ensureInitialized` into runZonedGuarded

### DIFF
--- a/docs/crashlytics/usage.mdx
+++ b/docs/crashlytics/usage.mdx
@@ -188,16 +188,17 @@ To catch such errors, you can use `runZonedGuarded` like do:
 
 ```dart
 void main() async {
-  WidgetsFlutterBinding.ensureInitialized();
-  await Firebase.initializeApp();
   runZonedGuarded<Future<void>>(() async {
+    WidgetsFlutterBinding.ensureInitialized();
+    await Firebase.initializeApp();
     // The following lines are the same as previously explained in "Handling uncaught errors"
     FlutterError.onError = FirebaseCrashlytics.instance.recordFlutterError;
 
     runApp(MyApp());
-  }, FirebaseCrashlytics.instance.recordError);
+  }, (error, stack) => FirebaseCrashlytics.instance.recordError(error, stack));
 }
 ```
+Note that you must call `WidgetsFlutterBinding.ensureInitialized()` inside `runZonedGuarded`. Error handling wouldn’t work if `WidgetsFlutterBinding.ensureInitialized()` was called from the outside.
 
 ### Errors outside of Flutter
 


### PR DESCRIPTION
Fix #6657 according to an official handling errors guide: https://flutter.dev/docs/testing/errors#errors-not-caught-by-flutter