### PR TITLE
fix(database): DataSnapshot is always present

### DIFF
--- a/packages/firebase_database/firebase_database/example/test_driver/firebase_database_e2e.dart
+++ b/packages/firebase_database/firebase_database/example/test_driver/firebase_database_e2e.dart
@@ -100,9 +100,27 @@ void testsMain() {
           .child('ordered/one')
           .get();
       expect(dataSnapshot, isNot(null));
-      expect(dataSnapshot!.key, 'one');
+      expect(dataSnapshot.key, 'one');
       expect(dataSnapshot.value['ref'], 'one');
       expect(dataSnapshot.value['value'], 23);
+    });
+
+    test('DataSnapshot.exists is false for no data', () async {
+      final dataSnapshot = await FirebaseDatabase.instance
+          .reference()
+          .child('a-non-existing-reference')
+          .get();
+
+      expect(dataSnapshot.exists, false);
+    });
+
+    test('DataSnapshot.exists is true for existing data', () async {
+      final dataSnapshot = await FirebaseDatabase.instance
+          .reference()
+          .child('ordered/one')
+          .get();
+
+      expect(dataSnapshot.exists, true);
     });
   });
 }

--- a/packages/firebase_database/firebase_database/lib/src/event.dart
+++ b/packages/firebase_database/firebase_database/lib/src/event.dart
@@ -29,7 +29,7 @@ class Event {
 /// A DataSnapshot contains data from a Firebase Database location.
 /// Any time you read Firebase data, you receive the data as a DataSnapshot.
 class DataSnapshot {
-  DataSnapshot._(this.key, this.value);
+  DataSnapshot._(this.key, this.value): exists = value != null;
 
   factory DataSnapshot._fromJson(
     Map<Object?, Object?> _data,
@@ -55,6 +55,9 @@ class DataSnapshot {
 
   /// Returns the contents of this data snapshot as native types.
   final dynamic value;
+
+  /// Ascertains whether the value exists at the Firebase Database location.
+  final bool exists;
 }
 
 class MutableData {

--- a/packages/firebase_database/firebase_database/lib/src/event.dart
+++ b/packages/firebase_database/firebase_database/lib/src/event.dart
@@ -29,7 +29,7 @@ class Event {
 /// A DataSnapshot contains data from a Firebase Database location.
 /// Any time you read Firebase data, you receive the data as a DataSnapshot.
 class DataSnapshot {
-  DataSnapshot._(this.key, this.value): exists = value != null;
+  DataSnapshot._(this.key, this.value) : exists = value != null;
 
   factory DataSnapshot._fromJson(
     Map<Object?, Object?> _data,

--- a/packages/firebase_database/firebase_database/lib/src/query.dart
+++ b/packages/firebase_database/firebase_database/lib/src/query.dart
@@ -82,7 +82,7 @@ class Query {
   Future<DataSnapshot> once() async => (await onValue.first).snapshot;
 
   /// Gets the most up-to-date result for this query.
-  Future<DataSnapshot?> get() async {
+  Future<DataSnapshot> get() async {
     final result = await _database._channel.invokeMethod<Map<dynamic, dynamic>>(
       'Query#get',
       <String, dynamic>{

--- a/packages/firebase_database/firebase_database/test/firebase_list_test.dart
+++ b/packages/firebase_database/firebase_database/test/firebase_list_test.dart
@@ -330,13 +330,16 @@ class MockEvent implements Event {
 }
 
 class MockDataSnapshot implements DataSnapshot {
-  MockDataSnapshot(this.key, this.value);
+  MockDataSnapshot(this.key, this.value) : exists = value != null;
 
   @override
   final String key;
 
   @override
   final dynamic value;
+
+  @override
+  final bool exists;
 
   @override
   // ignore: no_runtimetype_tostring


### PR DESCRIPTION
## Description

`DataSnapshot` is always returned from a `get()` request.
`DataSnapshot.exists` ascertains whether value exists at RTDB location.

## Related Issues

fixes https://github.com/FirebaseExtended/flutterfire/issues/6747

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
