### PR TITLE
docs: update macOS docs regarding outgoing connections

### DIFF
--- a/docs/installation/macos.mdx
+++ b/docs/installation/macos.mdx
@@ -32,6 +32,14 @@ Select the `GoogleService-Info.plist` file you downloaded, and ensure the "Copy 
   caption={false}
 />
 
+## Enabling Outgoing Connections
+
+**Important** It is important you enable `Outgoing Connections (Client)` on Xcode's `Runner.xcworkspace` as illustrated below:
+
+![image](https://user-images.githubusercontent.com/12681781/121333660-d1330500-c93a-11eb-8fb6-b1d803b9c7bb.png)
+
+Failure to enable will result in a network error. You will not b able to connect to services such as any Firebase Emulator.
+
 ## Enabling use of Firebase Emulator Suite
 
 The [Firebase Emulator Suite](https://firebase.google.com/docs/emulator-suite) uses un-encrypted networking connections in order to enable fast, uncomplicated setup. However macOS by default requires encrypted networking connections. If you would like to use any part of the Firebase Emulator Suite to emulate firebase services on your local machine during development, you must allow your macOS app to connect to local network services over insecure connections.
@@ -47,12 +55,6 @@ Specifically if your app is named 'MyApp', and are sharing your configuration be
     <true/>
 </dict>
 ```
-
-**Important** The next step is to enable `Outgoing Connections (Client)` on Xcode's `Runner.xcworkspace` as illustrated below:
-
-![image](https://user-images.githubusercontent.com/12681781/121333660-d1330500-c93a-11eb-8fb6-b1d803b9c7bb.png)
-
-Failure to enable will result in a network error.
 
 ## Initializing FlutterFire
 

--- a/docs/installation/macos.mdx
+++ b/docs/installation/macos.mdx
@@ -32,13 +32,11 @@ Select the `GoogleService-Info.plist` file you downloaded, and ensure the "Copy 
   caption={false}
 />
 
-## Enabling Outgoing Connections
+## Setting up entitlements
 
-It is **important** you enable `Outgoing Connections (Client)` on Xcode's `Runner.xcworkspace` as illustrated below:
+It is **important** you setup [entitlements](https://flutter.dev/desktop#setting-up-entitlements).
 
-![image](https://user-images.githubusercontent.com/12681781/121333660-d1330500-c93a-11eb-8fb6-b1d803b9c7bb.png)
-
-Failure to enable will result in a network error. You will not b able to connect to services such as any Firebase Emulator.
+Failure to setup will result in network errors. You will not be able to connect to services such as any Firebase Emulator.
 
 ## Enabling use of Firebase Emulator Suite
 

--- a/docs/installation/macos.mdx
+++ b/docs/installation/macos.mdx
@@ -48,6 +48,15 @@ Specifically if your app is named 'MyApp', and are sharing your configuration be
 </dict>
 ```
 
+**Important** The next step is to enable `Outgoing Connections (Client)` on Xcode's `Runner.xcworkspace` as illustrated below:
+
+![image](https://user-images.githubusercontent.com/12681781/121333660-d1330500-c93a-11eb-8fb6-b1d803b9c7bb.png)
+
+Failure to enable will result in a network error.
+
+
+
+
 ## Initializing FlutterFire
 
 Once complete follow the instructions on [Initializing FlutterFire](../overview.mdx#initializing-flutterfire).

--- a/docs/installation/macos.mdx
+++ b/docs/installation/macos.mdx
@@ -54,9 +54,6 @@ Specifically if your app is named 'MyApp', and are sharing your configuration be
 
 Failure to enable will result in a network error.
 
-
-
-
 ## Initializing FlutterFire
 
 Once complete follow the instructions on [Initializing FlutterFire](../overview.mdx#initializing-flutterfire).

--- a/docs/installation/macos.mdx
+++ b/docs/installation/macos.mdx
@@ -34,7 +34,7 @@ Select the `GoogleService-Info.plist` file you downloaded, and ensure the "Copy 
 
 ## Enabling Outgoing Connections
 
-**Important** It is important you enable `Outgoing Connections (Client)` on Xcode's `Runner.xcworkspace` as illustrated below:
+It is **important** you enable `Outgoing Connections (Client)` on Xcode's `Runner.xcworkspace` as illustrated below:
 
 ![image](https://user-images.githubusercontent.com/12681781/121333660-d1330500-c93a-11eb-8fb6-b1d803b9c7bb.png)
 


### PR DESCRIPTION
## Description

outgoing connections on macOS. Replacement PR for https://github.com/FirebaseExtended/flutterfire/pull/6376

## Related Issues

closes https://github.com/FirebaseExtended/flutterfire/issues/6356
## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
