### PR TITLE
feat: lower iOS & macOS deployment targets for relevant plugins

### DIFF
--- a/docs/installation/ios.mdx
+++ b/docs/installation/ios.mdx
@@ -54,4 +54,20 @@ Once complete follow the instructions on [Initializing FlutterFire](../overview.
 
 ## iOS Supported Versions
 
-FlutterFire supports an iOS deployment target of 10 or higher, in line with the requirements of the underlying [firebase-ios-sdk](https://firebase.google.com/docs/ios/setup).
+| Name                          | Deployment Target (minimum) |
+| ------------------------------| ----------------------------|
+| **firebase_core**             |            9.00             |
+| **cloud_firestore**           |            10.00            |
+| **firebase_analytics**        |            9.00             |
+| **firebase_app_check**        |            9.00             |
+| **firebase_auth**             |            10.00            |
+| **firebase_crashlytics**      |            9.00             |
+| **firebase_database**         |            10.00            |
+| **firebase_dynamic_links**    |            10.00            |
+| **firebase_in_app_messaging** |            10.00            |
+| **firebase_messaging**        |            10.00            |
+| **firebase_performance**      |            10.00            |
+| **firebase_remote_config**    |            10.00            |
+| **firebase_storage**          |            10.00            |
+
+Please see the underlying [firebase-ios-sdk](https://firebase.google.com/docs/ios/setup) for further details.

--- a/docs/installation/macos.mdx
+++ b/docs/installation/macos.mdx
@@ -54,4 +54,20 @@ Once complete follow the instructions on [Initializing FlutterFire](../overview.
 
 ## macOS Supported Versions
 
-FlutterFire supports a macOS deployment target of 10.12 or higher, in line with the requirements of the underlying [firebase-ios-sdk](https://firebase.google.com/docs/ios/setup).
+| Name                          | Deployment Target (minimum) |
+| ------------------------------| ----------------------------|
+| **firebase_core**             |            10.12            |
+| **cloud_firestore**           |            10.12            |
+| **firebase_analytics**        |            10.12            |
+| **firebase_app_check**        |            10.12            |
+| **firebase_auth**             |            10.12            |
+| **firebase_crashlytics**      |            10.12            |
+| **firebase_database**         |            10.12            |
+| **firebase_dynamic_links**    |            10.12            |
+| **firebase_in_app_messaging** |            10.12            |
+| **firebase_messaging**        |            10.12            |
+| **firebase_performance**      |            10.12            |
+| **firebase_remote_config**    |            10.12            |
+| **firebase_storage**          |            10.12            |
+
+Please see the underlying [firebase-ios-sdk](https://firebase.google.com/docs/ios/setup) for further details.

--- a/packages/firebase_analytics/firebase_analytics/ios/firebase_analytics.podspec
+++ b/packages/firebase_analytics/firebase_analytics/ios/firebase_analytics.podspec
@@ -29,19 +29,19 @@ Pod::Spec.new do |s|
   s.license          = { :file => '../LICENSE' }
   s.authors          = 'The Chromium Authors'
   s.source           = { :path => '.' }
-  
+
   s.source_files     = 'Classes/**/*.{h,m}'
   s.public_header_files = 'Classes/Public/*.h'
   s.private_header_files = 'Classes/Private/*.h'
 
-  s.ios.deployment_target = '10.0'
+  s.ios.deployment_target = '9.0'
   s.dependency 'Flutter'
 
   s.dependency 'firebase_core'
   s.dependency firebase_analytics, firebase_sdk_version
-  
+
   s.static_framework = true
-  s.pod_target_xcconfig = { 
+  s.pod_target_xcconfig = {
     'GCC_PREPROCESSOR_DEFINITIONS' => "LIBRARY_VERSION=\\@\\\"#{library_version}\\\" LIBRARY_NAME=\\@\\\"flutter-fire-analytics\\\"",
     'DEFINES_MODULE' => 'YES'
   }

--- a/packages/firebase_app_check/firebase_app_check/ios/firebase_app_check.podspec
+++ b/packages/firebase_app_check/firebase_app_check/ios/firebase_app_check.podspec
@@ -26,7 +26,7 @@ Pod::Spec.new do |s|
   s.source           = { :path => '.' }
   s.source_files     = 'Classes/**/*.{h,m}'
   s.public_header_files = 'Classes/*.h'
-  s.ios.deployment_target = '11.0'
+  s.ios.deployment_target = '9.0'
 
   # Flutter dependencies
   s.dependency 'Flutter'

--- a/packages/firebase_app_check/firebase_app_check/macos/firebase_app_check.podspec
+++ b/packages/firebase_app_check/firebase_app_check/macos/firebase_app_check.podspec
@@ -46,7 +46,7 @@ Pod::Spec.new do |s|
   s.source_files     = 'Classes/**/*.{h,m}'
   s.public_header_files = 'Classes/*.h'
 
-  s.platform = :osx, '10.15'
+  s.platform = :osx, '10.12'
 
   # Flutter dependencies
   s.dependency 'FlutterMacOS'

--- a/packages/firebase_core/firebase_core/ios/firebase_core.podspec
+++ b/packages/firebase_core/firebase_core/ios/firebase_core.podspec
@@ -26,15 +26,15 @@ Pod::Spec.new do |s|
   s.source           = { :path => '.' }
   s.source_files     = 'Classes/**/*'
   s.public_header_files = 'Classes/**/*.h'
-  
-  s.ios.deployment_target = '10.0'
-  
+
+  s.ios.deployment_target = '9.0'
+
   # Flutter dependencies
   s.dependency 'Flutter'
-  
+
   # Firebase dependencies
   s.dependency 'Firebase/CoreOnly', firebase_sdk_version
-   
+
   s.static_framework = true
   s.pod_target_xcconfig = {
     'GCC_PREPROCESSOR_DEFINITIONS' => "LIBRARY_VERSION=\\@\\\"#{library_version}\\\" LIBRARY_NAME=\\@\\\"flutter-fire-core\\\"",

--- a/packages/firebase_crashlytics/firebase_crashlytics/ios/firebase_crashlytics.podspec
+++ b/packages/firebase_crashlytics/firebase_crashlytics/ios/firebase_crashlytics.podspec
@@ -28,7 +28,7 @@ Pod::Spec.new do |s|
   s.source_files = 'Classes/**/*'
   s.public_header_files = 'Classes/**/*.h'
 
-  s.ios.deployment_target = '10.0'
+  s.ios.deployment_target = '9.0'
 
   s.dependency 'Flutter'
   s.dependency 'firebase_core'


### PR DESCRIPTION
## Description


Replacement PR for https://github.com/FirebaseExtended/flutterfire/pull/4626

Following deployment targets in the `podspec` files for each plugin within the [firebase-ios-sdk](https://github.com/firebase/firebase-ios-sdk).

Please note `dynamic_links`, `analytics`, `in_app_messaging` & `performance` did not have an `osx` deployment target within their `podspec` file. So it is assumed, like the other plugins, they target a minimum version of `10.12`.



## Related Issues

closes https://github.com/FirebaseExtended/flutterfire/issues/6204

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
