### PR TITLE
fix(messaging, ios): force token to refresh when calling `deleteToken`

### DIFF
--- a/packages/firebase_messaging/firebase_messaging/ios/Classes/FLTFirebaseMessagingPlugin.m
+++ b/packages/firebase_messaging/firebase_messaging/ios/Classes/FLTFirebaseMessagingPlugin.m
@@ -613,14 +613,15 @@ NSString *const kMessagingPresentationOptionsUserDefaults =
 
 - (void)messagingDeleteToken:(id)arguments
         withMethodCallResult:(FLTFirebaseMethodCallResult *)result {
-  FIRMessaging *messaging = [FIRMessaging messaging];
-  [messaging deleteTokenWithCompletion:^(NSError *_Nullable error) {
+  [[FIRInstallations installations] deleteWithCompletion:^(NSError *_Nullable error) {
     if (error != nil) {
       result.error(nil, nil, nil, error);
     } else {
       result.success(nil);
     }
   }];
+}];
+
 }
 
 #pragma mark - FLTFirebasePlugin

--- a/packages/firebase_messaging/firebase_messaging/ios/Classes/FLTFirebaseMessagingPlugin.m
+++ b/packages/firebase_messaging/firebase_messaging/ios/Classes/FLTFirebaseMessagingPlugin.m
@@ -620,8 +620,6 @@ NSString *const kMessagingPresentationOptionsUserDefaults =
       result.success(nil);
     }
   }];
-}];
-
 }
 
 #pragma mark - FLTFirebasePlugin


### PR DESCRIPTION
## Description

This will always refresh the fcm token, but it's unclear to me if this is the correct approach or not based on the documentation and changelog

I've opened up a ticket on firebase/firebase-ios-sdk#8491 for guidance from the iOS team.

I don't believe there are any side-effects of always deleting the installations id, but it would be good to get confirmation as this approach always will delete it when refreshing the fcm token.


## Related Issues

Fixes https://github.com/FirebaseExtended/flutterfire/issues/6766

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
