### PR TITLE
fix(firestore): allow querying on 'is not null' properties

### DIFF
--- a/packages/cloud_firestore/cloud_firestore/example/test_driver/query_e2e.dart
+++ b/packages/cloud_firestore/cloud_firestore/example/test_driver/query_e2e.dart
@@ -892,6 +892,53 @@ void runQueryTests() {
      */
 
     group('Query.where()', () {
+      test('returns documents when querying for properties that are not null',
+          () async {
+        CollectionReference<Map<String, dynamic>> collection =
+            await initializeTest('not-null');
+        await Future.wait([
+          collection.doc('doc1').set({
+            'foo': 'bar',
+          }),
+          collection.doc('doc2').set({
+            'foo': 'bar',
+          }),
+          collection.doc('doc3').set({
+            'foo': null,
+          }),
+        ]);
+
+        QuerySnapshot<Map<String, dynamic>> snapshot =
+            await collection.where('foo', isNull: false).get();
+
+        expect(snapshot.docs.length, equals(2));
+        expect(snapshot.docs[0].id, equals('doc1'));
+        expect(snapshot.docs[1].id, equals('doc2'));
+      });
+
+      test('returns documents when querying properties that are equal to null',
+          () async {
+        CollectionReference<Map<String, dynamic>> collection =
+            await initializeTest('not-null');
+        await Future.wait([
+          collection.doc('doc1').set({
+            'foo': 'bar',
+          }),
+          collection.doc('doc2').set({
+            'foo': 'bar',
+          }),
+          collection.doc('doc3').set({
+            'foo': null,
+          }),
+        ]);
+
+        QuerySnapshot<Map<String, dynamic>> snapshot =
+            await collection.where('foo', isNull: true).get();
+
+        expect(snapshot.docs.length, equals(1));
+        expect(snapshot.docs[0].id, equals('doc3'));
+      });
+
       test('returns with equal checks', () async {
         CollectionReference<Map<String, dynamic>> collection =
             await initializeTest('where-equal');

--- a/packages/cloud_firestore/cloud_firestore/lib/src/query.dart
+++ b/packages/cloud_firestore/cloud_firestore/lib/src/query.dart
@@ -645,11 +645,11 @@ class _JsonQuery implements Query<Map<String, dynamic>> {
     if (whereIn != null) addCondition(field, 'in', whereIn);
     if (whereNotIn != null) addCondition(field, 'not-in', whereNotIn);
     if (isNull != null) {
-      assert(
-          isNull,
-          'isNull can only be set to true. '
-          'Use isEqualTo to filter on non-null values.');
-      addCondition(field, '==', null);
+      if (isNull == true) {
+        addCondition(field, '==', null);
+      } else {
+        addCondition(field, '!=', null);
+      }
     }
 
     dynamic hasInequality;
@@ -692,11 +692,6 @@ class _JsonQuery implements Query<Map<String, dynamic>> {
           "You cannot use FieldPath.documentId field whilst using a '!=' filter on a different field.",
         );
         hasDocumentIdField = true;
-      }
-
-      if (value == null) {
-        assert(operator == '==',
-            'You can only perform equals comparisons on null.');
       }
 
       if (operator == 'in' ||


### PR DESCRIPTION
## Description

Firestore allows `where()` queries on properties which are null or not null.
 
## Related Issues

closes https://github.com/FirebaseExtended/flutterfire/issues/6712
## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
