### PR TITLE
fix(firestore): transactionHandler was losing ref to self in blocks

### DIFF
--- a/packages/cloud_firestore/cloud_firestore/ios/Classes/FLTTransactionStreamHandler.m
+++ b/packages/cloud_firestore/cloud_firestore/ios/Classes/FLTTransactionStreamHandler.m
@@ -12,7 +12,7 @@
 @property(nonatomic, copy, nonnull) void (^started)(FIRTransaction *);
 @property(nonatomic, copy, nonnull) void (^ended)(void);
 @property(strong) dispatch_semaphore_t semaphore;
-@property NSDictionary * response;
+@property NSDictionary *response;
 @end
 
 @implementation FLTTransactionStreamHandler {
@@ -37,7 +37,7 @@
                                        eventSink:(nonnull FlutterEventSink)events {
   FIRFirestore *firestore = arguments[@"firestore"];
   NSNumber *transactionTimeout = arguments[@"timeout"];
-  __weak FLTTransactionStreamHandler * weakSelf = self;
+  __weak FLTTransactionStreamHandler *weakSelf = self;
 
   id transactionRunBlock = ^id(FIRTransaction *transaction, NSError **pError) {
     weakSelf.started(transaction);

--- a/packages/cloud_firestore/cloud_firestore/ios/Classes/FLTTransactionStreamHandler.m
+++ b/packages/cloud_firestore/cloud_firestore/ios/Classes/FLTTransactionStreamHandler.m
@@ -41,7 +41,7 @@
 
   id transactionRunBlock = ^id(FIRTransaction *transaction, NSError **pError) {
     FLTTransactionStreamHandler *strongSelf = weakSelf;
-    
+
     strongSelf.started(transaction);
 
     dispatch_async(dispatch_get_main_queue(), ^{

--- a/packages/cloud_firestore/cloud_firestore/ios/Classes/FLTTransactionStreamHandler.m
+++ b/packages/cloud_firestore/cloud_firestore/ios/Classes/FLTTransactionStreamHandler.m
@@ -11,12 +11,12 @@
 @interface FLTTransactionStreamHandler ()
 @property(nonatomic, copy, nonnull) void (^started)(FIRTransaction *);
 @property(nonatomic, copy, nonnull) void (^ended)(void);
+@property(strong) dispatch_semaphore_t semaphore;
+@property NSDictionary * response;
 @end
 
 @implementation FLTTransactionStreamHandler {
   NSString *_transactionId;
-  dispatch_semaphore_t _semaphore;
-  NSDictionary *_response;
 }
 
 - (instancetype)initWithId:(NSString *)transactionId
@@ -27,8 +27,8 @@
     _transactionId = transactionId;
     self.started = startedListener;
     self.ended = endedListener;
-    _semaphore = dispatch_semaphore_create(0);
-    _response = [NSMutableDictionary dictionary];
+    self.semaphore = dispatch_semaphore_create(0);
+    self.response = [NSMutableDictionary dictionary];
   }
   return self;
 }
@@ -37,16 +37,17 @@
                                        eventSink:(nonnull FlutterEventSink)events {
   FIRFirestore *firestore = arguments[@"firestore"];
   NSNumber *transactionTimeout = arguments[@"timeout"];
+  __weak FLTTransactionStreamHandler * weakSelf = self;
 
   id transactionRunBlock = ^id(FIRTransaction *transaction, NSError **pError) {
-    self.started(transaction);
+    weakSelf.started(transaction);
 
     dispatch_async(dispatch_get_main_queue(), ^{
       events(@{@"appName" : [FLTFirebasePlugin firebaseAppNameFromIosName:firestore.app.name]});
     });
 
     long timedOut = dispatch_semaphore_wait(
-        self->_semaphore,
+        weakSelf.semaphore,
         dispatch_time(DISPATCH_TIME_NOW, [transactionTimeout integerValue] * NSEC_PER_MSEC));
 
     if (timedOut) {
@@ -66,7 +67,7 @@
       });
     }
 
-    NSDictionary *response = self->_response;
+    NSDictionary *response = weakSelf.response;
 
     if (response.count == 0) {
       return nil;
@@ -127,7 +128,7 @@
       events(FlutterEndOfEventStream);
     });
 
-    self.ended();
+    weakSelf.ended();
   };
 
   [firestore runTransactionWithBlock:transactionRunBlock completion:transactionCompleteBlock];
@@ -136,15 +137,15 @@
 }
 
 - (FlutterError *_Nullable)onCancelWithArguments:(id _Nullable)arguments {
-  dispatch_semaphore_signal(_semaphore);
+  dispatch_semaphore_signal(self.semaphore);
 
   return nil;
 }
 
 - (void)receiveTransactionResponse:(NSDictionary *)response {
-  _response = response;
+  self.response = response;
 
-  dispatch_semaphore_signal(_semaphore);
+  dispatch_semaphore_signal(self.semaphore);
 }
 
 @end


### PR DESCRIPTION
## Description

We believe this ought to resolve the bug whereby the transaction handler was losing a reference to itself when executing code in callback blocks. For further context, this is a solution we've [implemented on RNFB](https://github.com/invertase/react-native-firebase/blob/master/packages/firestore/ios/RNFBFirestore/RNFBFirestoreCollectionModule.m#L88).

## Related Issues

closes https://github.com/FirebaseExtended/flutterfire/issues/6722

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
