### PR TITLE
fix(auth): precise error message is propagated

### DIFF
--- a/packages/firebase_auth/firebase_auth/ios/Classes/FLTFirebaseAuthPlugin.m
+++ b/packages/firebase_auth/firebase_auth/ios/Classes/FLTFirebaseAuthPlugin.m
@@ -432,8 +432,7 @@ NSString *const kErrMsgInvalidCredential =
 
                       if (firebaseDictionary != nil && firebaseDictionary[@"message"] != nil) {
                         // error from firebase-ios-sdk is buried in underlying error.
-                        NSString *code = [NSString stringWithFormat:@"%li", underlyingError.code];
-                        result.error(code, firebaseDictionary[@"message"], nil, nil);
+                        result.error(nil, firebaseDictionary[@"message"], nil, nil);
                       } else {
                         result.error(nil, nil, nil, error);
                       }

--- a/packages/firebase_auth/firebase_auth/ios/Classes/FLTFirebaseAuthPlugin.m
+++ b/packages/firebase_auth/firebase_auth/ios/Classes/FLTFirebaseAuthPlugin.m
@@ -424,7 +424,19 @@ NSString *const kErrMsgInvalidCredential =
   [auth signInWithCredential:credential
                   completion:^(FIRAuthDataResult *authResult, NSError *error) {
                     if (error != nil) {
-                      result.error(nil, nil, nil, error);
+                      NSDictionary *userInfo = [error userInfo];
+                      NSError *underlyingError = [userInfo objectForKey:NSUnderlyingErrorKey];
+
+                      NSDictionary *firebaseDictionary =
+                          underlyingError.userInfo[@"FIRAuthErrorUserInfoDeserializedResponseKey"];
+
+                      if (firebaseDictionary != nil && firebaseDictionary[@"message"] != nil) {
+                        // error from firebase-ios-sdk is buried in underlying error.
+                        NSString *code = [NSString stringWithFormat:@"%li", underlyingError.code];
+                        result.error(code, firebaseDictionary[@"message"], nil, nil);
+                      } else {
+                        result.error(nil, nil, nil, error);
+                      }
                     } else {
                       result.success(authResult);
                     }


### PR DESCRIPTION
## Description

Error from `firebase-ios-sdk` had an underlying error with a more precise description of the issue. 

Using the auth example app, the following errors were produced trying to login to Twitter, Github & Facebook using the auth emulator:

![Screenshot 2021-08-11 at 12 49 13](https://user-images.githubusercontent.com/16018629/129018202-9a817575-2037-4925-a36e-58b409e72afc.png)


## Related Issues

closes https://github.com/FirebaseExtended/flutterfire/issues/6775

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
