### PR TITLE
fix(messaging): Fix link in documentation

### DIFF
--- a/docs/messaging/usage.mdx
+++ b/docs/messaging/usage.mdx
@@ -384,7 +384,7 @@ Topics allow you to simplify FCM server integration as you do not need to keep a
 - The frequency of new subscriptions is rate-limited per project. If you send too many subscription requests in a short period of time, FCM servers will respond with a 429 RESOURCE_EXHAUSTED ("quota exceeded") response. Retry with an exponential backoff.
 - A server integration can send a single message to multiple topics at once. This however is limited to 5 topics.
 
-To learn more about how to send messages to devices subscribed to topics, view the [Send messages to topics](server-integration#send-messages-to-topics) documentation.
+To learn more about how to send messages to devices subscribed to topics, view the [Send messages to topics](../server-integration.mdx#send-messages-to-topics) documentation.
 
 ### Subscribing to topics
 

--- a/docs/messaging/usage.mdx
+++ b/docs/messaging/usage.mdx
@@ -384,7 +384,7 @@ Topics allow you to simplify FCM server integration as you do not need to keep a
 - The frequency of new subscriptions is rate-limited per project. If you send too many subscription requests in a short period of time, FCM servers will respond with a 429 RESOURCE_EXHAUSTED ("quota exceeded") response. Retry with an exponential backoff.
 - A server integration can send a single message to multiple topics at once. This however is limited to 5 topics.
 
-To learn more about how to send messages to devices subscribed to topics, view the [Send messages to topics](../server-integration.mdx#send-messages-to-topics) documentation.
+To learn more about how to send messages to devices subscribed to topics, view the [Send messages to topics](server-integration.mdx#send-messages-to-topics) documentation.
 
 ### Subscribing to topics
 


### PR DESCRIPTION
## Description

The existing link leads to:
https://firebase.flutter.dev/docs/messaging/usage/server-integration#send-messages-to-topics
(which results in the Page Not Found page)

The correct link is:
https://firebase.flutter.dev/docs/messaging/server-integration#send-messages-to-topics
(without /usage)

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
