### PR TITLE
feat(auth): Add support for `secret` on `OAuthCredential` on web

### DIFF
--- a/packages/firebase_auth/firebase_auth_platform_interface/lib/src/providers/oauth.dart
+++ b/packages/firebase_auth/firebase_auth_platform_interface/lib/src/providers/oauth.dart
@@ -49,6 +49,7 @@ class OAuthProvider extends AuthProvider {
   /// Create a new [OAuthCredential] from a provided [accessToken];
   OAuthCredential credential({
     String? accessToken,
+    String? accessSecret,
     String? idToken,
     String? rawNonce,
   }) {
@@ -56,6 +57,7 @@ class OAuthProvider extends AuthProvider {
       providerId: providerId,
       signInMethod: 'oauth',
       accessToken: accessToken,
+      secret: accessSecret,
       idToken: idToken,
       rawNonce: rawNonce,
     );

--- a/packages/firebase_auth/firebase_auth_platform_interface/lib/src/providers/oauth.dart
+++ b/packages/firebase_auth/firebase_auth_platform_interface/lib/src/providers/oauth.dart
@@ -49,7 +49,7 @@ class OAuthProvider extends AuthProvider {
   /// Create a new [OAuthCredential] from a provided [accessToken];
   OAuthCredential credential({
     String? accessToken,
-    String? accessSecret,
+    String? secret,
     String? idToken,
     String? rawNonce,
   }) {
@@ -57,7 +57,7 @@ class OAuthProvider extends AuthProvider {
       providerId: providerId,
       signInMethod: 'oauth',
       accessToken: accessToken,
-      secret: accessSecret,
+      secret: secret,
       idToken: idToken,
       rawNonce: rawNonce,
     );

--- a/packages/firebase_auth/firebase_auth_platform_interface/test/providers_tests/oauth_test.dart
+++ b/packages/firebase_auth/firebase_auth_platform_interface/test/providers_tests/oauth_test.dart
@@ -58,13 +58,13 @@ void main() {
 
     group('credential()', () {
       const String kMockAccessToken = 'test-token';
-      const String kMockAccessSecret = 'test-secret';
+      const String kMockSecret = 'test-secret';
       const String kMockIdToken = 'id';
       const String kMockRawNonce = 'test-raw-nonce';
       test('creates a new [OAuthCredential]', () {
         final result = oAuthProvider.credential(
             accessToken: kMockAccessToken,
-            accessSecret: kMockAccessSecret,
+            secret: kMockSecret,
             idToken: kMockIdToken,
             rawNonce: kMockRawNonce);
 
@@ -73,7 +73,7 @@ void main() {
         expect(result.idToken, equals(kMockIdToken));
         expect(result.rawNonce, equals(kMockRawNonce));
         expect(result.accessToken, equals(kMockAccessToken));
-        expect(result.secret, equals(kMockAccessSecret));
+        expect(result.secret, equals(kMockSecret));
         expect(result.providerId, equals(kMockProviderId));
         expect(result.signInMethod, equals('oauth'));
       });

--- a/packages/firebase_auth/firebase_auth_platform_interface/test/providers_tests/oauth_test.dart
+++ b/packages/firebase_auth/firebase_auth_platform_interface/test/providers_tests/oauth_test.dart
@@ -58,11 +58,13 @@ void main() {
 
     group('credential()', () {
       const String kMockAccessToken = 'test-token';
+      const String kMockAccessSecret = 'test-secret';
       const String kMockIdToken = 'id';
       const String kMockRawNonce = 'test-raw-nonce';
       test('creates a new [OAuthCredential]', () {
         final result = oAuthProvider.credential(
             accessToken: kMockAccessToken,
+            accessSecret: kMockAccessSecret,
             idToken: kMockIdToken,
             rawNonce: kMockRawNonce);
 
@@ -71,6 +73,7 @@ void main() {
         expect(result.idToken, equals(kMockIdToken));
         expect(result.rawNonce, equals(kMockRawNonce));
         expect(result.accessToken, equals(kMockAccessToken));
+        expect(result.secret, equals(kMockAccessSecret));
         expect(result.providerId, equals(kMockProviderId));
         expect(result.signInMethod, equals('oauth'));
       });

--- a/packages/firebase_auth/firebase_auth_web/lib/src/utils/web_utils.dart
+++ b/packages/firebase_auth/firebase_auth_web/lib/src/utils/web_utils.dart
@@ -204,6 +204,7 @@ AuthCredential? convertWebOAuthCredential(
 
   return OAuthProvider(oAuthCredential.providerId).credential(
     accessToken: oAuthCredential.accessToken,
+    accessSecret: oAuthCredential.secret,
     idToken: oAuthCredential.idToken,
   );
 }

--- a/packages/firebase_auth/firebase_auth_web/lib/src/utils/web_utils.dart
+++ b/packages/firebase_auth/firebase_auth_web/lib/src/utils/web_utils.dart
@@ -204,7 +204,7 @@ AuthCredential? convertWebOAuthCredential(
 
   return OAuthProvider(oAuthCredential.providerId).credential(
     accessToken: oAuthCredential.accessToken,
-    accessSecret: oAuthCredential.secret,
+    secret: oAuthCredential.secret,
     idToken: oAuthCredential.idToken,
   );
 }


### PR DESCRIPTION
## Description

When using `signInWithPopup` as auth method for Twitter login, the received Firebase JS object contains more data than mapped to the `OAuthCredential` object. One of them is the `accessSecret` field which is crucial when working with the Twitter API to perform requests on behalf of other users (with their consent). This field is `null` when received via the `UserCredentials` object and the only available token is the `accessToken`. 

This PR is mapping the `accessSecret` field from the JS Auth object (`oAuthCredential`) to the `OAuthCredential` object.

## Related Issues
No issue reported from me, neither found existing ones.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.
