### PR TITLE
feat: update Firebase Android SDK to `28.3.1` & Firebase iOS SDK to `8.6.0`

### DIFF
--- a/docs/overview.mdx
+++ b/docs/overview.mdx
@@ -239,14 +239,14 @@ Once initialized, you're ready to get started using FlutterFire!
 
 Currently the Firestore iOS SDK depends on some 500k lines of mostly C++ code which can take upwards of 5 minutes to build in XCode. To reduce build times significantly, you can use a pre-compiled version by adding 1 line to your `ios/Podfile` inside your Flutter project;
 
-`pod 'FirebaseFirestore', :git => 'https://github.com/invertase/firestore-ios-sdk-frameworks.git', :tag => '8.3.0'`
+`pod 'FirebaseFirestore', :git => 'https://github.com/invertase/firestore-ios-sdk-frameworks.git', :tag => '8.6.0'`
 
 Add this line inside your target 'Runner' do block in your Podfile, e.g.:
 
 ```
 # ...
 target 'Runner' do
-  pod 'FirebaseFirestore', :git => 'https://github.com/invertase/firestore-ios-sdk-frameworks.git', :tag => '8.5.0'
+  pod 'FirebaseFirestore', :git => 'https://github.com/invertase/firestore-ios-sdk-frameworks.git', :tag => '8.6.0'
 # ...
 end
 ```
@@ -270,7 +270,7 @@ In the `/android/app/build.gradle` file, you can provide your own versions using
 ```groovy
 rootProject.ext {
   set('FlutterFire', [
-    FirebaseSDKVersion: '25.12.0'
+    FirebaseSDKVersion: '28.3.1'
   ])
 }
 ```
@@ -281,7 +281,7 @@ Open your `/ios/Podfile` or `/macos/Podfile` file and add any of the globals bel
 
 ```ruby
 # Override Firebase SDK Version
-$FirebaseSDKVersion = '8.5.0'
+$FirebaseSDKVersion = '8.6.0'
 ```
 
 ## Next Steps

--- a/packages/firebase_core/firebase_core/android/gradle.properties
+++ b/packages/firebase_core/firebase_core/android/gradle.properties
@@ -1,2 +1,2 @@
 # https://firebase.google.com/support/release-notes/android
-FirebaseSDKVersion=28.1.0
+FirebaseSDKVersion=28.3.1

--- a/packages/firebase_core/firebase_core/ios/firebase_sdk_version.rb
+++ b/packages/firebase_core/firebase_core/ios/firebase_sdk_version.rb
@@ -1,4 +1,4 @@
 # https://firebase.google.com/support/release-notes/ios
 def firebase_sdk_version!()
-  '8.5.0'
+  '8.6.0'
 end


### PR DESCRIPTION
## Description
Updates the Android Bill of Materials to 28.3.1 and the iOS Firebase SDK to 8.6.0.

The version changes between 28.1.0 and 28.3.1 can be seen here:
https://firebase.google.com/support/release-notes/android

We've had problems with Firestore not properly detecting the network status which might have been fixed in Firestore 23.0.2 (23.0.3 is included in the BoM).

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
