### PR TITLE
docs(messaging): wrong import

### DIFF
--- a/docs/messaging/overview.mdx
+++ b/docs/messaging/overview.mdx
@@ -42,7 +42,7 @@ For legacy package imports, place the following ignore comment to hide Dart anal
 
 ```dart
 // ignore: import_of_legacy_library_into_null_safe
-import 'package:firebase_analytics/firebase_analytics.dart';
+import 'package:firebase_messaging/firebase_messaging.dart';
 ```
 
 </TabItem>


### PR DESCRIPTION
I can only assume that a wrong import was copy and pasted.
On the [next page](https://firebase.flutter.dev/docs/messaging/usage/) it refers to 
`import 'package:firebase_messaging/firebase_messaging.dart';`
again.