### PR TITLE
fix(dynamic-links, android): null-check intent before calling getDynamicLink

### DIFF
--- a/packages/firebase_dynamic_links/android/src/main/java/io/flutter/plugins/firebasedynamiclinks/FirebaseDynamicLinksPlugin.java
+++ b/packages/firebase_dynamic_links/android/src/main/java/io/flutter/plugins/firebasedynamiclinks/FirebaseDynamicLinksPlugin.java
@@ -209,8 +209,8 @@ public class FirebaseDynamicLinksPlugin
   }
 
   private void handleGetInitialDynamicLink(final Result result) {
-    // If there's no activity, then there's no initial dynamic link.
-    if (activity == null) {
+    // If there's no activity or initial Intent, then there's no initial dynamic link.
+    if (activity == null || activity.getIntent() == null) {
       result.success(null);
       return;
     }


### PR DESCRIPTION

## Description

firebase-android-sdk requires a `@NonNull` Intent argument to the `getDynamicLink(Intent)`
call, despite the documentation indicating otherwise

## Related Issues

Related https://github.com/firebase/firebase-android-sdk/issues/2336
Related https://github.com/invertase/react-native-firebase/pull/5662 - with all credit to @daltonpurnell - thanks Dalton!

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
