### PR TITLE
fix(firebase_analytics): Fix incorrect type name in error message

### DIFF
--- a/packages/firebase_analytics/firebase_analytics/android/src/main/java/io/flutter/plugins/firebaseanalytics/FirebaseAnalyticsPlugin.java
+++ b/packages/firebase_analytics/firebase_analytics/android/src/main/java/io/flutter/plugins/firebaseanalytics/FirebaseAnalyticsPlugin.java
@@ -66,7 +66,7 @@ public class FirebaseAnalyticsPlugin implements MethodCallHandler, FlutterPlugin
           } else {
             throw new IllegalArgumentException(
                 "Unsupported value type: "
-                    + value.getClass().getCanonicalName()
+                    + item.getClass().getCanonicalName()
                     + " in list at key "
                     + key);
           }


### PR DESCRIPTION
## Description

- Currently, pass `List` instance with unsupported type element (such as `String`) to `firebase_analytics` plugin's `logEvent` function will throw a Exception. But error message is incorrect. It always shows `value` 's type.
- Fix error message to show list's `item` type.

## Related Issues

None

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
