### PR TITLE
fix(messaging): was creating a new instance each time

### DIFF
--- a/packages/firebase_messaging/firebase_messaging/lib/src/messaging.dart
+++ b/packages/firebase_messaging/firebase_messaging/lib/src/messaging.dart
@@ -35,7 +35,7 @@ class FirebaseMessaging extends FirebasePluginPlatform {
 
   //  Messaging does not yet support multiple Firebase Apps. Default app only.
   /// Returns an instance using a specified [FirebaseApp].
-   factory FirebaseMessaging._instanceFor({required FirebaseApp app}) {
+  factory FirebaseMessaging._instanceFor({required FirebaseApp app}) {
     return _firebaseMessagingInstances.putIfAbsent(app.name, () {
       return FirebaseMessaging._(app: app);
     });

--- a/packages/firebase_messaging/firebase_messaging/lib/src/messaging.dart
+++ b/packages/firebase_messaging/firebase_messaging/lib/src/messaging.dart
@@ -14,6 +14,8 @@ class FirebaseMessaging extends FirebasePluginPlatform {
   // instance with the default app before a user specifies an app.
   FirebaseMessagingPlatform? _delegatePackingProperty;
 
+  static Map<String, FirebaseMessaging> _firebaseMessagingInstances = {};
+
   FirebaseMessagingPlatform get _delegate {
     return _delegatePackingProperty ??= FirebaseMessagingPlatform.instanceFor(
         app: app, pluginConstants: pluginConstants);
@@ -27,31 +29,17 @@ class FirebaseMessaging extends FirebasePluginPlatform {
 
   /// Returns an instance using the default [FirebaseApp].
   static FirebaseMessaging get instance {
-    return FirebaseMessaging._(app: Firebase.app());
+    FirebaseApp defaultAppInstance = Firebase.app();
+    return FirebaseMessaging._instanceFor(app: defaultAppInstance);
   }
 
   //  Messaging does not yet support multiple Firebase Apps. Default app only.
-  /// Returns an instance using a specified [FirebaseApp]
-  ///
-  /// If [app] is not provided, the default Firebase app will be used.
-  // static FirebaseMessaging instanceFor({
-  //   FirebaseApp app,
-  // }) {
-  //   app ??= Firebase.app();
-  //   assert(app != null);
-  //
-  //   String key = '${app.name}';
-  //   if (_cachedInstances.containsKey(key)) {
-  //     return _cachedInstances[key];
-  //   }
-  //
-  //   FirebaseMessaging newInstance = FirebaseMessaging._(app: app);
-  //   _cachedInstances[key] = newInstance;
-  //
-  //   return newInstance;
-  // }
-  //
-  // static final Map<String, FirebaseMessaging> _cachedInstances = {};
+  /// Returns an instance using a specified [FirebaseApp].
+   factory FirebaseMessaging._instanceFor({required FirebaseApp app}) {
+    return _firebaseMessagingInstances.putIfAbsent(app.name, () {
+      return FirebaseMessaging._(app: app);
+    });
+  }
 
   /// Returns a Stream that is called when an incoming FCM payload is received whilst
   /// the Flutter instance is in the foreground.


### PR DESCRIPTION
## Description

Fixes a bug where a new `FirebaseMessaging` instance was created each time `FirebaseMessaging.instance` was called which was invocating a new `StreamController` each time.

I've also made `instanceFor` factory private so that the default app is the only `FirebaseMessaging` one that can be instantiated.

## Related Issues

fixes https://github.com/FirebaseExtended/flutterfire/issues/5389

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
