### PR TITLE
chore(crashlytics): fix example to include "ensureInitialized" within runZonedGuarded

### DIFF
--- a/packages/firebase_crashlytics/firebase_crashlytics/example/lib/main.dart
+++ b/packages/firebase_crashlytics/firebase_crashlytics/example/lib/main.dart
@@ -20,12 +20,14 @@ const _kShouldTestAsyncErrorOnInit = false;
 // Toggle this for testing Crashlytics in your app locally.
 const _kTestingCrashlytics = true;
 //ignore: avoid_void_async
-void main() async {
-  WidgetsFlutterBinding.ensureInitialized();
-  await Firebase.initializeApp();
-  runZonedGuarded(() {
+void main() {
+  runZonedGuarded(() async {
+    WidgetsFlutterBinding.ensureInitialized();
+    await Firebase.initializeApp();
     runApp(MyApp());
-  }, FirebaseCrashlytics.instance.recordError);
+  }, (error, stackTrace) {
+    FirebaseCrashlytics.instance.recordError(error, stackTrace);
+  });
 }
 
 class MyApp extends StatefulWidget {

--- a/packages/firebase_crashlytics/firebase_crashlytics/example/lib/main.dart
+++ b/packages/firebase_crashlytics/firebase_crashlytics/example/lib/main.dart
@@ -20,10 +20,10 @@ const _kShouldTestAsyncErrorOnInit = false;
 // Toggle this for testing Crashlytics in your app locally.
 const _kTestingCrashlytics = true;
 //ignore: avoid_void_async
-void main() {
-  runZonedGuarded(() async {
-    WidgetsFlutterBinding.ensureInitialized();
-    await Firebase.initializeApp();
+void main() async {
+  WidgetsFlutterBinding.ensureInitialized();
+  await Firebase.initializeApp();
+  runZonedGuarded(() {
     runApp(MyApp());
   }, FirebaseCrashlytics.instance.recordError);
 }

--- a/packages/firebase_crashlytics/firebase_crashlytics/example/lib/main.dart
+++ b/packages/firebase_crashlytics/firebase_crashlytics/example/lib/main.dart
@@ -24,6 +24,7 @@ void main() {
   runZonedGuarded(() async {
     WidgetsFlutterBinding.ensureInitialized();
     await Firebase.initializeApp();
+    FlutterError.onError = FirebaseCrashlytics.instance.recordFlutterError;
     runApp(MyApp());
   }, (error, stackTrace) {
     FirebaseCrashlytics.instance.recordError(error, stackTrace);


### PR DESCRIPTION
## Description

Ensure `WidgetsFlutterBinding.ensureInitialized();` is called within `runZonedGuard`.

## Related Issues

fixes https://github.com/FirebaseExtended/flutterfire/issues/6964

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
