### PR TITLE
docs(auth): bump plugins versions to null-safe

### DIFF
--- a/docs/auth/social.mdx
+++ b/docs/auth/social.mdx
@@ -226,8 +226,8 @@ Install the [`sign_in_with_apple`](https://pub.dev/packages/sign_in_with_apple) 
 
 ```yaml title="pubspec.yaml"
 dependencies:
-  sign_in_with_apple: ^2.5.2
-  crypto: ^2.1.5
+  sign_in_with_apple: ^3.0.0
+  crypto: ^3.0.1
 ```
 
 ```dart


### PR DESCRIPTION
## Description

Docs suggest outdated versions of plugins

@Salakar @Ehesp could we make sure these are kept up-to-date automatically?

## Related Issues

None

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
