### PR TITLE
chore(firebase_messaging): migrate example app to null-safety

### DIFF
--- a/packages/firebase_messaging/firebase_messaging/example/lib/main.dart
+++ b/packages/firebase_messaging/firebase_messaging/example/lib/main.dart
@@ -3,8 +3,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-// @dart=2.9
-
 import 'dart:async';
 import 'dart:convert';
 
@@ -32,10 +30,10 @@ Future<void> _firebaseMessagingBackgroundHandler(RemoteMessage message) async {
 }
 
 /// Create a [AndroidNotificationChannel] for heads up notifications
-AndroidNotificationChannel channel;
+late AndroidNotificationChannel channel;
 
 /// Initialize the [FlutterLocalNotificationsPlugin] package.
-FlutterLocalNotificationsPlugin flutterLocalNotificationsPlugin;
+late FlutterLocalNotificationsPlugin flutterLocalNotificationsPlugin;
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
@@ -95,7 +93,7 @@ class MessagingExampleApp extends StatelessWidget {
 int _messageCount = 0;
 
 /// The API endpoint here accepts a raw FCM payload for demonstration purposes.
-String constructFCMPayload(String token) {
+String constructFCMPayload(String? token) {
   _messageCount++;
   return jsonEncode({
     'token': token,
@@ -117,14 +115,14 @@ class Application extends StatefulWidget {
 }
 
 class _Application extends State<Application> {
-  String _token;
+  String? _token;
 
   @override
   void initState() {
     super.initState();
     FirebaseMessaging.instance
         .getInitialMessage()
-        .then((RemoteMessage message) {
+        .then((RemoteMessage? message) {
       if (message != null) {
         Navigator.pushNamed(context, '/message',
             arguments: MessageArguments(message, true));
@@ -132,8 +130,8 @@ class _Application extends State<Application> {
     });
 
     FirebaseMessaging.onMessage.listen((RemoteMessage message) {
-      RemoteNotification notification = message.notification;
-      AndroidNotification android = message.notification?.android;
+      RemoteNotification? notification = message.notification;
+      AndroidNotification? android = message.notification?.android;
       if (notification != null && android != null && !kIsWeb) {
         flutterLocalNotificationsPlugin.show(
             notification.hashCode,
@@ -204,7 +202,7 @@ class _Application extends State<Application> {
           if (defaultTargetPlatform == TargetPlatform.iOS ||
               defaultTargetPlatform == TargetPlatform.macOS) {
             print('FlutterFire Messaging Example: Getting APNs token...');
-            String token = await FirebaseMessaging.instance.getAPNSToken();
+            String? token = await FirebaseMessaging.instance.getAPNSToken();
             print('FlutterFire Messaging Example: Got APNs token: $token');
           } else {
             print(

--- a/packages/firebase_messaging/firebase_messaging/example/lib/message.dart
+++ b/packages/firebase_messaging/firebase_messaging/example/lib/message.dart
@@ -21,16 +21,20 @@ class MessageView extends StatelessWidget {
   Widget row(String title, String? value) {
     return Padding(
       padding: const EdgeInsets.only(left: 8, right: 8, top: 8),
-      child: Row(children: [
-        Text('$title: '),
-        Text(value ?? 'N/A'),
-      ]),
+      child: Row(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text('$title: '),
+          Expanded(child: Text(value ?? 'N/A')),
+        ],
+      ),
     );
   }
 
   @override
   Widget build(BuildContext context) {
-    final MessageArguments args = ModalRoute.of(context)!.settings.arguments! as MessageArguments;
+    final MessageArguments args =
+        ModalRoute.of(context)!.settings.arguments! as MessageArguments;
     RemoteMessage message = args.message;
     RemoteNotification? notification = message.notification;
 
@@ -41,107 +45,114 @@ class MessageView extends StatelessWidget {
       body: SingleChildScrollView(
           child: Padding(
         padding: const EdgeInsets.all(8),
-        child: Column(children: [
-          row('Triggered application open', args.openedApplication.toString()),
-          row('Message ID', message.messageId),
-          row('Sender ID', message.senderId),
-          row('Category', message.category),
-          row('Collapse Key', message.collapseKey),
-          row('Content Available', message.contentAvailable.toString()),
-          row('Data', message.data.toString()),
-          row('From', message.from),
-          row('Message ID', message.messageId),
-          row('Sent Time', message.sentTime?.toString()),
-          row('Thread ID', message.threadId),
-          row('Time to Live (TTL)', message.ttl?.toString()),
-          if (notification != null) ...[
-            Padding(
-              padding: const EdgeInsets.only(top: 16),
-              child: Column(children: [
-                const Text(
-                  'Remote Notification',
-                  style: TextStyle(fontSize: 18),
+        child: Column(
+          children: [
+            row('Triggered application open',
+                args.openedApplication.toString()),
+            row('Message ID', message.messageId),
+            row('Sender ID', message.senderId),
+            row('Category', message.category),
+            row('Collapse Key', message.collapseKey),
+            row('Content Available', message.contentAvailable.toString()),
+            row('Data', message.data.toString()),
+            row('From', message.from),
+            row('Message ID', message.messageId),
+            row('Sent Time', message.sentTime?.toString()),
+            row('Thread ID', message.threadId),
+            row('Time to Live (TTL)', message.ttl?.toString()),
+            if (notification != null) ...[
+              Padding(
+                padding: const EdgeInsets.only(top: 16),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    const Text(
+                      'Remote Notification',
+                      style: TextStyle(fontSize: 18),
+                    ),
+                    row(
+                      'Title',
+                      notification.title,
+                    ),
+                    row(
+                      'Body',
+                      notification.body,
+                    ),
+                    if (notification.android != null) ...[
+                      const SizedBox(height: 16),
+                      const Text(
+                        'Android Properties',
+                        style: TextStyle(fontSize: 18),
+                      ),
+                      row(
+                        'Channel ID',
+                        notification.android!.channelId,
+                      ),
+                      row(
+                        'Click Action',
+                        notification.android!.clickAction,
+                      ),
+                      row(
+                        'Color',
+                        notification.android!.color,
+                      ),
+                      row(
+                        'Count',
+                        notification.android!.count?.toString(),
+                      ),
+                      row(
+                        'Image URL',
+                        notification.android!.imageUrl,
+                      ),
+                      row(
+                        'Link',
+                        notification.android!.link,
+                      ),
+                      row(
+                        'Priority',
+                        notification.android!.priority.toString(),
+                      ),
+                      row(
+                        'Small Icon',
+                        notification.android!.smallIcon,
+                      ),
+                      row(
+                        'Sound',
+                        notification.android!.sound,
+                      ),
+                      row(
+                        'Ticker',
+                        notification.android!.ticker,
+                      ),
+                      row(
+                        'Visibility',
+                        notification.android!.visibility.toString(),
+                      ),
+                    ],
+                    if (notification.apple != null) ...[
+                      const Text(
+                        'Apple Properties',
+                        style: TextStyle(fontSize: 18),
+                      ),
+                      row(
+                        'Subtitle',
+                        notification.apple!.subtitle,
+                      ),
+                      row(
+                        'Badge',
+                        notification.apple!.badge,
+                      ),
+                      row(
+                        'Sound',
+                        notification.apple!.sound?.name,
+                      ),
+                    ]
+                  ],
                 ),
-                row(
-                  'Title',
-                  notification.title,
-                ),
-                row(
-                  'Body',
-                  notification.body,
-                ),
-                if (notification.android != null) ...[
-                  const Text(
-                    'Android Properties',
-                    style: TextStyle(fontSize: 18),
-                  ),
-                  row(
-                    'Channel ID',
-                    notification.android!.channelId,
-                  ),
-                  row(
-                    'Click Action',
-                    notification.android!.clickAction,
-                  ),
-                  row(
-                    'Color',
-                    notification.android!.color,
-                  ),
-                  row(
-                    'Count',
-                    notification.android!.count?.toString(),
-                  ),
-                  row(
-                    'Image URL',
-                    notification.android!.imageUrl,
-                  ),
-                  row(
-                    'Link',
-                    notification.android!.link,
-                  ),
-                  row(
-                    'Priority',
-                    notification.android!.priority.toString(),
-                  ),
-                  row(
-                    'Small Icon',
-                    notification.android!.smallIcon,
-                  ),
-                  row(
-                    'Sound',
-                    notification.android!.sound,
-                  ),
-                  row(
-                    'Ticker',
-                    notification.android!.ticker,
-                  ),
-                  row(
-                    'Visibility',
-                    notification.android!.visibility.toString(),
-                  ),
-                ],
-                if (notification.apple != null) ...[
-                  const Text(
-                    'Apple Properties',
-                    style: TextStyle(fontSize: 18),
-                  ),
-                  row(
-                    'Subtitle',
-                    notification.apple!.subtitle,
-                  ),
-                  row(
-                    'Badge',
-                    notification.apple!.badge,
-                  ),
-                  row(
-                    'Sound',
-                    notification.apple!.sound?.name,
-                  ),
-                ]
-              ]),
-            )
-          ]
-        ]),
+              )
+            ]
+          ],
+        ),
       )),
     );
   }

--- a/packages/firebase_messaging/firebase_messaging/example/lib/message.dart
+++ b/packages/firebase_messaging/firebase_messaging/example/lib/message.dart
@@ -1,5 +1,4 @@
 // ignore_for_file: require_trailing_commas
-// @dart=2.9
 
 import 'package:firebase_messaging/firebase_messaging.dart';
 import 'package:flutter/material.dart';
@@ -13,14 +12,13 @@ class MessageArguments {
   final bool openedApplication;
 
   // ignore: public_member_api_docs
-  MessageArguments(this.message, this.openedApplication)
-      : assert(message != null);
+  MessageArguments(this.message, this.openedApplication);
 }
 
 /// Displays information about a [RemoteMessage].
 class MessageView extends StatelessWidget {
   /// A single data row.
-  Widget row(String title, String value) {
+  Widget row(String title, String? value) {
     return Padding(
       padding: const EdgeInsets.only(left: 8, right: 8, top: 8),
       child: Row(children: [
@@ -32,13 +30,13 @@ class MessageView extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final MessageArguments args = ModalRoute.of(context).settings.arguments;
+    final MessageArguments args = ModalRoute.of(context)!.settings.arguments! as MessageArguments;
     RemoteMessage message = args.message;
-    RemoteNotification notification = message.notification;
+    RemoteNotification? notification = message.notification;
 
     return Scaffold(
       appBar: AppBar(
-        title: Text(message.messageId),
+        title: Text(message.messageId!),
       ),
       body: SingleChildScrollView(
           child: Padding(
@@ -79,47 +77,47 @@ class MessageView extends StatelessWidget {
                   ),
                   row(
                     'Channel ID',
-                    notification.android.channelId,
+                    notification.android!.channelId,
                   ),
                   row(
                     'Click Action',
-                    notification.android.clickAction,
+                    notification.android!.clickAction,
                   ),
                   row(
                     'Color',
-                    notification.android.color,
+                    notification.android!.color,
                   ),
                   row(
                     'Count',
-                    notification.android.count?.toString(),
+                    notification.android!.count?.toString(),
                   ),
                   row(
                     'Image URL',
-                    notification.android.imageUrl,
+                    notification.android!.imageUrl,
                   ),
                   row(
                     'Link',
-                    notification.android.link,
+                    notification.android!.link,
                   ),
                   row(
                     'Priority',
-                    notification.android.priority?.toString(),
+                    notification.android!.priority.toString(),
                   ),
                   row(
                     'Small Icon',
-                    notification.android.smallIcon,
+                    notification.android!.smallIcon,
                   ),
                   row(
                     'Sound',
-                    notification.android.sound,
+                    notification.android!.sound,
                   ),
                   row(
                     'Ticker',
-                    notification.android.ticker,
+                    notification.android!.ticker,
                   ),
                   row(
                     'Visibility',
-                    notification.android.visibility?.toString(),
+                    notification.android!.visibility.toString(),
                   ),
                 ],
                 if (notification.apple != null) ...[
@@ -129,15 +127,15 @@ class MessageView extends StatelessWidget {
                   ),
                   row(
                     'Subtitle',
-                    notification.apple.subtitle,
+                    notification.apple!.subtitle,
                   ),
                   row(
                     'Badge',
-                    notification.apple.badge,
+                    notification.apple!.badge,
                   ),
                   row(
                     'Sound',
-                    notification.apple.sound?.name,
+                    notification.apple!.sound?.name,
                   ),
                 ]
               ]),

--- a/packages/firebase_messaging/firebase_messaging/example/lib/message_list.dart
+++ b/packages/firebase_messaging/firebase_messaging/example/lib/message_list.dart
@@ -1,5 +1,4 @@
 // ignore_for_file: require_trailing_commas
-// @dart=2.9
 
 import 'package:firebase_messaging/firebase_messaging.dart';
 import 'package:flutter/material.dart';

--- a/packages/firebase_messaging/firebase_messaging/example/lib/permissions.dart
+++ b/packages/firebase_messaging/firebase_messaging/example/lib/permissions.dart
@@ -1,5 +1,4 @@
 // ignore_for_file: require_trailing_commas
-// @dart=2.9
 
 import 'package:firebase_messaging/firebase_messaging.dart';
 import 'package:flutter/foundation.dart';
@@ -14,7 +13,7 @@ class Permissions extends StatefulWidget {
 class _Permissions extends State<Permissions> {
   bool _requested = false;
   bool _fetching = false;
-  NotificationSettings _settings;
+  late NotificationSettings _settings;
 
   Future<void> requestPermissions() async {
     setState(() {
@@ -61,16 +60,16 @@ class _Permissions extends State<Permissions> {
     }
 
     return Column(children: [
-      row('Authorization Status', statusMap[_settings.authorizationStatus]),
+      row('Authorization Status', statusMap[_settings.authorizationStatus]!),
       if (defaultTargetPlatform == TargetPlatform.iOS) ...[
-        row('Alert', settingsMap[_settings.alert]),
-        row('Announcement', settingsMap[_settings.announcement]),
-        row('Badge', settingsMap[_settings.badge]),
-        row('Car Play', settingsMap[_settings.carPlay]),
-        row('Lock Screen', settingsMap[_settings.lockScreen]),
-        row('Notification Center', settingsMap[_settings.notificationCenter]),
-        row('Show Previews', previewMap[_settings.showPreviews]),
-        row('Sound', settingsMap[_settings.sound]),
+        row('Alert', settingsMap[_settings.alert]!),
+        row('Announcement', settingsMap[_settings.announcement]!),
+        row('Badge', settingsMap[_settings.badge]!),
+        row('Car Play', settingsMap[_settings.carPlay]!),
+        row('Lock Screen', settingsMap[_settings.lockScreen]!),
+        row('Notification Center', settingsMap[_settings.notificationCenter]!),
+        row('Show Previews', previewMap[_settings.showPreviews]!),
+        row('Sound', settingsMap[_settings.sound]!),
       ],
       ElevatedButton(
           onPressed: () => {}, child: const Text('Reload Permissions')),

--- a/packages/firebase_messaging/firebase_messaging/example/lib/token_monitor.dart
+++ b/packages/firebase_messaging/firebase_messaging/example/lib/token_monitor.dart
@@ -1,5 +1,4 @@
 // ignore_for_file: require_trailing_commas
-// @dart=2.9
 
 import 'package:firebase_messaging/firebase_messaging.dart';
 import 'package:flutter/material.dart';
@@ -11,17 +10,17 @@ class TokenMonitor extends StatefulWidget {
   // ignore: public_member_api_docs
   TokenMonitor(this._builder);
 
-  final Widget Function(String token) _builder;
+  final Widget Function(String? token) _builder;
 
   @override
   State<StatefulWidget> createState() => _TokenMonitor();
 }
 
 class _TokenMonitor extends State<TokenMonitor> {
-  String _token;
-  Stream<String> _tokenStream;
+  String? _token;
+  late Stream<String> _tokenStream;
 
-  void setToken(String token) {
+  void setToken(String? token) {
     print('FCM Token: $token');
     setState(() {
       _token = token;

--- a/packages/firebase_messaging/firebase_messaging/example/pubspec.yaml
+++ b/packages/firebase_messaging/firebase_messaging/example/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
     path: ../
   flutter:
     sdk: flutter
-  flutter_local_notifications: ^3.0.0
+  flutter_local_notifications: ^8.2.0
   http: ^0.13.0
 
 dependency_overrides:
@@ -32,7 +32,7 @@ dependency_overrides:
   plugin_platform_interface: ^2.0.0
 
 dev_dependencies:
-  drive: 0.1.0
+  drive: ^1.0.0-1.0.nullsafety.0
   flutter_driver:
     sdk: flutter
   test: any

--- a/packages/firebase_messaging/firebase_messaging/example/test_driver/firebase_messaging_e2e.dart
+++ b/packages/firebase_messaging/firebase_messaging/example/test_driver/firebase_messaging_e2e.dart
@@ -1,5 +1,4 @@
 // ignore_for_file: require_trailing_commas
-// @dart = 2.9
 
 // Copyright 2020, the Chromium project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a

--- a/packages/firebase_messaging/firebase_messaging/example/test_driver/firebase_messaging_e2e_test.dart
+++ b/packages/firebase_messaging/firebase_messaging/example/test_driver/firebase_messaging_e2e_test.dart
@@ -1,5 +1,4 @@
 // ignore_for_file: require_trailing_commas
-// @dart = 2.9
 
 // Copyright 2020, the Chromium project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a

--- a/packages/firebase_messaging/firebase_messaging/example/test_driver/test_utils.dart
+++ b/packages/firebase_messaging/firebase_messaging/example/test_driver/test_utils.dart
@@ -1,5 +1,4 @@
 // ignore_for_file: require_trailing_commas
-// @dart = 2.9
 
 // Copyright 2020, the Chromium project authors.  Please see the AUTHORS file
 // for details. All rights reserved. Use of this source code is governed by a


### PR DESCRIPTION
Migrates the example app in Firebase Messaging package to null-safety and fixes a small overflow issue.
closes #6987 