### PR TITLE
fix(firestore): an issue where `Query.==` throws when using `withConverter`

### DIFF
--- a/packages/cloud_firestore/cloud_firestore/lib/src/query.dart
+++ b/packages/cloud_firestore/cloud_firestore/lib/src/query.dart
@@ -961,7 +961,7 @@ class _WithConverterQuery<T extends Object?> implements Query<T> {
   @override
   bool operator ==(Object other) {
     return runtimeType == other.runtimeType &&
-        other is _WithConverterQuery &&
+        other is _WithConverterQuery<T> &&
         other._fromFirestore == _fromFirestore &&
         other._toFirestore == _toFirestore &&
         other._originalQuery == _originalQuery;

--- a/packages/cloud_firestore/cloud_firestore/test/query_test.dart
+++ b/packages/cloud_firestore/cloud_firestore/test/query_test.dart
@@ -319,6 +319,18 @@ void main() {
 
         int fromFirestore(Object? snapshot, Object? options) => 42;
         Map<String, Object?> toFirestore(Object? value, Object? options) => {};
+        Map<String, Object?> intToFirestore(int value, Object? options) => {};
+
+        expect(
+          query.withConverter<int>(
+            fromFirestore: fromFirestore,
+            toFirestore: intToFirestore,
+          ),
+          query.withConverter<int>(
+            fromFirestore: fromFirestore,
+            toFirestore: intToFirestore,
+          ),
+        );
 
         expect(
           query.withConverter<int>(


### PR DESCRIPTION
## Description

Fixes a bug where  query.== throws when using withConverter

## Related Issues

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
