### PR TITLE
fix(firebase_database): List of values erroring on transaction result

### DIFF
--- a/packages/firebase_database/firebase_database/example/test_driver/firebase_database_e2e.dart
+++ b/packages/firebase_database/firebase_database/example/test_driver/firebase_database_e2e.dart
@@ -79,7 +79,6 @@ void testsMain() {
       });
 
       test('get primitive list values', () async {
-
         List<String> data = ['first', 'second'];
         final FirebaseDatabase database = FirebaseDatabase.instance;
         final DatabaseReference ref = database.reference().child('list-values');

--- a/packages/firebase_database/firebase_database/example/test_driver/firebase_database_e2e.dart
+++ b/packages/firebase_database/firebase_database/example/test_driver/firebase_database_e2e.dart
@@ -59,22 +59,39 @@ void testsMain() {
       // Skipped because it needs to be initialized first on android
     }, skip: Platform.isAndroid);
 
-    test('runTransaction', () async {
-      final FirebaseDatabase database = FirebaseDatabase.instance;
-      final DatabaseReference ref = database.reference().child('flutterfire');
+    group('runTransation', () {
+      test('update and check values', () async {
+        final FirebaseDatabase database = FirebaseDatabase.instance;
+        final DatabaseReference ref = database.reference().child('flutterfire');
 
-      await ref.set(0);
+        await ref.set(0);
 
-      final DataSnapshot snapshot = await ref.once();
-      final int value = snapshot.value ?? 0;
-      final TransactionResult transactionResult =
-          await ref.runTransaction((MutableData mutableData) async {
-        mutableData.value = (mutableData.value ?? 0) + 1;
-        return mutableData;
+        final DataSnapshot snapshot = await ref.once();
+        final int value = snapshot.value ?? 0;
+        final TransactionResult transactionResult =
+            await ref.runTransaction((MutableData mutableData) async {
+          mutableData.value = (mutableData.value ?? 0) + 1;
+          return mutableData;
+        });
+
+        expect(transactionResult.committed, true);
+        expect(transactionResult.dataSnapshot!.value > value, true);
       });
 
-      expect(transactionResult.committed, true);
-      expect(transactionResult.dataSnapshot!.value > value, true);
+      test('get primitive list values', () async {
+
+        List<String> data = ['first', 'second'];
+        final FirebaseDatabase database = FirebaseDatabase.instance;
+        final DatabaseReference ref = database.reference().child('list-values');
+
+        await ref.set({'list': data});
+
+        final transactionResult = await ref.runTransaction((mutableData) async {
+          return mutableData;
+        });
+
+        expect(transactionResult.dataSnapshot!.value['list'], data);
+      });
     });
 
     test('DataSnapshot supports null childKeys for maps', () async {

--- a/packages/firebase_database/firebase_database_platform_interface/lib/src/platform_interface/event.dart
+++ b/packages/firebase_database/firebase_database_platform_interface/lib/src/platform_interface/event.dart
@@ -51,10 +51,9 @@ class DataSnapshotPlatform {
 
     if (dataValue is Map<Object?, Object?> && childKeys != null) {
       value = {for (final key in childKeys) key: dataValue[key]};
-    } else if (dataValue is List<Object?>) {
-      value = childKeys!
-          .map((key) => dataValue[int.parse(key! as String)])
-          .toList();
+    } else if (dataValue is List<Object?> && childKeys != null) {
+      value =
+          childKeys.map((key) => dataValue[int.parse(key! as String)]).toList();
     } else {
       value = dataValue;
     }


### PR DESCRIPTION
## Description

transactions don't pass `childKeys` so we pass the data back as it is.

## Related Issues

fixes https://github.com/FirebaseExtended/flutterfire/issues/6583

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
