### PR TITLE
fix(firebase_storage): fix localhost url parsing for Storage Emulator

### DIFF
--- a/packages/firebase_storage/firebase_storage/example/test_driver/instance_e2e.dart
+++ b/packages/firebase_storage/firebase_storage/example/test_driver/instance_e2e.dart
@@ -128,6 +128,23 @@ void runInstanceTests() {
         expect(ref.fullPath, '1mbTestFile.gif');
       });
 
+      test('accepts a https url including port number', () {
+        const url =
+            'https://firebasestorage.googleapis.com:433/v0/b/react-native-firebase-testing.appspot.com/o/nested/path/segments/1mbTestFile.gif?alt=media';
+        Reference ref = storage.refFromURL(url);
+        expect(ref.bucket, 'react-native-firebase-testing.appspot.com');
+        expect(ref.name, '1mbTestFile.gif');
+        expect(ref.fullPath, 'nested/path/segments/1mbTestFile.gif');
+
+        const googleUrl =
+            'https://storage.googleapis.com/react-native-firebase-testing.appspot.com/pdf/4lqA70lYwfRgH1krOevw6mLMgPs2_162613790513241';
+        Reference refGoogle = storage.refFromURL(googleUrl);
+        expect(refGoogle.bucket, 'react-native-firebase-testing.appspot.com');
+        expect(refGoogle.name, '4lqA70lYwfRgH1krOevw6mLMgPs2_162613790513241');
+        expect(refGoogle.fullPath,
+            'pdf/4lqA70lYwfRgH1krOevw6mLMgPs2_162613790513241');
+      });
+
       test('throws an error if https url could not be parsed', () async {
         try {
           storage.refFromURL('https://invertase.io');

--- a/packages/firebase_storage/firebase_storage/example/test_driver/instance_e2e.dart
+++ b/packages/firebase_storage/firebase_storage/example/test_driver/instance_e2e.dart
@@ -119,6 +119,15 @@ void runInstanceTests() {
         expect(ref.fullPath, '1mbTestFile.gif');
       });
 
+      test('accepts a Storage emulator url', () {
+        const url =
+            'http://localhost:9199/v0/b/react-native-firebase-testing.appspot.com/o/1mbTestFile.gif?alt=media';
+        Reference ref = storage.refFromURL(url);
+        expect(ref.bucket, 'react-native-firebase-testing.appspot.com');
+        expect(ref.name, '1mbTestFile.gif');
+        expect(ref.fullPath, '1mbTestFile.gif');
+      });
+
       test('throws an error if https url could not be parsed', () async {
         try {
           storage.refFromURL('https://invertase.io');

--- a/packages/firebase_storage/firebase_storage/lib/src/utils.dart
+++ b/packages/firebase_storage/firebase_storage/lib/src/utils.dart
@@ -28,6 +28,7 @@ const String _bucketDomain = r'([A-Za-z0-9.\-_]+)';
 const String _version = 'v[A-Za-z0-9_]+';
 const String _firebaseStoragePath = r'(/([^?#]*).*)?$';
 const String _cloudStoragePath = r'([^?#]*)*$';
+const String optionalPort = r'(?::\d+)?';
 
 /// Returns a path from a given `http://` or `https://` URL.
 ///
@@ -52,7 +53,7 @@ Map<String, String?>? partsFromHttpUrl(String url) {
     }
 
     RegExp firebaseStorageRegExp = RegExp(
-      '$origin/$_version/b/$_bucketDomain/o$_firebaseStoragePath',
+      '$origin$optionalPort/$_version/b/$_bucketDomain/o$_firebaseStoragePath',
       caseSensitive: false,
     );
 
@@ -69,7 +70,7 @@ Map<String, String?>? partsFromHttpUrl(String url) {
     // google cloud storage url
   } else {
     RegExp cloudStorageRegExp = RegExp(
-      '^https?://$_cloudStorageHost/$_bucketDomain/$_cloudStoragePath',
+      '^https?://$_cloudStorageHost$optionalPort/$_bucketDomain/$_cloudStoragePath',
       caseSensitive: false,
     );
 

--- a/packages/firebase_storage/firebase_storage/lib/src/utils.dart
+++ b/packages/firebase_storage/firebase_storage/lib/src/utils.dart
@@ -28,7 +28,7 @@ const String _bucketDomain = r'([A-Za-z0-9.\-_]+)';
 const String _version = 'v[A-Za-z0-9_]+';
 const String _firebaseStoragePath = r'(/([^?#]*).*)?$';
 const String _cloudStoragePath = r'([^?#]*)*$';
-const String optionalPort = r'(?::\d+)?';
+const String _optionalPort = r'(?::\d+)?';
 
 /// Returns a path from a given `http://` or `https://` URL.
 ///
@@ -53,7 +53,7 @@ Map<String, String?>? partsFromHttpUrl(String url) {
     }
 
     RegExp firebaseStorageRegExp = RegExp(
-      '$origin$optionalPort/$_version/b/$_bucketDomain/o$_firebaseStoragePath',
+      '$origin$_optionalPort/$_version/b/$_bucketDomain/o$_firebaseStoragePath',
       caseSensitive: false,
     );
 
@@ -70,7 +70,7 @@ Map<String, String?>? partsFromHttpUrl(String url) {
     // google cloud storage url
   } else {
     RegExp cloudStorageRegExp = RegExp(
-      '^https?://$_cloudStorageHost$optionalPort/$_bucketDomain/$_cloudStoragePath',
+      '^https?://$_cloudStorageHost$_optionalPort/$_bucketDomain/$_cloudStoragePath',
       caseSensitive: false,
     );
 

--- a/packages/firebase_storage/firebase_storage/lib/src/utils.dart
+++ b/packages/firebase_storage/firebase_storage/lib/src/utils.dart
@@ -43,9 +43,8 @@ Map<String, String?>? partsFromHttpUrl(String url) {
   // firebase storage url
   if (decodedUrl.contains(_firebaseStorageHost) ||
       decodedUrl.contains('localhost')) {
-
     String origin;
-    if(decodedUrl.contains('localhost')){
+    if (decodedUrl.contains('localhost')) {
       Uri uri = Uri.parse(url);
       origin = '^http?://${uri.host}:${uri.port}';
     } else {

--- a/packages/firebase_storage/firebase_storage/lib/src/utils.dart
+++ b/packages/firebase_storage/firebase_storage/lib/src/utils.dart
@@ -39,10 +39,21 @@ Map<String, String?>? partsFromHttpUrl(String url) {
   if (decodedUrl == null) {
     return null;
   }
+
   // firebase storage url
-  if (decodedUrl.contains(_firebaseStorageHost)) {
+  if (decodedUrl.contains(_firebaseStorageHost) ||
+      decodedUrl.contains('localhost')) {
+
+    String origin;
+    if(decodedUrl.contains('localhost')){
+      Uri uri = Uri.parse(url);
+      origin = '^http?://${uri.host}:${uri.port}';
+    } else {
+      origin = '^https?://$_firebaseStorageHost';
+    }
+
     RegExp firebaseStorageRegExp = RegExp(
-      '^https?://$_firebaseStorageHost/$_version/b/$_bucketDomain/o$_firebaseStoragePath',
+      '$origin/$_version/b/$_bucketDomain/o$_firebaseStoragePath',
       caseSensitive: false,
     );
 


### PR DESCRIPTION
## Description

`refFromUrl` was not parsing `localhost` urls needed for using the emulator.

## Related Issues

fixes https://github.com/FirebaseExtended/flutterfire/issues/6944

**update on additional fix**
-  used optional items to capture preceding regex: https://www.regular-expressions.info/optional.html
-  also used non-capturing group so the port number doesn't mess up the groupings: https://www.regular-expressions.info/refcapture.html
- link to regex: https://regex101.com/r/hlI7zP/1

fixes https://github.com/FirebaseExtended/flutterfire/issues/7019

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
