### PR TITLE
docs: update apple-integration.mdx line numbers

### DIFF
--- a/docs/messaging/apple-integration.mdx
+++ b/docs/messaging/apple-integration.mdx
@@ -221,7 +221,6 @@ Ensure that your new extension has access to Firebase/Messaging pod by adding it
 
 ```ruby
 target 'ImageNotification' do
-  use_frameworks!
   pod 'Firebase/Messaging'
 end
 ```

--- a/docs/messaging/apple-integration.mdx
+++ b/docs/messaging/apple-integration.mdx
@@ -204,7 +204,7 @@ service extension. This is not a required step.
 
 - From Xcode top menu go to: **File > New > Target...**
 - A modal will present a list of possible targets, scroll down or use the filter to select "Notification Service Extension". Press Next.
-- Add a product name (use `ImageNotification` to follow along) and click **Finish**.
+- Add a product name (use `ImageNotification` to follow along), set `Language` to `Objective-C` and click **Finish**.
 - Enable the scheme by clicking **Activate**.
 
 <Image
@@ -221,6 +221,7 @@ Ensure that your new extension has access to Firebase/Messaging pod by adding it
 
 ```ruby
 target 'ImageNotification' do
+  use_frameworks!
   pod 'Firebase/Messaging'
 end
 ```
@@ -245,7 +246,7 @@ At this point everything should still be running normally. This is the final ste
 + #import "FirebaseMessaging.h"
 ```
 
-- Replace everything from line 25 to 28 with the extension helper:
+- Replace everything from line 24 to 27 with the extension helper:
 
 ```diff
 - // Modify the notification content here...


### PR DESCRIPTION
## Description

- To follow to instructions the image notification extension must be added with Objective-C language.
- Podfile target should include `use_frameworks!`
- Lines to be modified in `NotificationService.m` are 24-27 and not 25-28.

## Related Issues

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
