### PR TITLE
chore: bump ios to `8.7.0` & android to `28.4.1`

### DIFF
--- a/docs/overview.mdx
+++ b/docs/overview.mdx
@@ -270,7 +270,7 @@ In the `/android/app/build.gradle` file, you can provide your own versions using
 ```groovy
 rootProject.ext {
   set('FlutterFire', [
-    FirebaseSDKVersion: '28.3.1'
+    FirebaseSDKVersion: '28.4.1'
   ])
 }
 ```
@@ -281,7 +281,7 @@ Open your `/ios/Podfile` or `/macos/Podfile` file and add any of the globals bel
 
 ```ruby
 # Override Firebase SDK Version
-$FirebaseSDKVersion = '8.6.0'
+$FirebaseSDKVersion = '8.7.0'
 ```
 
 ## Next Steps

--- a/packages/firebase_core/firebase_core/android/gradle.properties
+++ b/packages/firebase_core/firebase_core/android/gradle.properties
@@ -1,2 +1,2 @@
 # https://firebase.google.com/support/release-notes/android
-FirebaseSDKVersion=28.3.1
+FirebaseSDKVersion=28.4.1

--- a/packages/firebase_core/firebase_core/ios/firebase_sdk_version.rb
+++ b/packages/firebase_core/firebase_core/ios/firebase_sdk_version.rb
@@ -1,4 +1,4 @@
 # https://firebase.google.com/support/release-notes/ios
 def firebase_sdk_version!()
-  '8.6.0'
+  '8.7.0'
 end


### PR DESCRIPTION
## Description

bump native SDKs.

## Related Issues

fixes https://github.com/FirebaseExtended/flutterfire/issues/6794

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [ ] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
