### PR TITLE
fix(firebase_crashlytics): switch usage of `dumpErrorToConsole` to `presentError` to remove duplicate logging

### DIFF
--- a/packages/firebase_crashlytics/firebase_crashlytics/example/lib/main.dart
+++ b/packages/firebase_crashlytics/firebase_crashlytics/example/lib/main.dart
@@ -19,7 +19,7 @@ const _kShouldTestAsyncErrorOnInit = false;
 
 // Toggle this for testing Crashlytics in your app locally.
 const _kTestingCrashlytics = true;
-//ignore: avoid_void_async
+
 void main() {
   runZonedGuarded(() async {
     WidgetsFlutterBinding.ensureInitialized();
@@ -60,14 +60,6 @@ class _MyAppState extends State<MyApp> {
       await FirebaseCrashlytics.instance
           .setCrashlyticsCollectionEnabled(!kDebugMode);
     }
-
-    // Pass all uncaught errors to Crashlytics.
-    Function originalOnError = FlutterError.onError;
-    FlutterError.onError = (FlutterErrorDetails errorDetails) async {
-      await FirebaseCrashlytics.instance.recordFlutterError(errorDetails);
-      // Forward to original handler.
-      originalOnError(errorDetails);
-    };
 
     if (_kShouldTestAsyncErrorOnInit) {
       await _testAsyncErrorOnInit();

--- a/packages/firebase_crashlytics/firebase_crashlytics/lib/src/firebase_crashlytics.dart
+++ b/packages/firebase_crashlytics/firebase_crashlytics/lib/src/firebase_crashlytics.dart
@@ -131,7 +131,7 @@ class FirebaseCrashlytics extends FirebasePluginPlatform {
 
   /// Submits a Crashlytics report of a non-fatal error caught by the Flutter framework.
   Future<void> recordFlutterError(FlutterErrorDetails flutterErrorDetails) {
-    FlutterError.dumpErrorToConsole(flutterErrorDetails, forceReport: true);
+    FlutterError.presentError(flutterErrorDetails);
 
     return recordError(
       flutterErrorDetails.exceptionAsString(),


### PR DESCRIPTION
## Description

Changes `dumpErrorToConsole` to `presentError` and also removes unneeded piece of code from the `example`

## Related Issues

See https://github.com/flutter/flutter/pull/88253 and https://github.com/flutter/website/issues/6164

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
