### PR TITLE
fix(firebase_performance): remove the app creation during plugin initialization.

### DIFF
--- a/packages/firebase_performance/firebase_performance/example/lib/main.dart
+++ b/packages/firebase_performance/firebase_performance/example/lib/main.dart
@@ -7,7 +7,6 @@
 
 import 'dart:async';
 
-import 'package:firebase_core/firebase_core.dart';
 import 'package:firebase_performance/firebase_performance.dart';
 import 'package:flutter/material.dart';
 import 'package:http/http.dart';
@@ -15,7 +14,9 @@ import 'package:pedantic/pedantic.dart';
 
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
-  await Firebase.initializeApp();
+  // Firebase Performance Monitoring uses default app so no need to initialize
+  // it here.
+  // await Firebase.initializeApp();
   runApp(MyApp());
 }
 

--- a/packages/firebase_performance/firebase_performance/lib/src/firebase_performance.dart
+++ b/packages/firebase_performance/firebase_performance/lib/src/firebase_performance.dart
@@ -10,7 +10,8 @@ part of firebase_performance;
 /// You can get an instance by calling [FirebasePerformance.instance].
 class FirebasePerformance extends FirebasePluginPlatform {
   FirebasePerformance._()
-      : super(Firebase.app().name, 'plugins.flutter.io/firebase_performance');
+      : super(
+            defaultFirebaseAppName, 'plugins.flutter.io/firebase_performance');
 
   late final _delegate = FirebasePerformancePlatform.instance;
 


### PR DESCRIPTION
Fireperf SDK doesn't require creating an app instance. Removing it allows the developer to not call `await Firebase.initializeApp()` at the beginning of Flutter app which saves app startup time. This should fix #7060.

## Related Issues
#7060

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
