### PR TITLE
fix: fixed a bug where `withConverter.endBeforeDocument` incorrectly behaved as `endAtDocument`

### DIFF
--- a/packages/cloud_firestore/cloud_firestore/example/test_driver/query_e2e.dart
+++ b/packages/cloud_firestore/cloud_firestore/example/test_driver/query_e2e.dart
@@ -1650,6 +1650,54 @@ void runQueryTests() {
         timeout: const Timeout.factor(3),
       );
 
+      test('endBefore', () async {
+        final collection = await initializeTest('foo');
+
+        final converted = collection.withConverter<int>(
+          fromFirestore: (snapshots, _) => snapshots.data()!['value']! as int,
+          toFirestore: (value, _) => {'value': value},
+        );
+
+        await converted.add(1);
+        await converted.add(2);
+        await converted.add(3);
+
+        expect(
+          await converted
+              .orderBy('value')
+              .endBefore([2])
+              .get()
+              .then((d) => d.docs),
+          [isA<DocumentSnapshot<int>>().having((e) => e.data(), 'data', 1)],
+        );
+      });
+
+      test(
+        'endBeforeDocument',
+        () async {
+          final collection = await initializeTest('foo');
+
+          final converted = collection.withConverter<int>(
+            fromFirestore: (snapshots, _) => snapshots.data()!['value']! as int,
+            toFirestore: (value, _) => {'value': value},
+          );
+
+          await converted.add(1);
+          final doc2 = await converted.add(2);
+          await converted.add(3);
+
+          expect(
+            await converted
+                .orderBy('value')
+                .endBeforeDocument(await doc2.get())
+                .get()
+                .then((d) => d.docs),
+            [isA<DocumentSnapshot<int>>().having((e) => e.data(), 'data', 1)],
+          );
+        },
+        timeout: const Timeout.factor(3),
+      );
+
       test(
         'startAt',
         () async {
@@ -1703,6 +1751,58 @@ void runQueryTests() {
               isA<DocumentSnapshot<int>>().having((e) => e.data(), 'data', 2),
               isA<DocumentSnapshot<int>>().having((e) => e.data(), 'data', 3),
             ],
+          );
+        },
+        timeout: const Timeout.factor(3),
+      );
+
+      test(
+        'startAfter',
+        () async {
+          final collection = await initializeTest('foo');
+
+          final converted = collection.withConverter<int>(
+            fromFirestore: (snapshots, _) => snapshots.data()!['value']! as int,
+            toFirestore: (value, _) => {'value': value},
+          );
+
+          await converted.add(1);
+          await converted.add(2);
+          await converted.add(3);
+
+          expect(
+            await converted
+                .orderBy('value')
+                .startAfter([2])
+                .get()
+                .then((d) => d.docs),
+            [isA<DocumentSnapshot<int>>().having((e) => e.data(), 'data', 3)],
+          );
+        },
+        timeout: const Timeout.factor(3),
+      );
+
+      test(
+        'startAfterDocument',
+        () async {
+          final collection = await initializeTest('foo');
+
+          final converted = collection.withConverter<int>(
+            fromFirestore: (snapshots, _) => snapshots.data()!['value']! as int,
+            toFirestore: (value, _) => {'value': value},
+          );
+
+          await converted.add(1);
+          final doc2 = await converted.add(2);
+          await converted.add(3);
+
+          expect(
+            await converted
+                .orderBy('value')
+                .startAfterDocument(await doc2.get())
+                .get()
+                .then((d) => d.docs),
+            [isA<DocumentSnapshot<int>>().having((e) => e.data(), 'data', 3)],
           );
         },
         timeout: const Timeout.factor(3),

--- a/packages/cloud_firestore/cloud_firestore/lib/src/query.dart
+++ b/packages/cloud_firestore/cloud_firestore/lib/src/query.dart
@@ -875,7 +875,7 @@ class _WithConverterQuery<T extends Object?> implements Query<T> {
 
   @override
   Query<T> endBeforeDocument(DocumentSnapshot documentSnapshot) {
-    return _mapQuery(_originalQuery.endAtDocument(documentSnapshot));
+    return _mapQuery(_originalQuery.endBeforeDocument(documentSnapshot));
   }
 
   @override


### PR DESCRIPTION
## Description

See the title

## Related Issues

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
