### PR TITLE
docs(firebase_dynamic_links): changed "ibn" to "ibi" iOS param name in long dynamic link example

### DIFF
--- a/packages/firebase_dynamic_links/README.md
+++ b/packages/firebase_dynamic_links/README.md
@@ -68,7 +68,7 @@ To shorten a long Dynamic Link, use the DynamicLinkParameters.shortenUrl method.
 
 ```dart
 final ShortDynamicLink shortenedLink = await DynamicLinkParameters.shortenUrl(
-  Uri.parse('https://example.page.link/?link=https://example.com/&apn=com.example.android&ibn=com.example.ios'),
+  Uri.parse('https://example.page.link/?link=https://example.com/&apn=com.example.android&ibi=com.example.ios'),
   DynamicLinkParametersOptions(ShortDynamicLinkPathLength.unguessable),
 );
 


### PR DESCRIPTION
According to the documentation, the query parameter referent to the iOS bundle id is called "ibi" and not "ibn"

## Description

The long link example has a wrong query parameter.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [X] All existing and new tests are passing.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [X] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA]. `@googlebot I signed it!`
- [X] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [X] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
