### PR TITLE
fix(cloud_firestore): propagate query index link  to firebase console for user

### DIFF
--- a/packages/cloud_firestore/cloud_firestore/android/src/main/java/io/flutter/plugins/firebase/firestore/FlutterFirebaseFirestoreException.java
+++ b/packages/cloud_firestore/cloud_firestore/android/src/main/java/io/flutter/plugins/firebase/firestore/FlutterFirebaseFirestoreException.java
@@ -79,7 +79,7 @@ public class FlutterFirebaseFirestoreException extends Exception {
             break;
           case "FAILED_PRECONDITION":
             code = "failed-precondition";
-            if (foundMessage.contains("query requires an index")) {
+            if (foundMessage.contains("query requires an index") || foundMessage.contains("")) {
               message = foundMessage;
             } else {
               message = ERROR_FAILED_PRECONDITION;
@@ -154,7 +154,8 @@ public class FlutterFirebaseFirestoreException extends Exception {
         case FAILED_PRECONDITION:
           code = "failed-precondition";
           if (nativeException.getMessage() != null
-              && nativeException.getMessage().contains("query requires an index")) {
+                  && nativeException.getMessage().contains("query requires an index")
+              || nativeException.getMessage().contains("ensure it has been indexed")) {
             message = nativeException.getMessage();
           } else {
             message = ERROR_FAILED_PRECONDITION;

--- a/packages/cloud_firestore/cloud_firestore/android/src/main/java/io/flutter/plugins/firebase/firestore/FlutterFirebaseFirestoreException.java
+++ b/packages/cloud_firestore/cloud_firestore/android/src/main/java/io/flutter/plugins/firebase/firestore/FlutterFirebaseFirestoreException.java
@@ -79,7 +79,8 @@ public class FlutterFirebaseFirestoreException extends Exception {
             break;
           case "FAILED_PRECONDITION":
             code = "failed-precondition";
-            if (foundMessage.contains("query requires an index") || foundMessage.contains("")) {
+            if (foundMessage.contains("query requires an index")
+                || foundMessage.contains("ensure it has been indexed")) {
               message = foundMessage;
             } else {
               message = ERROR_FAILED_PRECONDITION;

--- a/packages/cloud_firestore/cloud_firestore/ios/Classes/FLTFirebaseFirestoreUtils.m
+++ b/packages/cloud_firestore/cloud_firestore/ios/Classes/FLTFirebaseFirestoreUtils.m
@@ -100,7 +100,8 @@ NSMutableDictionary<NSString *, FIRFirestore *> *firestoreInstanceCache;
       break;
     case FIRFirestoreErrorCodeFailedPrecondition:
       code = @"failed-precondition";
-      if ([error.localizedDescription containsString:@"query requires an index"]) {
+      if ([error.localizedDescription containsString:@"query requires an index"] ||
+          [error.localizedDescription containsString:@"requires a COLLECTION_GROUP_DESC index"]) {
         message = error.localizedDescription;
       } else {
         message = @"Operation was rejected because the system is not in a state required for the "


### PR DESCRIPTION
## Description

Propagate the query index link to user when they use a composite `collectionGroup` query. Only for iOS & android. Web works as intended.

<img width="591" alt="Screenshot 2021-09-28 at 13 05 03" src="https://user-images.githubusercontent.com/16018629/135078922-694ae1af-d66f-434e-8d5d-da434c0081e8.png">

## Related Issues

fixes https://github.com/FirebaseExtended/flutterfire/issues/7010

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
