### PR TITLE
fix(firebase_messaging): Fix crash on Android in onDetachedFromEngine

### DIFF
--- a/packages/firebase_messaging/firebase_messaging/android/src/main/java/io/flutter/plugins/firebase/messaging/FlutterFirebaseMessagingPlugin.java
+++ b/packages/firebase_messaging/firebase_messaging/android/src/main/java/io/flutter/plugins/firebase/messaging/FlutterFirebaseMessagingPlugin.java
@@ -87,8 +87,10 @@ public class FlutterFirebaseMessagingPlugin extends BroadcastReceiver
 
   @Override
   public void onDetachedFromEngine(@NonNull FlutterPluginBinding binding) {
-    LocalBroadcastManager.getInstance(ContextHolder.getApplicationContext())
-        .unregisterReceiver(this);
+    if (binding.getApplicationContext() != null) {
+        LocalBroadcastManager.getInstance(binding.getApplicationContext())
+            .unregisterReceiver(this);
+    }
   }
 
   @Override

--- a/packages/firebase_messaging/firebase_messaging/android/src/main/java/io/flutter/plugins/firebase/messaging/FlutterFirebaseMessagingPlugin.java
+++ b/packages/firebase_messaging/firebase_messaging/android/src/main/java/io/flutter/plugins/firebase/messaging/FlutterFirebaseMessagingPlugin.java
@@ -88,8 +88,7 @@ public class FlutterFirebaseMessagingPlugin extends BroadcastReceiver
   @Override
   public void onDetachedFromEngine(@NonNull FlutterPluginBinding binding) {
     if (binding.getApplicationContext() != null) {
-        LocalBroadcastManager.getInstance(binding.getApplicationContext())
-            .unregisterReceiver(this);
+      LocalBroadcastManager.getInstance(binding.getApplicationContext()).unregisterReceiver(this);
     }
   }
 


### PR DESCRIPTION
This fixes NullPointerException: Attempt to invoke virtual method 'android.content.Context android.content.Context.getApplicationContext() as propagated by @talent-apps in Issue #6998

## Description

*Replace this paragraph with a description of what this PR is doing. If you're modifying existing behavior, describe the existing behavior, how this PR is changing it, and what motivated the change.*

## Related Issues

fixes #6998

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [x] No, this is *not* a breaking change.
