### PR TITLE
fix(firebase_messaging): Pass null value to RemoteMessage constructor then lead to crash. #6759

### DIFF
--- a/packages/firebase_messaging/firebase_messaging/android/src/main/java/io/flutter/plugins/firebase/messaging/FlutterFirebaseMessagingReceiver.java
+++ b/packages/firebase_messaging/firebase_messaging/android/src/main/java/io/flutter/plugins/firebase/messaging/FlutterFirebaseMessagingReceiver.java
@@ -23,6 +23,9 @@ public class FlutterFirebaseMessagingReceiver extends BroadcastReceiver {
       ContextHolder.setApplicationContext(context.getApplicationContext());
     }
 
+    // Pass null value to RemoteMessage constructor will lead to crash.
+    if (intent.getExtras() == null) return;
+
     RemoteMessage remoteMessage = new RemoteMessage(intent.getExtras());
 
     // Store the RemoteMessage if the message contains a notification payload.


### PR DESCRIPTION
## Description
Fix issue：Pass null value to RemoteMessage constructor then lead to crash.

## Related Issues
[firebase_messaging] Crash - FlutterFirebaseMessagingReceiver.java line 29 #6759

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [x] No, this is *not* a breaking change.