### PR TITLE
fix(firebase_storage): remove https port number from `downloadUrl` for `iOS`

### DIFF
--- a/packages/firebase_storage/firebase_storage/ios/Classes/FLTFirebaseStoragePlugin.m
+++ b/packages/firebase_storage/firebase_storage/ios/Classes/FLTFirebaseStoragePlugin.m
@@ -212,8 +212,15 @@ typedef NS_ENUM(NSUInteger, FLTFirebaseStorageStringType) {
     if (error != nil) {
       result.error(nil, nil, nil, error);
     } else {
+      NSString *url = URL.absoluteString;
+
+      if ([url rangeOfString:@":443"].location != NSNotFound) {
+        NSRange replaceRange = [url rangeOfString:@":443"];
+        url = [url stringByReplacingCharactersInRange:replaceRange withString:@""];
+      }
+
       result.success(@{
-        @"downloadURL" : URL.absoluteString,
+        @"downloadURL" : url,
       });
     }
   }];


### PR DESCRIPTION
## Description

`iOS` was returning download URL with the port number which is inconsistent with `web` and `android`. We cannot test as we use the emulator for testing which uses a different port number. So I did a before and after of the url returned by printing in the console:

before:
https://firebasestorage.googleapis.com:443/v0/b/react-native-firebase-testing.appspot.com/o/putString.json?alt=media&token=faabe1fc-1c51-4d63-8986-7c89bfdb9916

after:
https://firebasestorage.googleapis.com/v0/b/react-native-firebase-testing.appspot.com/o/putString.json?alt=media&token=faabe1fc-1c51-4d63-8986-7c89bfdb9916


## Related Issues

fixes https://github.com/FirebaseExtended/flutterfire/issues/7036

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
