### PR TITLE
Add the missing include header that defines TARGET_OS_OSX

### DIFF
--- a/packages/cloud_firestore/cloud_firestore/ios/Classes/FLTFirebaseFirestorePlugin.m
+++ b/packages/cloud_firestore/cloud_firestore/ios/Classes/FLTFirebaseFirestorePlugin.m
@@ -5,6 +5,7 @@
 #import <Firebase/Firebase.h>
 #import <firebase_core/FLTFirebasePluginRegistry.h>
 
+#import <TargetConditionals.h>
 #import "Private/FLTDocumentSnapshotStreamHandler.h"
 #import "Private/FLTFirebaseFirestoreUtils.h"
 #import "Private/FLTLoadBundleStreamHandler.h"

--- a/packages/cloud_firestore/cloud_firestore/ios/Classes/Private/FLTDocumentSnapshotStreamHandler.h
+++ b/packages/cloud_firestore/cloud_firestore/ios/Classes/Private/FLTDocumentSnapshotStreamHandler.h
@@ -1,6 +1,7 @@
 // Copyright 2021 The Chromium Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+#import <TargetConditionals.h>
 
 #if TARGET_OS_OSX
 #import <FlutterMacOS/FlutterMacOS.h>

--- a/packages/cloud_firestore/cloud_firestore/ios/Classes/Private/FLTFirebaseFirestoreReader.h
+++ b/packages/cloud_firestore/cloud_firestore/ios/Classes/Private/FLTFirebaseFirestoreReader.h
@@ -1,6 +1,7 @@
 // Copyright 2020 The Chromium Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+#import <TargetConditionals.h>
 
 #if TARGET_OS_OSX
 #import <FlutterMacOS/FlutterMacOS.h>

--- a/packages/cloud_firestore/cloud_firestore/ios/Classes/Private/FLTFirebaseFirestoreUtils.h
+++ b/packages/cloud_firestore/cloud_firestore/ios/Classes/Private/FLTFirebaseFirestoreUtils.h
@@ -1,6 +1,7 @@
 // Copyright 2020 The Chromium Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+#import <TargetConditionals.h>
 
 #if TARGET_OS_OSX
 #import <FlutterMacOS/FlutterMacOS.h>

--- a/packages/cloud_firestore/cloud_firestore/ios/Classes/Private/FLTFirebaseFirestoreWriter.h
+++ b/packages/cloud_firestore/cloud_firestore/ios/Classes/Private/FLTFirebaseFirestoreWriter.h
@@ -1,6 +1,7 @@
 // Copyright 2020 The Chromium Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+#import <TargetConditionals.h>
 
 #if TARGET_OS_OSX
 #import <FlutterMacOS/FlutterMacOS.h>

--- a/packages/cloud_firestore/cloud_firestore/ios/Classes/Private/FLTLoadBundleStreamHandler.h
+++ b/packages/cloud_firestore/cloud_firestore/ios/Classes/Private/FLTLoadBundleStreamHandler.h
@@ -4,6 +4,7 @@
 //
 //  Created by Russell Wheatley on 05/05/2021.
 //
+#import <TargetConditionals.h>
 
 #if TARGET_OS_OSX
 #import <FlutterMacOS/FlutterMacOS.h>

--- a/packages/cloud_firestore/cloud_firestore/ios/Classes/Private/FLTQuerySnapshotStreamHandler.h
+++ b/packages/cloud_firestore/cloud_firestore/ios/Classes/Private/FLTQuerySnapshotStreamHandler.h
@@ -1,6 +1,7 @@
 // Copyright 2021 The Chromium Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+#import <TargetConditionals.h>
 
 #if TARGET_OS_OSX
 #import <FlutterMacOS/FlutterMacOS.h>

--- a/packages/cloud_firestore/cloud_firestore/ios/Classes/Private/FLTSnapshotsInSyncStreamHandler.h
+++ b/packages/cloud_firestore/cloud_firestore/ios/Classes/Private/FLTSnapshotsInSyncStreamHandler.h
@@ -1,6 +1,7 @@
 // Copyright 2021 The Chromium Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+#import <TargetConditionals.h>
 
 #if TARGET_OS_OSX
 #import <FlutterMacOS/FlutterMacOS.h>

--- a/packages/cloud_firestore/cloud_firestore/ios/Classes/Private/FLTTransactionStreamHandler.h
+++ b/packages/cloud_firestore/cloud_firestore/ios/Classes/Private/FLTTransactionStreamHandler.h
@@ -1,6 +1,7 @@
 // Copyright 2021 The Chromium Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+#import <TargetConditionals.h>
 
 #if TARGET_OS_OSX
 #import <FlutterMacOS/FlutterMacOS.h>

--- a/packages/cloud_firestore/cloud_firestore/ios/Classes/Public/FLTFirebaseFirestorePlugin.h
+++ b/packages/cloud_firestore/cloud_firestore/ios/Classes/Public/FLTFirebaseFirestorePlugin.h
@@ -1,6 +1,7 @@
 // Copyright 2020 The Chromium Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+#import <TargetConditionals.h>
 
 #if TARGET_OS_OSX
 #import <FlutterMacOS/FlutterMacOS.h>

--- a/packages/firebase_auth/firebase_auth/ios/Classes/FLTFirebaseAuthPlugin.m
+++ b/packages/firebase_auth/firebase_auth/ios/Classes/FLTFirebaseAuthPlugin.m
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+#import <TargetConditionals.h>
 #import <Firebase/Firebase.h>
 #import <firebase_core/FLTFirebasePluginRegistry.h>
 

--- a/packages/firebase_auth/firebase_auth/ios/Classes/Private/FLTAuthStateChannelStreamHandler.h
+++ b/packages/firebase_auth/firebase_auth/ios/Classes/Private/FLTAuthStateChannelStreamHandler.h
@@ -1,6 +1,7 @@
 // Copyright 2021 The Chromium Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+#import <TargetConditionals.h>
 
 #if TARGET_OS_OSX
 #import <FlutterMacOS/FlutterMacOS.h>

--- a/packages/firebase_auth/firebase_auth/ios/Classes/Private/FLTIdTokenChannelStreamHandler.h
+++ b/packages/firebase_auth/firebase_auth/ios/Classes/Private/FLTIdTokenChannelStreamHandler.h
@@ -1,6 +1,7 @@
 // Copyright 2021 The Chromium Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+#import <TargetConditionals.h>
 
 #if TARGET_OS_OSX
 #import <FlutterMacOS/FlutterMacOS.h>

--- a/packages/firebase_auth/firebase_auth/ios/Classes/Private/FLTPhoneNumberVerificationStreamHandler.h
+++ b/packages/firebase_auth/firebase_auth/ios/Classes/Private/FLTPhoneNumberVerificationStreamHandler.h
@@ -1,6 +1,7 @@
 // Copyright 2021 The Chromium Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+#import <TargetConditionals.h>
 
 #if TARGET_OS_OSX
 #import <FlutterMacOS/FlutterMacOS.h>

--- a/packages/firebase_auth/firebase_auth/ios/Classes/Public/FLTFirebaseAuthPlugin.h
+++ b/packages/firebase_auth/firebase_auth/ios/Classes/Public/FLTFirebaseAuthPlugin.h
@@ -1,6 +1,7 @@
 // Copyright 2020 The Chromium Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+#import <TargetConditionals.h>
 
 #import <Firebase/Firebase.h>
 #if TARGET_OS_OSX

--- a/packages/firebase_core/firebase_core/ios/Classes/FLTFirebaseCorePlugin.h
+++ b/packages/firebase_core/firebase_core/ios/Classes/FLTFirebaseCorePlugin.h
@@ -1,6 +1,7 @@
 // Copyright 2020 The Chromium Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+#import <TargetConditionals.h>
 
 #if TARGET_OS_OSX
 #import <FlutterMacOS/FlutterMacOS.h>

--- a/packages/firebase_core/firebase_core/ios/Classes/FLTFirebasePlugin.h
+++ b/packages/firebase_core/firebase_core/ios/Classes/FLTFirebasePlugin.h
@@ -8,6 +8,7 @@
 //       inside framework module".
 #import <FirebaseCore/FirebaseCore.h>
 #import <Foundation/Foundation.h>
+#import <TargetConditionals.h>
 
 #if TARGET_OS_OSX
 #import <FlutterMacOS/FlutterMacOS.h>

--- a/packages/firebase_messaging/firebase_messaging/ios/Classes/FLTFirebaseMessagingPlugin.h
+++ b/packages/firebase_messaging/firebase_messaging/ios/Classes/FLTFirebaseMessagingPlugin.h
@@ -1,6 +1,7 @@
 // Copyright 2020 The Chromium Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+#import <TargetConditionals.h>
 
 #if TARGET_OS_OSX
 #import <FlutterMacOS/FlutterMacOS.h>

--- a/packages/firebase_messaging/firebase_messaging/ios/Classes/FLTFirebaseMessagingPlugin.m
+++ b/packages/firebase_messaging/firebase_messaging/ios/Classes/FLTFirebaseMessagingPlugin.m
@@ -1,6 +1,7 @@
 // Copyright 2020 The Chromium Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+#import <TargetConditionals.h>
 
 #import <GoogleUtilities/GULAppDelegateSwizzler.h>
 #import <firebase_core/FLTFirebasePluginRegistry.h>

--- a/packages/firebase_remote_config/firebase_remote_config/ios/Classes/FLTFirebaseRemoteConfigPlugin.h
+++ b/packages/firebase_remote_config/firebase_remote_config/ios/Classes/FLTFirebaseRemoteConfigPlugin.h
@@ -1,6 +1,7 @@
 // Copyright 2020 The Chromium Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+#import <TargetConditionals.h>
 
 #if TARGET_OS_OSX
 #import <FlutterMacOS/FlutterMacOS.h>

--- a/packages/firebase_remote_config/firebase_remote_config/ios/Classes/FLTFirebaseRemoteConfigUtils.h
+++ b/packages/firebase_remote_config/firebase_remote_config/ios/Classes/FLTFirebaseRemoteConfigUtils.h
@@ -1,6 +1,7 @@
 // Copyright 2020 The Chromium Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+#import <TargetConditionals.h>
 
 #import <Foundation/Foundation.h>
 

--- a/packages/firebase_storage/firebase_storage/ios/Classes/FLTFirebaseStoragePlugin.h
+++ b/packages/firebase_storage/firebase_storage/ios/Classes/FLTFirebaseStoragePlugin.h
@@ -1,6 +1,7 @@
 // Copyright 2020 The Chromium Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+#import <TargetConditionals.h>
 
 #if TARGET_OS_OSX
 #import <FlutterMacOS/FlutterMacOS.h>

--- a/packages/firebase_storage/firebase_storage/ios/Classes/FLTFirebaseStoragePlugin.m
+++ b/packages/firebase_storage/firebase_storage/ios/Classes/FLTFirebaseStoragePlugin.m
@@ -1,6 +1,7 @@
 // Copyright 2020 The Chromium Authors. All rights reserved.
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+#import <TargetConditionals.h>
 
 #import <Firebase/Firebase.h>
 #import <firebase_core/FLTFirebasePluginRegistry.h>


### PR DESCRIPTION
## Description

Add the missing include header that defines TARGET_OS_OSX.

## Related Issues

None.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
