### PR TITLE
fix(analytics, crashlytics, core, messaging) Remove unused deprecated V1 embedding

### DIFF
--- a/packages/firebase_analytics/firebase_analytics/android/src/main/java/io/flutter/plugins/firebaseanalytics/FirebaseAnalyticsPlugin.java
+++ b/packages/firebase_analytics/firebase_analytics/android/src/main/java/io/flutter/plugins/firebaseanalytics/FirebaseAnalyticsPlugin.java
@@ -17,7 +17,6 @@ import io.flutter.plugin.common.MethodCall;
 import io.flutter.plugin.common.MethodChannel;
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler;
 import io.flutter.plugin.common.MethodChannel.Result;
-import io.flutter.plugin.common.PluginRegistry;
 import java.util.ArrayList;
 import java.util.Map;
 
@@ -25,8 +24,6 @@ import java.util.Map;
 public class FirebaseAnalyticsPlugin implements MethodCallHandler, FlutterPlugin {
   private FirebaseAnalytics firebaseAnalytics;
   private MethodChannel methodChannel;
-  // Only set registrar for v1 embedder.
-  private PluginRegistry.Registrar registrar;
   // Only set activity for v2 embedder. Always access activity from getActivity() method.
   private Activity activity;
 

--- a/packages/firebase_analytics/firebase_analytics/android/src/main/java/io/flutter/plugins/firebaseanalytics/FirebaseAnalyticsPlugin.java
+++ b/packages/firebase_analytics/firebase_analytics/android/src/main/java/io/flutter/plugins/firebaseanalytics/FirebaseAnalyticsPlugin.java
@@ -27,12 +27,7 @@ public class FirebaseAnalyticsPlugin implements MethodCallHandler, FlutterPlugin
   // Only set activity for v2 embedder. Always access activity from getActivity() method.
   private Activity activity;
 
-  public static void registerWith(PluginRegistry.Registrar registrar) {
-    FirebaseAnalyticsPlugin instance = new FirebaseAnalyticsPlugin();
-    instance.registrar = registrar;
-    instance.onAttachedToEngine(registrar.context(), registrar.messenger());
-  }
-
+  @SuppressWarnings("unchecked")
   private static Bundle createBundleFromMap(Map<String, Object> map) {
     if (map == null) {
       return null;

--- a/packages/firebase_core/firebase_core/android/src/main/java/io/flutter/plugins/firebase/core/FlutterFirebaseCorePlugin.java
+++ b/packages/firebase_core/firebase_core/android/src/main/java/io/flutter/plugins/firebase/core/FlutterFirebaseCorePlugin.java
@@ -14,7 +14,6 @@ import com.google.firebase.FirebaseOptions;
 import io.flutter.embedding.engine.plugins.FlutterPlugin;
 import io.flutter.plugin.common.MethodCall;
 import io.flutter.plugin.common.MethodChannel;
-import io.flutter.plugin.common.PluginRegistry;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -58,19 +57,6 @@ public class FlutterFirebaseCorePlugin implements FlutterPlugin, MethodChannel.M
 
   private FlutterFirebaseCorePlugin(Context applicationContext) {
     this.applicationContext = applicationContext;
-  }
-
-  /**
-   * Registers a plugin with the v1 embedding api {@code io.flutter.plugin.common}.
-   *
-   * <p>Calling this will register the plugin with the passed registrar. However plugins initialized
-   * this way won't react to changes in activity or context, unlike {@link
-   * FlutterFirebaseCorePlugin}.
-   */
-  @SuppressWarnings("unused")
-  public static void registerWith(PluginRegistry.Registrar registrar) {
-    final MethodChannel channel = new MethodChannel(registrar.messenger(), CHANNEL_NAME);
-    channel.setMethodCallHandler(new FlutterFirebaseCorePlugin(registrar.context()));
   }
 
   @Override

--- a/packages/firebase_core/firebase_core/android/src/main/java/io/flutter/plugins/firebase/core/FlutterFirebaseCorePlugin.java
+++ b/packages/firebase_core/firebase_core/android/src/main/java/io/flutter/plugins/firebase/core/FlutterFirebaseCorePlugin.java
@@ -170,7 +170,7 @@ public class FlutterFirebaseCorePlugin implements FlutterPlugin, MethodChannel.M
         cachedThreadPool,
         () -> {
           String appName = (String) Objects.requireNonNull(arguments.get(KEY_APP_NAME));
-          boolean enabled = (boolean) Objects.requireNonNull(arguments.get(KEY_ENABLED));
+          Boolean enabled = (Boolean) Objects.requireNonNull(arguments.get(KEY_ENABLED));
           FirebaseApp firebaseApp = FirebaseApp.getInstance(appName);
           firebaseApp.setDataCollectionDefaultEnabled(enabled);
           return null;

--- a/packages/firebase_crashlytics/firebase_crashlytics/android/src/main/java/io/flutter/plugins/firebase/crashlytics/FlutterFirebaseCrashlyticsPlugin.java
+++ b/packages/firebase_crashlytics/firebase_crashlytics/android/src/main/java/io/flutter/plugins/firebase/crashlytics/FlutterFirebaseCrashlyticsPlugin.java
@@ -21,7 +21,6 @@ import io.flutter.plugin.common.BinaryMessenger;
 import io.flutter.plugin.common.MethodCall;
 import io.flutter.plugin.common.MethodChannel;
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler;
-import io.flutter.plugin.common.PluginRegistry.Registrar;
 import io.flutter.plugins.firebase.core.FlutterFirebasePlugin;
 import io.flutter.plugins.firebase.core.FlutterFirebasePluginRegistry;
 import java.util.ArrayList;
@@ -35,12 +34,6 @@ public class FlutterFirebaseCrashlyticsPlugin
     implements FlutterFirebasePlugin, FlutterPlugin, MethodCallHandler {
   public static final String TAG = "FLTFirebaseCrashlytics";
   private MethodChannel channel;
-
-  /** Plugin registration. */
-  public static void registerWith(Registrar registrar) {
-    FlutterFirebaseCrashlyticsPlugin instance = new FlutterFirebaseCrashlyticsPlugin();
-    instance.initInstance(registrar.messenger());
-  }
 
   private void initInstance(BinaryMessenger messenger) {
     String channelName = "plugins.flutter.io/firebase_crashlytics";

--- a/packages/firebase_messaging/firebase_messaging/android/src/main/java/io/flutter/plugins/firebase/messaging/FlutterFirebaseMessagingBackgroundExecutor.java
+++ b/packages/firebase_messaging/firebase_messaging/android/src/main/java/io/flutter/plugins/firebase/messaging/FlutterFirebaseMessagingBackgroundExecutor.java
@@ -17,7 +17,7 @@ import io.flutter.embedding.engine.FlutterEngine;
 import io.flutter.embedding.engine.FlutterShellArgs;
 import io.flutter.embedding.engine.dart.DartExecutor;
 import io.flutter.embedding.engine.dart.DartExecutor.DartCallback;
-import io.flutter.embedding.engine.plugins.shim.ShimPluginRegistry;
+import io.flutter.embedding.engine.loader.FlutterLoader;
 import io.flutter.plugin.common.BinaryMessenger;
 import io.flutter.plugin.common.MethodCall;
 import io.flutter.plugin.common.MethodChannel;
@@ -39,8 +39,6 @@ public class FlutterFirebaseMessagingBackgroundExecutor implements MethodCallHan
   private static final String CALLBACK_HANDLE_KEY = "callback_handle";
   private static final String USER_CALLBACK_HANDLE_KEY = "user_callback_handle";
 
-  private static io.flutter.plugin.common.PluginRegistry.PluginRegistrantCallback
-      pluginRegistrantCallback;
   private final AtomicBoolean isCallbackDispatcherReady = new AtomicBoolean(false);
   /**
    * The {@link MethodChannel} that connects the Android side of this plugin with the background
@@ -49,19 +47,6 @@ public class FlutterFirebaseMessagingBackgroundExecutor implements MethodCallHan
   private MethodChannel backgroundChannel;
 
   private FlutterEngine backgroundFlutterEngine;
-
-  /**
-   * Sets the {@code io.flutter.plugin.common.PluginRegistry.PluginRegistrantCallback} used to
-   * register plugins with the newly spawned isolate.
-   *
-   * <p>Note: this is only necessary for applications using the V1 engine embedding API as plugins
-   * are automatically registered via reflection in the V2 engine embedding API. If not set,
-   * background message callbacks will not be able to utilize functionality from other plugins.
-   */
-  public static void setPluginRegistrant(
-      io.flutter.plugin.common.PluginRegistry.PluginRegistrantCallback callback) {
-    pluginRegistrantCallback = callback;
-  }
 
   /**
    * Sets the Dart callback handle for the Dart method that is responsible for initializing the
@@ -124,8 +109,6 @@ public class FlutterFirebaseMessagingBackgroundExecutor implements MethodCallHan
    * <ul>
    *   <li>The given callback must correspond to a registered Dart callback. If the handle does not
    *       resolve to a Dart callback then this method does nothing.
-   *   <li>A static {@link #pluginRegistrantCallback} must exist, otherwise a {@link
-   *       PluginRegistrantException} will be thrown.
    * </ul>
    */
   public void startBackgroundIsolate() {
@@ -153,8 +136,6 @@ public class FlutterFirebaseMessagingBackgroundExecutor implements MethodCallHan
    * <ul>
    *   <li>The given {@code callbackHandle} must correspond to a registered Dart callback. If the
    *       handle does not resolve to a Dart callback then this method does nothing.
-   *   <li>A static {@link #pluginRegistrantCallback} must exist, otherwise a {@link
-   *       PluginRegistrantException} will be thrown.
    * </ul>
    */
   public void startBackgroundIsolate(long callbackHandle, FlutterShellArgs shellArgs) {
@@ -199,13 +180,6 @@ public class FlutterFirebaseMessagingBackgroundExecutor implements MethodCallHan
                       new DartCallback(assets, appBundlePath, flutterCallback);
 
                   executor.executeDartCallback(dartCallback);
-
-                  // The pluginRegistrantCallback should only be set in the V1 embedding as
-                  // plugin registration is done via reflection in the V2 embedding.
-                  if (pluginRegistrantCallback != null) {
-                    pluginRegistrantCallback.registerWith(
-                        new ShimPluginRegistry(backgroundFlutterEngine));
-                  }
                 }
               });
         };

--- a/packages/firebase_messaging/firebase_messaging/android/src/main/java/io/flutter/plugins/firebase/messaging/FlutterFirebaseMessagingBackgroundExecutor.java
+++ b/packages/firebase_messaging/firebase_messaging/android/src/main/java/io/flutter/plugins/firebase/messaging/FlutterFirebaseMessagingBackgroundExecutor.java
@@ -144,16 +144,17 @@ public class FlutterFirebaseMessagingBackgroundExecutor implements MethodCallHan
       return;
     }
 
+    FlutterLoader loader = new FlutterLoader();
     Handler mainHandler = new Handler(Looper.getMainLooper());
     Runnable myRunnable =
         () -> {
-          io.flutter.view.FlutterMain.startInitialization(ContextHolder.getApplicationContext());
-          io.flutter.view.FlutterMain.ensureInitializationCompleteAsync(
+          loader.startInitialization(ContextHolder.getApplicationContext());
+          loader.ensureInitializationCompleteAsync(
               ContextHolder.getApplicationContext(),
               null,
               mainHandler,
               () -> {
-                String appBundlePath = io.flutter.view.FlutterMain.findAppBundlePath();
+                String appBundlePath = loader.findAppBundlePath();
                 AssetManager assets = ContextHolder.getApplicationContext().getAssets();
                 if (isNotRunning()) {
                   if (shellArgs != null) {

--- a/packages/firebase_messaging/firebase_messaging/android/src/main/java/io/flutter/plugins/firebase/messaging/FlutterFirebaseMessagingBackgroundService.java
+++ b/packages/firebase_messaging/firebase_messaging/android/src/main/java/io/flutter/plugins/firebase/messaging/FlutterFirebaseMessagingBackgroundService.java
@@ -97,23 +97,6 @@ public class FlutterFirebaseMessagingBackgroundService extends JobIntentService 
     FlutterFirebaseMessagingBackgroundExecutor.setUserCallbackHandle(callbackHandle);
   }
 
-  /**
-   * Sets the {@link io.flutter.plugin.common.PluginRegistry.PluginRegistrantCallback} used to
-   * register the plugins used by an application with the newly spawned background isolate.
-   *
-   * <p>This should be invoked in {@link MainApplication.onCreate} with {@link
-   * GeneratedPluginRegistrant} in applications using the V1 embedding API in order to use other
-   * plugins in the background isolate. For applications using the V2 embedding API, it is not
-   * necessary to set a {@link io.flutter.plugin.common.PluginRegistry.PluginRegistrantCallback} as
-   * plugins are registered automatically.
-   */
-  @SuppressWarnings({"deprecation", "JavadocReference"})
-  public static void setPluginRegistrant(
-      io.flutter.plugin.common.PluginRegistry.PluginRegistrantCallback callback) {
-    // Indirectly set in FlutterFirebaseMessagingBackgroundExecutor for backwards compatibility.
-    FlutterFirebaseMessagingBackgroundExecutor.setPluginRegistrant(callback);
-  }
-
   @Override
   public void onCreate() {
     super.onCreate();

--- a/packages/firebase_messaging/firebase_messaging/android/src/main/java/io/flutter/plugins/firebase/messaging/FlutterFirebaseMessagingPlugin.java
+++ b/packages/firebase_messaging/firebase_messaging/android/src/main/java/io/flutter/plugins/firebase/messaging/FlutterFirebaseMessagingPlugin.java
@@ -29,7 +29,6 @@ import io.flutter.plugin.common.MethodChannel;
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler;
 import io.flutter.plugin.common.MethodChannel.Result;
 import io.flutter.plugin.common.PluginRegistry.NewIntentListener;
-import io.flutter.plugin.common.PluginRegistry.Registrar;
 import io.flutter.plugins.firebase.core.FlutterFirebasePlugin;
 import java.util.HashMap;
 import java.util.Map;
@@ -48,14 +47,6 @@ public class FlutterFirebaseMessagingPlugin extends BroadcastReceiver
   private Activity mainActivity;
   private RemoteMessage initialMessage;
 
-  @SuppressWarnings("unused")
-  public static void registerWith(Registrar registrar) {
-    FlutterFirebaseMessagingPlugin instance = new FlutterFirebaseMessagingPlugin();
-    instance.setActivity(registrar.activity());
-    registrar.addNewIntentListener(instance);
-    instance.initInstance(registrar.messenger());
-  }
-
   private void initInstance(BinaryMessenger messenger) {
     String channelName = "plugins.flutter.io/firebase_messaging";
     channel = new MethodChannel(messenger, channelName);
@@ -72,24 +63,14 @@ public class FlutterFirebaseMessagingPlugin extends BroadcastReceiver
     registerPlugin(channelName, this);
   }
 
-  private void onAttachedToEngine(Context context, BinaryMessenger binaryMessenger) {
-    initInstance(binaryMessenger);
-  }
-
-  private void setActivity(Activity flutterActivity) {
-    this.mainActivity = flutterActivity;
-  }
-
   @Override
   public void onAttachedToEngine(FlutterPluginBinding binding) {
-    onAttachedToEngine(binding.getApplicationContext(), binding.getBinaryMessenger());
+    initInstance(binding.getBinaryMessenger());
   }
 
   @Override
   public void onDetachedFromEngine(@NonNull FlutterPluginBinding binding) {
-    if (binding.getApplicationContext() != null) {
-      LocalBroadcastManager.getInstance(binding.getApplicationContext()).unregisterReceiver(this);
-    }
+    LocalBroadcastManager.getInstance(binding.getApplicationContext()).unregisterReceiver(this);
   }
 
   @Override


### PR DESCRIPTION
## Description

This PR removes deprecated embedding functions from analytics, crashlytics, core and messaging.
It also migrates the use of FlutterMain to FlutterLoader in messaging since this is also deprecated.

## Related Issues

See #6745

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change. > Because embedding v2 is supported since flutter 1.12, and the minimum required for these packages is flutter 1.12, i don't think anyone will be affected.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
