### PR TITLE
fix(firebase_auth): null-safety migration issue for web types

### DIFF
--- a/packages/firebase_auth/firebase_auth_web/lib/src/interop/auth.dart
+++ b/packages/firebase_auth/firebase_auth_web/lib/src/interop/auth.dart
@@ -206,8 +206,8 @@ class User extends UserInfo<auth_interop.UserJsImpl> {
 
   /// Unlinks a provider with [providerId] from a user account.
   Future<User> unlink(String providerId) =>
-      handleThenable(jsObject.unlink(providerId)).then(
-          User.getInstance as FutureOr<User> Function(auth_interop.UserJsImpl));
+      handleThenable(jsObject.unlink(providerId))
+          .then((user) => User.getInstance(user)!);
 
   /// Updates the user's e-mail address to [newEmail].
   Future<void> updateEmail(String newEmail) =>


### PR DESCRIPTION
Fixes the failure in web tests [here](https://github.com/FirebaseExtended/flutterfire/pull/7111).