### PR TITLE
fix(firebase_messaging): Add Android implementation to get notification permissions

### DIFF
--- a/docs/messaging/usage.mdx
+++ b/docs/messaging/usage.mdx
@@ -94,7 +94,7 @@ The `authorizationStatus` property can return a value which can be used to deter
 - `notDetermined`: The user has not yet chosen whether to grant permission.
 - `provisional`: The user granted provisional permission (see [Provisional Permission](permissions#provisional-permission)).
 
-> On Android `authorizationStatus` is always `authorized`.
+> On Android `authorizationStatus` will return `authorized` if the user has not disabled notifications for the app via the operating systems settings.
 
 The other properties on `NotificationSettings` return whether a specific permission is enabled, disabled or not supported on the current
 device.

--- a/packages/firebase_messaging/firebase_messaging/android/src/main/java/io/flutter/plugins/firebase/messaging/FlutterFirebaseMessagingPlugin.java
+++ b/packages/firebase_messaging/firebase_messaging/android/src/main/java/io/flutter/plugins/firebase/messaging/FlutterFirebaseMessagingPlugin.java
@@ -13,6 +13,7 @@ import android.content.Intent;
 import android.content.IntentFilter;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.core.app.NotificationManagerCompat;
 import androidx.localbroadcastmanager.content.LocalBroadcastManager;
 import com.google.android.gms.tasks.Task;
 import com.google.android.gms.tasks.Tasks;
@@ -250,6 +251,18 @@ public class FlutterFirebaseMessagingPlugin extends BroadcastReceiver
         });
   }
 
+  private Task<Map<String, Integer>> getPermissions() {
+    return Tasks.call(
+        cachedThreadPool,
+        () -> {
+          final Map<String, Integer> permissions = new HashMap<>();
+          final boolean areNotificationsEnabled =
+              NotificationManagerCompat.from(mainActivity).areNotificationsEnabled();
+          permissions.put("authorizationStatus", areNotificationsEnabled ? 1 : 0);
+          return permissions;
+        });
+  }
+
   @Override
   public void onMethodCall(final MethodCall call, @NonNull final Result result) {
     Task<?> methodCallTask;
@@ -318,6 +331,10 @@ public class FlutterFirebaseMessagingPlugin extends BroadcastReceiver
         break;
       case "Messaging#setAutoInitEnabled":
         methodCallTask = setAutoInitEnabled(call.arguments());
+        break;
+      case "Messaging#requestPermission":
+      case "Messaging#getNotificationSettings":
+        methodCallTask = getPermissions();
         break;
       default:
         result.notImplemented();

--- a/packages/firebase_messaging/firebase_messaging/example/lib/permissions.dart
+++ b/packages/firebase_messaging/firebase_messaging/example/lib/permissions.dart
@@ -34,6 +34,21 @@ class _Permissions extends State<Permissions> {
     });
   }
 
+  Future<void> checkPermissions() async {
+    setState(() {
+      _fetching = true;
+    });
+
+    NotificationSettings settings =
+        await FirebaseMessaging.instance.getNotificationSettings();
+
+    setState(() {
+      _requested = true;
+      _fetching = false;
+      _settings = settings;
+    });
+  }
+
   Widget row(String title, String value) {
     return Container(
       margin: const EdgeInsets.only(bottom: 8),
@@ -72,7 +87,7 @@ class _Permissions extends State<Permissions> {
         row('Sound', settingsMap[_settings.sound]!),
       ],
       ElevatedButton(
-          onPressed: () => {}, child: const Text('Reload Permissions')),
+          onPressed: checkPermissions, child: const Text('Reload Permissions')),
     ]);
   }
 }

--- a/packages/firebase_messaging/firebase_messaging/lib/src/messaging.dart
+++ b/packages/firebase_messaging/firebase_messaging/lib/src/messaging.dart
@@ -137,10 +137,9 @@ class FirebaseMessaging extends FirebasePluginPlatform {
   ///
   ///  - On iOS, a dialog is shown requesting the users permission.
   ///  - On macOS, a notification will appear asking to grant permission.
-  ///  - On Android, is it not required to call this method. If called however,
-  ///    a [NotificationSettings] class will be returned with
-  ///    [NotificationSettings.authorizationStatus] returning the value whether 
-  ///    or not the app has notifications blocked in the system settings.
+  ///  - On Android, a [NotificationSettings] class will be returned with the
+  ///    value of [NotificationSettings.authorizationStatus] indicating whether
+  ///    the app has notifications enabled or blocked in the system settings.
   ///  - On Web, a popup requesting the users permission is shown using the native browser API.
   ///
   /// Note that on iOS, if [provisional] is set to `true`, silent notification permissions will be

--- a/packages/firebase_messaging/firebase_messaging/lib/src/messaging.dart
+++ b/packages/firebase_messaging/firebase_messaging/lib/src/messaging.dart
@@ -139,8 +139,8 @@ class FirebaseMessaging extends FirebasePluginPlatform {
   ///  - On macOS, a notification will appear asking to grant permission.
   ///  - On Android, is it not required to call this method. If called however,
   ///    a [NotificationSettings] class will be returned with
-  ///    [NotificationSettings.authorizationStatus] returning
-  ///    [AuthorizationStatus.authorized].
+  ///    [NotificationSettings.authorizationStatus] returning the value whether 
+  ///    or not the app has notifications blocked in the system settings.
   ///  - On Web, a popup requesting the users permission is shown using the native browser API.
   ///
   /// Note that on iOS, if [provisional] is set to `true`, silent notification permissions will be

--- a/packages/firebase_messaging/firebase_messaging/test/firebase_messaging_test.dart
+++ b/packages/firebase_messaging/firebase_messaging/test/firebase_messaging_test.dart
@@ -132,7 +132,7 @@ void main() {
           criticalAlert: anyNamed('criticalAlert'),
           provisional: anyNamed('provisional'),
           sound: anyNamed('sound'),
-        )).thenAnswer((_) => Future.value(androidNotificationSettings));
+        )).thenAnswer((_) => Future.value(defaultNotificationSettings));
 
         // true values
         await messaging!.requestPermission(

--- a/packages/firebase_messaging/firebase_messaging_platform_interface/lib/src/method_channel/method_channel_messaging.dart
+++ b/packages/firebase_messaging/firebase_messaging_platform_interface/lib/src/method_channel/method_channel_messaging.dart
@@ -233,8 +233,9 @@ class MethodChannelFirebaseMessaging extends FirebaseMessagingPlatform {
   @override
   Future<NotificationSettings> getNotificationSettings() async {
     if (defaultTargetPlatform != TargetPlatform.iOS &&
-        defaultTargetPlatform != TargetPlatform.macOS) {
-      return androidNotificationSettings;
+        defaultTargetPlatform != TargetPlatform.macOS &&
+        defaultTargetPlatform != TargetPlatform.android) {
+      return defaultNotificationSettings;
     }
 
     try {
@@ -250,17 +251,19 @@ class MethodChannelFirebaseMessaging extends FirebaseMessagingPlatform {
   }
 
   @override
-  Future<NotificationSettings> requestPermission(
-      {bool alert = true,
-      bool announcement = false,
-      bool badge = true,
-      bool carPlay = false,
-      bool criticalAlert = false,
-      bool provisional = false,
-      bool sound = true}) async {
+  Future<NotificationSettings> requestPermission({
+    bool alert = true,
+    bool announcement = false,
+    bool badge = true,
+    bool carPlay = false,
+    bool criticalAlert = false,
+    bool provisional = false,
+    bool sound = true,
+  }) async {
     if (defaultTargetPlatform != TargetPlatform.iOS &&
-        defaultTargetPlatform != TargetPlatform.macOS) {
-      return androidNotificationSettings;
+        defaultTargetPlatform != TargetPlatform.macOS &&
+        defaultTargetPlatform != TargetPlatform.android) {
+      return defaultNotificationSettings;
     }
 
     try {

--- a/packages/firebase_messaging/firebase_messaging_platform_interface/lib/src/utils.dart
+++ b/packages/firebase_messaging/firebase_messaging_platform_interface/lib/src/utils.dart
@@ -110,8 +110,8 @@ NotificationSettings convertToNotificationSettings(Map<String, int> map) {
   );
 }
 
-/// Used to return [NotificationSettings] for all Android devices.
-const NotificationSettings androidNotificationSettings = NotificationSettings(
+// Default [NotificationSettings] for platforms which do not require permissions
+const NotificationSettings defaultNotificationSettings = NotificationSettings(
   authorizationStatus: AuthorizationStatus.authorized,
   alert: AppleNotificationSetting.notSupported,
   announcement: AppleNotificationSetting.notSupported,


### PR DESCRIPTION
## Description

On Android, the plugin always returns permissions granted when queried for the notification permissions. Given an Android API exist for actually checking whether a user has notifications enabled or disabled for the app in the OS settings, it makes sense to utilise this API on Android.

- Update messaging plugin on android to use NotificationManagerCompat to get notification permissions.
- Renamed androidNotificationSettings to defaultNotificationSettings.
- Update the example add to give functionality to the reload permissions
  button.

## Related Issues

* #4492

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
