### PR TITLE
Implement rawData for remote message

### DIFF
--- a/packages/firebase_messaging/firebase_messaging_platform_interface/lib/src/remote_message.dart
+++ b/packages/firebase_messaging/firebase_messaging_platform_interface/lib/src/remote_message.dart
@@ -9,7 +9,8 @@ import 'package:firebase_messaging_platform_interface/firebase_messaging_platfor
 class RemoteMessage {
   // ignore: public_member_api_docs
   const RemoteMessage(
-      {this.senderId,
+      {required this.rawData,
+      this.senderId,
       this.category,
       this.collapseKey,
       this.contentAvailable = false,
@@ -49,8 +50,12 @@ class RemoteMessage {
               int.parse(map['sentTime'].toString())),
       threadId: map['threadId'],
       ttl: map['ttl'],
+      rawData: map,
     );
   }
+
+  /// The raw data sent from firebase
+  final Map<String, dynamic> rawData;
 
   /// The ID of the upstream sender location.
   final String? senderId;

--- a/packages/firebase_messaging/firebase_messaging_platform_interface/test/remote_message_test.dart
+++ b/packages/firebase_messaging/firebase_messaging_platform_interface/test/remote_message_test.dart
@@ -49,6 +49,7 @@ void main() {
     test('"RemoteMessage.fromMap" with every possible property expected', () {
       final message = RemoteMessage.fromMap(mockMessageMap!);
 
+      expect(message.rawData, mockMessageMap);
       expect(message.senderId, mockMessageMap!['senderId']);
       expect(message.category, mockMessageMap!['category']);
       expect(message.collapseKey, mockMessageMap!['collapseKey']);
@@ -79,6 +80,7 @@ void main() {
         () {
       final message = RemoteMessage.fromMap(mockNullableMessageMap);
 
+      expect(message.rawData, mockNullableMessageMap);
       expect(message.senderId, mockNullableMessageMap['senderId']);
       expect(message.category, mockNullableMessageMap['category']);
       expect(message.collapseKey, mockNullableMessageMap['collapseKey']);
@@ -99,6 +101,7 @@ void main() {
       DateTime date = DateTime.now();
 
       final message = RemoteMessage(
+        rawData: mockMessageMap!,
         senderId: mockMessageMap!['senderId'],
         category: mockMessageMap!['category'],
         collapseKey: mockMessageMap!['collapseKey'],
@@ -114,6 +117,7 @@ void main() {
         ttl: mockMessageMap!['ttl'],
       );
 
+      expect(message.rawData, mockMessageMap);
       expect(message.senderId, mockMessageMap!['senderId']);
       expect(message.category, mockMessageMap!['category']);
       expect(message.collapseKey, mockMessageMap!['collapseKey']);
@@ -147,8 +151,10 @@ void main() {
         'ttl': null
       };
 
-      RemoteMessage message = const RemoteMessage();
+      final emptyMap = <String, dynamic>{};
+      RemoteMessage message = const RemoteMessage(rawData: {});
 
+      expect(message.rawData, emptyMap);
       expect(message.senderId, mockNullableMessageMap['senderId']);
       expect(message.category, mockNullableMessageMap['category']);
       expect(message.collapseKey, mockNullableMessageMap['collapseKey']);


### PR DESCRIPTION
## Description

This PR is adding a new field to the RemoteMessage class, `rawData`, which simply contains the raw map as parsed by the plugin. This allows access to any additional keys not contained in the message, as well as better interoperability with other plugins which give access to the same data for local notifications for example.

## Related Issues

This is directly from #7259 but could potentially help with others such as #7258

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
