### PR TITLE
fix(firebase_analytics, ios): fix channel name

### DIFF
--- a/packages/firebase_analytics/firebase_analytics/ios/Classes/FLTFirebaseAnalyticsPlugin.m
+++ b/packages/firebase_analytics/firebase_analytics/ios/Classes/FLTFirebaseAnalyticsPlugin.m
@@ -22,7 +22,7 @@ NSString *const kAdStorage = @"adStorage";
 NSString *const kAnalyticsStorage = @"analyticsStorage";
 NSString *const kUserId = @"userId";
 
-NSString *const kFLTFirebaseCrashlyticsChannelName = @"plugins.flutter.io/firebase_analytics";
+NSString *const kFLTFirebaseAnalyticsChannelName = @"plugins.flutter.io/firebase_analytics";
 
 @implementation FLTFirebaseAnalyticsPlugin {
 }
@@ -42,7 +42,7 @@ NSString *const kFLTFirebaseCrashlyticsChannelName = @"plugins.flutter.io/fireba
 
 + (void)registerWithRegistrar:(NSObject<FlutterPluginRegistrar> *)registrar {
   FlutterMethodChannel *channel =
-      [FlutterMethodChannel methodChannelWithName:kFLTFirebaseCrashlyticsChannelName
+      [FlutterMethodChannel methodChannelWithName:kFLTFirebaseAnalyticsChannelName
                                   binaryMessenger:[registrar messenger]];
   FLTFirebaseAnalyticsPlugin *instance = [FLTFirebaseAnalyticsPlugin sharedInstance];
   [registrar addMethodCallDelegate:instance channel:channel];
@@ -185,7 +185,7 @@ NSString *const kFLTFirebaseCrashlyticsChannelName = @"plugins.flutter.io/fireba
 }
 
 - (NSString *_Nonnull)flutterChannelName {
-  return kFLTFirebaseCrashlyticsChannelName;
+  return kFLTFirebaseAnalyticsChannelName;
 }
 
 - (NSDictionary *_Nonnull)pluginConstantsForFIRApp:(FIRApp *_Nonnull)firebaseApp {


### PR DESCRIPTION
## Description

Fix `firebase_analytics` channel name which caused CI failure. 

## Related Issues

*Replace this paragraph with a list of issues related to this PR from the [issue database](https://github.com/flutter/flutter/issues). Indicate, which of these issues are resolved or fixed by this PR. Note that you'll have to prefix the issue numbers with flutter/flutter#.*

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
