### PR TITLE
feat: allow web to initialize from Dart lazily without crashing on missing initialization script

### DIFF
--- a/packages/cloud_firestore/cloud_firestore/example/web/index.html
+++ b/packages/cloud_firestore/cloud_firestore/example/web/index.html
@@ -1,13 +1,15 @@
 <!DOCTYPE html>
 <html>
+
 <head>
   <meta charset="UTF-8">
   <title>example</title>
 </head>
+
 <body>
   <script src="https://www.gstatic.com/firebasejs/8.6.1/firebase-app.js"></script>
   <script src="https://www.gstatic.com/firebasejs/8.6.1/firebase-firestore.js"></script>
-  <script>
+  <!-- <script>
     // Your web app's Firebase configuration
     var firebaseConfig = {
       apiKey: "AIzaSyAgUhHU8wSJgO5MVNy95tMT07NEjzMOfz0",
@@ -21,8 +23,8 @@
     };
     // Initialize Firebase
     firebase.initializeApp(firebaseConfig);
-  </script>
+  </script> -->
   <script src="main.dart.js" type="application/javascript"></script>
 </body>
-</html>
 
+</html>

--- a/packages/cloud_firestore/cloud_firestore_web/lib/cloud_firestore_web.dart
+++ b/packages/cloud_firestore/cloud_firestore_web/lib/cloud_firestore_web.dart
@@ -25,8 +25,14 @@ import 'src/interop/firestore.dart' as firestore_interop;
 /// Web implementation for [FirebaseFirestorePlatform]
 /// delegates calls to firestore web plugin
 class FirebaseFirestoreWeb extends FirebaseFirestorePlatform {
-  /// instance of Firestore from the web plugin
-  final firestore_interop.Firestore _webFirestore;
+  /// instance of Analytics from the web plugin
+  firestore_interop.Firestore? _webFirestore;
+
+  /// Lazily initialize [_webFirestore] on first method call
+  firestore_interop.Firestore get _delegate {
+    return _webFirestore ??=
+        firestore_interop.getFirestoreInstance(core_interop.app(app.name));
+  }
 
   /// Called by PluginRegistry to register this plugin for Flutter Web
   static void registerWith(Registrar registrar) {
@@ -35,10 +41,7 @@ class FirebaseFirestoreWeb extends FirebaseFirestorePlatform {
 
   /// Builds an instance of [FirebaseFirestoreWeb] with an optional [FirebaseApp] instance
   /// If [app] is null then the created instance will use the default [FirebaseApp]
-  FirebaseFirestoreWeb({FirebaseApp? app})
-      : _webFirestore =
-            firestore_interop.getFirestoreInstance(core_interop.app(app?.name)),
-        super(appInstance: app) {
+  FirebaseFirestoreWeb({FirebaseApp? app}) : super(appInstance: app) {
     FieldValueFactoryPlatform.instance = FieldValueFactoryWeb();
   }
 
@@ -50,55 +53,55 @@ class FirebaseFirestoreWeb extends FirebaseFirestorePlatform {
 
   @override
   CollectionReferencePlatform collection(String collectionPath) {
-    return CollectionReferenceWeb(this, _webFirestore, collectionPath);
+    return CollectionReferenceWeb(this, _delegate, collectionPath);
   }
 
   @override
-  WriteBatchPlatform batch() => WriteBatchWeb(_webFirestore);
+  WriteBatchPlatform batch() => WriteBatchWeb(_delegate);
 
   @override
   Future<void> clearPersistence() {
-    return guard(_webFirestore.clearPersistence);
+    return guard(_delegate.clearPersistence);
   }
 
   @override
   void useEmulator(String host, int port) {
-    return _webFirestore.useEmulator(host, port);
+    return _delegate.useEmulator(host, port);
   }
 
   @override
   QueryPlatform collectionGroup(String collectionPath) {
     return QueryWeb(
-        this, collectionPath, _webFirestore.collectionGroup(collectionPath),
+        this, collectionPath, _delegate.collectionGroup(collectionPath),
         isCollectionGroupQuery: true);
   }
 
   @override
   Future<void> disableNetwork() {
-    return guard(_webFirestore.disableNetwork);
+    return guard(_delegate.disableNetwork);
   }
 
   @override
   DocumentReferencePlatform doc(String documentPath) =>
-      DocumentReferenceWeb(this, _webFirestore, documentPath);
+      DocumentReferenceWeb(this, _delegate, documentPath);
 
   @override
   Future<void> enableNetwork() {
-    return guard(_webFirestore.enableNetwork);
+    return guard(_delegate.enableNetwork);
   }
 
   @override
   Stream<void> snapshotsInSync() {
-    return _webFirestore.snapshotsInSync();
+    return _delegate.snapshotsInSync();
   }
 
   @override
   Future<T?> runTransaction<T>(TransactionHandler<T> transactionHandler,
       {Duration timeout = const Duration(seconds: 30)}) async {
     await guard(() {
-      return _webFirestore.runTransaction((transaction) async {
+      return _delegate.runTransaction((transaction) async {
         return transactionHandler(
-            TransactionWeb(this, _webFirestore, transaction!));
+            TransactionWeb(this, _delegate, transaction!));
       }).timeout(timeout);
     });
     // Workaround for 'Runtime type information not available for type_variable_local'
@@ -126,12 +129,12 @@ class FirebaseFirestoreWeb extends FirebaseFirestorePlatform {
     }
 
     if (settings.host != null && settings.sslEnabled != null) {
-      _webFirestore.settings(firestore_interop.Settings(
+      _delegate.settings(firestore_interop.Settings(
           cacheSizeBytes: cacheSizeBytes,
           host: settings.host,
           ssl: settings.sslEnabled));
     } else {
-      _webFirestore
+      _delegate
           .settings(firestore_interop.Settings(cacheSizeBytes: cacheSizeBytes));
     }
   }
@@ -144,25 +147,25 @@ class FirebaseFirestoreWeb extends FirebaseFirestorePlatform {
           firestore_interop.PersistenceSettings(
               synchronizeTabs: settings.synchronizeTabs);
 
-      return guard(() => _webFirestore.enablePersistence(interopSettings));
+      return guard(() => _delegate.enablePersistence(interopSettings));
     }
 
-    return guard(_webFirestore.enablePersistence);
+    return guard(_delegate.enablePersistence);
   }
 
   @override
   Future<void> terminate() {
-    return guard(_webFirestore.terminate);
+    return guard(_delegate.terminate);
   }
 
   @override
   Future<void> waitForPendingWrites() {
-    return guard(_webFirestore.waitForPendingWrites);
+    return guard(_delegate.waitForPendingWrites);
   }
 
   @override
   LoadBundleTaskPlatform loadBundle(Uint8List bundle) {
-    return LoadBundleTaskWeb(_webFirestore.loadBundle(bundle));
+    return LoadBundleTaskWeb(_delegate.loadBundle(bundle));
   }
 
   @override
@@ -170,7 +173,7 @@ class FirebaseFirestoreWeb extends FirebaseFirestorePlatform {
     String name, {
     GetOptions options = const GetOptions(),
   }) async {
-    firestore_interop.Query? query = await _webFirestore.namedQuery(name);
+    firestore_interop.Query? query = await _delegate.namedQuery(name);
     firestore_interop.QuerySnapshot snapshot =
         await query.get(convertGetOptions(options));
 

--- a/packages/cloud_functions/cloud_functions/example/web/index.html
+++ b/packages/cloud_functions/cloud_functions/example/web/index.html
@@ -6,17 +6,19 @@
 
 <!DOCTYPE html>
 <html lang="en">
+
 <head>
     <meta charset="UTF-8">
     <title>Cloud Functions example app</title>
 </head>
-<body>
-<!-- The core Firebase JS SDK is always required and must be listed first -->
-<script src="https://www.gstatic.com/firebasejs/8.6.1/firebase-app.js"></script>
-<script src="https://www.gstatic.com/firebasejs/8.6.1/firebase-functions.js"></script>
 
-<!-- Initialize Firebase -->
-<script>
+<body>
+    <!-- The core Firebase JS SDK is always required and must be listed first -->
+    <script src="https://www.gstatic.com/firebasejs/8.6.1/firebase-app.js"></script>
+    <script src="https://www.gstatic.com/firebasejs/8.6.1/firebase-functions.js"></script>
+
+    <!-- Initialize Firebase -->
+    <!-- <script>
     const firebaseConfig = {
         apiKey: "AIzaSyAgUhHU8wSJgO5MVNy95tMT07NEjzMOfz0",
         authDomain: "react-native-firebase-testing.firebaseapp.com",
@@ -29,7 +31,8 @@
     };
     // Initialize Firebase
     let firebaseApp = firebase.initializeApp(firebaseConfig);
-</script>
-<script src="main.dart.js" type="application/javascript"></script>
+</script> -->
+    <script src="main.dart.js" type="application/javascript"></script>
 </body>
+
 </html>

--- a/packages/cloud_functions/cloud_functions_web/lib/cloud_functions_web.dart
+++ b/packages/cloud_functions/cloud_functions_web/lib/cloud_functions_web.dart
@@ -15,9 +15,7 @@ import 'interop/functions.dart' as functions_interop;
 class FirebaseFunctionsWeb extends FirebaseFunctionsPlatform {
   /// The entry point for the [FirebaseFunctionsWeb] class.
   FirebaseFunctionsWeb({FirebaseApp? app, required String region})
-      : _webFunctions = functions_interop.getFunctionsInstance(
-            core_interop.app(app?.name), region),
-        super(app, region);
+      : super(app, region);
 
   /// Stub initializer to allow the [registerWith] to create an instance without
   /// registering the web delegates or listeners.
@@ -26,7 +24,13 @@ class FirebaseFunctionsWeb extends FirebaseFunctionsPlatform {
         super(null, 'us-central1');
 
   /// Instance of functions from the web plugin
-  final functions_interop.Functions? _webFunctions;
+  functions_interop.Functions? _webFunctions;
+
+  /// Lazily initialize [_webFunctions] on first method call
+  functions_interop.Functions get _delegate {
+    return _webFunctions ??=
+        functions_interop.getFunctionsInstance(core_interop.app(app?.name));
+  }
 
   /// Create the default instance of the [FirebaseFunctionsPlatform] as a [FirebaseFunctionsWeb]
   static void registerWith(Registrar registrar) {
@@ -47,6 +51,6 @@ class FirebaseFunctionsWeb extends FirebaseFunctionsPlatform {
   @override
   HttpsCallablePlatform httpsCallable(
       String? origin, String name, HttpsCallableOptions options) {
-    return HttpsCallableWeb(this, _webFunctions!, origin, name, options);
+    return HttpsCallableWeb(this, _delegate, origin, name, options);
   }
 }

--- a/packages/firebase_analytics/firebase_analytics/example/web/index.html
+++ b/packages/firebase_analytics/firebase_analytics/example/web/index.html
@@ -1,5 +1,6 @@
 <!DOCTYPE html>
 <html>
+
 <head>
   <meta charset="UTF-8">
   <meta content="IE=Edge" http-equiv="X-UA-Compatible">
@@ -12,7 +13,7 @@
   <link rel="apple-touch-icon" href="icons/Icon-192.png">
 
   <!-- Favicon -->
-  <link rel="shortcut icon" type="image/png" href="favicon.png"/>
+  <link rel="shortcut icon" type="image/png" href="favicon.png" />
 
   <title>example</title>
   <link rel="manifest" href="manifest.json">
@@ -24,7 +25,7 @@
       https://firebase.google.com/docs/web/setup#available-libraries -->
   <script src="https://www.gstatic.com/firebasejs/8.6.1/firebase-analytics.js"></script>
 
-  <script>
+  <!-- <script>
     // Your web app's Firebase configuration
     var firebaseConfig = {
       apiKey: "AIzaSyAgUhHU8wSJgO5MVNy95tMT07NEjzMOfz0",
@@ -39,10 +40,11 @@
     // Initialize Firebase
     firebase.initializeApp(firebaseConfig);
     firebase.analytics();
-  </script>
+  </script> -->
 
 
 </head>
+
 <body>
   <!-- This script installs service_worker.js to provide PWA functionality to
        application. For more information, see:
@@ -56,4 +58,5 @@
   </script>
   <script src="main.dart.js" type="application/javascript"></script>
 </body>
+
 </html>

--- a/packages/firebase_analytics/firebase_analytics_web/lib/firebase_analytics_web.dart
+++ b/packages/firebase_analytics/firebase_analytics_web/lib/firebase_analytics_web.dart
@@ -13,14 +13,17 @@ import 'interop/analytics.dart' as analytics_interop;
 /// Web implementation of [FirebaseAnalyticsPlatform]
 class FirebaseAnalyticsWeb extends FirebaseAnalyticsPlatform {
   /// instance of Analytics from the web plugin
-  final analytics_interop.Analytics _webAnalytics;
+  analytics_interop.Analytics? _webAnalytics;
+
+  /// Lazily initialize [_webAnalytics] on first method call
+  analytics_interop.Analytics get _delegate {
+    return _webAnalytics ??=
+        analytics_interop.getAnalyticsInstance(core_interop.app(app.name));
+  }
 
   /// Builds an instance of [FirebaseAnalyticsWeb] with an optional [FirebaseApp] instance
   /// If [app] is null then the created instance will use the default [FirebaseApp]
-  FirebaseAnalyticsWeb({FirebaseApp? app})
-      : _webAnalytics =
-            analytics_interop.getAnalyticsInstance(core_interop.app(app?.name)),
-        super(appInstance: app);
+  FirebaseAnalyticsWeb({FirebaseApp? app}) : super(appInstance: app);
 
   /// Called by PluginRegistry to register this plugin for Flutter Web
   static void registerWith(Registrar registrar) {
@@ -38,7 +41,7 @@ class FirebaseAnalyticsWeb extends FirebaseAnalyticsPlatform {
     Map<String, Object?>? parameters,
     CallOptions? callOptions,
   }) async {
-    _webAnalytics.logEvent(
+    _delegate.logEvent(
       name: name,
       parameters: parameters ?? {},
       callOptions: callOptions,
@@ -53,7 +56,7 @@ class FirebaseAnalyticsWeb extends FirebaseAnalyticsPlatform {
 
   @override
   Future<void> setAnalyticsCollectionEnabled(bool enabled) async {
-    _webAnalytics.setAnalyticsCollectionEnabled(enabled: enabled);
+    _delegate.setAnalyticsCollectionEnabled(enabled: enabled);
   }
 
   @override
@@ -61,7 +64,7 @@ class FirebaseAnalyticsWeb extends FirebaseAnalyticsPlatform {
     String? id,
     CallOptions? callOptions,
   }) async {
-    _webAnalytics.setUserId(
+    _delegate.setUserId(
       id: id,
       callOptions: callOptions,
     );
@@ -73,7 +76,7 @@ class FirebaseAnalyticsWeb extends FirebaseAnalyticsPlatform {
     String? screenClassOverride,
     CallOptions? callOptions,
   }) async {
-    _webAnalytics.setCurrentScreen(
+    _delegate.setCurrentScreen(
       screenName: screenName,
       callOptions: callOptions,
     );
@@ -90,7 +93,7 @@ class FirebaseAnalyticsWeb extends FirebaseAnalyticsPlatform {
     required Object value,
     CallOptions? callOptions,
   }) async {
-    _webAnalytics.setUserProperty(
+    _delegate.setUserProperty(
       name: name,
       value: value,
       callOptions: callOptions,

--- a/packages/firebase_app_check/firebase_app_check_web/lib/firebase_app_check_web.dart
+++ b/packages/firebase_app_check/firebase_app_check_web/lib/firebase_app_check_web.dart
@@ -18,9 +18,7 @@ class FirebaseAppCheckWeb extends FirebaseAppCheckPlatform {
         super(appInstance: null);
 
   /// The entry point for the [FirebaseAuthWeb] class.
-  FirebaseAppCheckWeb({required FirebaseApp app})
-      : _webAppCheck = app_check_interop.getAppCheckInstance(),
-        super(appInstance: app);
+  FirebaseAppCheckWeb({required FirebaseApp app}) : super(appInstance: app);
 
   /// Called by PluginRegistry to register this plugin for Flutter Web
   static void registerWith(Registrar registrar) {
@@ -33,7 +31,12 @@ class FirebaseAppCheckWeb extends FirebaseAppCheckPlatform {
   }
 
   /// instance of AppCheck from the web plugin
-  final app_check_interop.AppCheck? _webAppCheck;
+  app_check_interop.AppCheck? _webAppCheck;
+
+  /// Lazily initialize [_webAppCheck] on first method call
+  app_check_interop.AppCheck get _delegate {
+    return _webAppCheck ??= app_check_interop.getAppCheckInstance();
+  }
 
   @override
   FirebaseAppCheckWeb setInitialValues() {
@@ -43,6 +46,6 @@ class FirebaseAppCheckWeb extends FirebaseAppCheckPlatform {
   @override
   Future<void> activate({String? webRecaptchaSiteKey}) async {
     return guard<Future<void>>(
-        () async => _webAppCheck!.activate(webRecaptchaSiteKey));
+        () async => _delegate.activate(webRecaptchaSiteKey));
   }
 }

--- a/packages/firebase_auth/firebase_auth/example/web/index.html
+++ b/packages/firebase_auth/firebase_auth/example/web/index.html
@@ -1,14 +1,17 @@
 <!DOCTYPE html>
 <html>
+
 <head>
   <meta charset="UTF-8">
-  <meta name="google-signin-client_id" content="159623150305-q05bbbtsutr02abhips3suj7hujfk4bg.apps.googleusercontent.com" />
+  <meta name="google-signin-client_id"
+    content="159623150305-q05bbbtsutr02abhips3suj7hujfk4bg.apps.googleusercontent.com" />
   <title>Firebase Auth Example</title>
 </head>
+
 <body>
   <script src="https://www.gstatic.com/firebasejs/8.6.1/firebase-app.js"></script>
   <script src="https://www.gstatic.com/firebasejs/8.6.1/firebase-auth.js"></script>
-  <script>
+  <!-- <script>
     // Your web app's Firebase configuration
     var firebaseConfig = {
       apiKey: "AIzaSyAgUhHU8wSJgO5MVNy95tMT07NEjzMOfz0",
@@ -22,7 +25,8 @@
     };
     // Initialize Firebase
     firebase.initializeApp(firebaseConfig);
-  </script>
+  </script> -->
   <script src="main.dart.js" type="application/javascript"></script>
 </body>
+
 </html>

--- a/packages/firebase_auth/firebase_auth_web/lib/firebase_auth_web.dart
+++ b/packages/firebase_auth/firebase_auth_web/lib/firebase_auth_web.dart
@@ -29,9 +29,7 @@ class FirebaseAuthWeb extends FirebaseAuthPlatform {
   Completer<void> _initialized = Completer();
 
   /// The entry point for the [FirebaseAuthWeb] class.
-  FirebaseAuthWeb({required FirebaseApp app})
-      : _webAuth = auth_interop.getAuthInstance(core_interop.app(app.name)),
-        super(appInstance: app) {
+  FirebaseAuthWeb({required FirebaseApp app}) : super(appInstance: app) {
     // Create a app instance broadcast stream for both delegate listener events
     _userChangesListeners[app.name] =
         StreamController<UserPlatform?>.broadcast();
@@ -41,7 +39,7 @@ class FirebaseAuthWeb extends FirebaseAuthPlatform {
         StreamController<UserPlatform?>.broadcast();
 
     // TODO(rrousselGit): close StreamSubscription
-    _webAuth!.onAuthStateChanged.map((auth_interop.User? webUser) {
+    _delegate.onAuthStateChanged.map((auth_interop.User? webUser) {
       if (!_initialized.isCompleted) {
         _initialized.complete();
       }
@@ -57,7 +55,7 @@ class FirebaseAuthWeb extends FirebaseAuthPlatform {
 
     // TODO(rrousselGit): close StreamSubscription
     // Also triggers `userChanged` events
-    _webAuth!.onIdTokenChanged.map((auth_interop.User? webUser) {
+    _delegate.onIdTokenChanged.map((auth_interop.User? webUser) {
       if (webUser == null) {
         return null;
       } else {
@@ -91,7 +89,12 @@ class FirebaseAuthWeb extends FirebaseAuthPlatform {
   }
 
   /// instance of Auth from the web plugin
-  final auth_interop.Auth? _webAuth;
+  auth_interop.Auth? _webAuth;
+
+  auth_interop.Auth get _delegate {
+    return _webAuth ??=
+        auth_interop.getAuthInstance(core_interop.app(app.name));
+  }
 
   @override
   FirebaseAuthPlatform delegateFor({required FirebaseApp app}) {
@@ -109,23 +112,23 @@ class FirebaseAuthWeb extends FirebaseAuthPlatform {
 
   @override
   UserPlatform? get currentUser {
-    auth_interop.User? webCurrentUser = _webAuth!.currentUser;
+    auth_interop.User? webCurrentUser = _delegate.currentUser;
 
     if (webCurrentUser == null) {
       return null;
     }
 
-    return UserWeb(this, _webAuth!.currentUser!);
+    return UserWeb(this, _delegate.currentUser!);
   }
 
   @override
   String? get tenantId {
-    return _webAuth!.tenantId;
+    return _delegate.tenantId;
   }
 
   @override
   set tenantId(String? tenantId) {
-    _webAuth!.tenantId = tenantId;
+    _delegate.tenantId = tenantId;
   }
 
   @override
@@ -138,7 +141,7 @@ class FirebaseAuthWeb extends FirebaseAuthPlatform {
   @override
   Future<void> applyActionCode(String code) async {
     try {
-      await _webAuth!.applyActionCode(code);
+      await _delegate.applyActionCode(code);
     } catch (e) {
       throw getFirebaseAuthException(e);
     }
@@ -147,7 +150,7 @@ class FirebaseAuthWeb extends FirebaseAuthPlatform {
   @override
   Future<ActionCodeInfo> checkActionCode(String code) async {
     try {
-      return convertWebActionCodeInfo(await _webAuth!.checkActionCode(code))!;
+      return convertWebActionCodeInfo(await _delegate.checkActionCode(code))!;
     } catch (e) {
       throw getFirebaseAuthException(e);
     }
@@ -156,7 +159,7 @@ class FirebaseAuthWeb extends FirebaseAuthPlatform {
   @override
   Future<void> confirmPasswordReset(String code, String newPassword) async {
     try {
-      await _webAuth!.confirmPasswordReset(code, newPassword);
+      await _delegate.confirmPasswordReset(code, newPassword);
     } catch (e) {
       throw getFirebaseAuthException(e);
     }
@@ -168,7 +171,7 @@ class FirebaseAuthWeb extends FirebaseAuthPlatform {
     try {
       return UserCredentialWeb(
         this,
-        await _webAuth!.createUserWithEmailAndPassword(email, password),
+        await _delegate.createUserWithEmailAndPassword(email, password),
       );
     } catch (e) {
       throw getFirebaseAuthException(e);
@@ -178,7 +181,7 @@ class FirebaseAuthWeb extends FirebaseAuthPlatform {
   @override
   Future<List<String>> fetchSignInMethodsForEmail(String email) async {
     try {
-      return await _webAuth!.fetchSignInMethodsForEmail(email);
+      return await _delegate.fetchSignInMethodsForEmail(email);
     } catch (e) {
       throw getFirebaseAuthException(e);
     }
@@ -187,7 +190,7 @@ class FirebaseAuthWeb extends FirebaseAuthPlatform {
   @override
   Future<UserCredentialPlatform> getRedirectResult() async {
     try {
-      return UserCredentialWeb(this, await _webAuth!.getRedirectResult());
+      return UserCredentialWeb(this, await _delegate.getRedirectResult());
     } catch (e) {
       throw getFirebaseAuthException(e);
     }
@@ -220,7 +223,7 @@ class FirebaseAuthWeb extends FirebaseAuthPlatform {
     ActionCodeSettings? actionCodeSettings,
   ]) async {
     try {
-      await _webAuth!.sendPasswordResetEmail(
+      await _delegate.sendPasswordResetEmail(
           email, convertPlatformActionCodeSettings(actionCodeSettings));
     } catch (e) {
       throw getFirebaseAuthException(e);
@@ -233,7 +236,7 @@ class FirebaseAuthWeb extends FirebaseAuthPlatform {
     ActionCodeSettings? actionCodeSettings,
   ]) async {
     try {
-      await _webAuth!.sendSignInLinkToEmail(
+      await _delegate.sendSignInLinkToEmail(
           email, convertPlatformActionCodeSettings(actionCodeSettings));
     } catch (e) {
       throw getFirebaseAuthException(e);
@@ -242,12 +245,12 @@ class FirebaseAuthWeb extends FirebaseAuthPlatform {
 
   @override
   String get languageCode {
-    return _webAuth!.languageCode;
+    return _delegate.languageCode;
   }
 
   @override
   Future<void> setLanguageCode(String? languageCode) async {
-    _webAuth!.languageCode = languageCode;
+    _delegate.languageCode = languageCode;
   }
 
   @override
@@ -258,14 +261,14 @@ class FirebaseAuthWeb extends FirebaseAuthPlatform {
     String? smsCode,
     bool? forceRecaptchaFlow,
   }) async {
-    _webAuth!.settings.appVerificationDisabledForTesting =
+    _delegate.settings.appVerificationDisabledForTesting =
         appVerificationDisabledForTesting;
   }
 
   @override
   Future<void> setPersistence(Persistence persistence) async {
     try {
-      return _webAuth!.setPersistence(convertPlatformPersistence(persistence));
+      return _delegate.setPersistence(convertPlatformPersistence(persistence));
     } catch (e) {
       throw getFirebaseAuthException(e);
     }
@@ -274,7 +277,7 @@ class FirebaseAuthWeb extends FirebaseAuthPlatform {
   @override
   Future<UserCredentialPlatform> signInAnonymously() async {
     try {
-      return UserCredentialWeb(this, await _webAuth!.signInAnonymously());
+      return UserCredentialWeb(this, await _delegate.signInAnonymously());
     } catch (e) {
       throw getFirebaseAuthException(e);
     }
@@ -286,7 +289,7 @@ class FirebaseAuthWeb extends FirebaseAuthPlatform {
     try {
       return UserCredentialWeb(
           this,
-          await _webAuth!
+          await _delegate
               .signInWithCredential(convertPlatformCredential(credential)!));
     } catch (e) {
       throw getFirebaseAuthException(e);
@@ -297,7 +300,7 @@ class FirebaseAuthWeb extends FirebaseAuthPlatform {
   Future<UserCredentialPlatform> signInWithCustomToken(String token) async {
     try {
       return UserCredentialWeb(
-          this, await _webAuth!.signInWithCustomToken(token));
+          this, await _delegate.signInWithCustomToken(token));
     } catch (e) {
       throw getFirebaseAuthException(e);
     }
@@ -308,7 +311,7 @@ class FirebaseAuthWeb extends FirebaseAuthPlatform {
       String email, String password) async {
     try {
       return UserCredentialWeb(
-          this, await _webAuth!.signInWithEmailAndPassword(email, password));
+          this, await _delegate.signInWithEmailAndPassword(email, password));
     } catch (e) {
       throw getFirebaseAuthException(e);
     }
@@ -319,7 +322,7 @@ class FirebaseAuthWeb extends FirebaseAuthPlatform {
       String email, String emailLink) async {
     try {
       return UserCredentialWeb(
-          this, await _webAuth!.signInWithEmailLink(email, emailLink));
+          this, await _delegate.signInWithEmailLink(email, emailLink));
     } catch (e) {
       throw getFirebaseAuthException(e);
     }
@@ -335,7 +338,7 @@ class FirebaseAuthWeb extends FirebaseAuthPlatform {
       auth_interop.RecaptchaVerifier verifier = applicationVerifier.delegate;
 
       return ConfirmationResultWeb(
-          this, await _webAuth!.signInWithPhoneNumber(phoneNumber, verifier));
+          this, await _delegate.signInWithPhoneNumber(phoneNumber, verifier));
     } catch (e) {
       throw getFirebaseAuthException(e);
     }
@@ -346,7 +349,7 @@ class FirebaseAuthWeb extends FirebaseAuthPlatform {
     try {
       return UserCredentialWeb(
         this,
-        await _webAuth!.signInWithPopup(convertPlatformAuthProvider(provider)),
+        await _delegate.signInWithPopup(convertPlatformAuthProvider(provider)),
       );
     } catch (e) {
       throw getFirebaseAuthException(e);
@@ -356,7 +359,7 @@ class FirebaseAuthWeb extends FirebaseAuthPlatform {
   @override
   Future<void> signInWithRedirect(AuthProvider provider) async {
     try {
-      return _webAuth!
+      return _delegate
           .signInWithRedirect(convertPlatformAuthProvider(provider));
     } catch (e) {
       throw getFirebaseAuthException(e);
@@ -366,7 +369,7 @@ class FirebaseAuthWeb extends FirebaseAuthPlatform {
   @override
   Future<void> signOut() async {
     try {
-      await _webAuth!.signOut();
+      await _delegate.signOut();
     } catch (e) {
       throw getFirebaseAuthException(e);
     }
@@ -378,7 +381,7 @@ class FirebaseAuthWeb extends FirebaseAuthPlatform {
       // The generic platform interface is with host and port split to
       // centralize logic between android/ios native, but web takes the
       // origin as a single string
-      _webAuth!.useAuthEmulator('http://$host:$port');
+      _delegate.useAuthEmulator('http://$host:$port');
     } catch (e) {
       throw getFirebaseAuthException(e);
     }
@@ -387,7 +390,7 @@ class FirebaseAuthWeb extends FirebaseAuthPlatform {
   @override
   Future<String> verifyPasswordResetCode(String code) async {
     try {
-      return await _webAuth!.verifyPasswordResetCode(code);
+      return await _delegate.verifyPasswordResetCode(code);
     } catch (e) {
       throw getFirebaseAuthException(e);
     }

--- a/packages/firebase_core/firebase_core/example/web/index.html
+++ b/packages/firebase_core/firebase_core/example/web/index.html
@@ -1,13 +1,15 @@
 <!DOCTYPE html>
 <html>
+
 <head>
   <meta charset="UTF-8">
   <title>Firebase Core Example</title>
 </head>
+
 <body>
   <script src="https://www.gstatic.com/firebasejs/8.6.1/firebase-app.js"></script>
   <!-- Initialize Firebase -->
-  <script>
+  <!-- <script>
     var firebaseConfig = {
       apiKey: "AIzaSyAgUhHU8wSJgO5MVNy95tMT07NEjzMOfz0",
       authDomain: "react-native-firebase-testing.firebaseapp.com",
@@ -21,7 +23,8 @@
     // Initialize Firebase
     firebase.initializeApp(firebaseConfig);
     firebase.analytics();
-  </script>
+  </script> -->
   <script src="main.dart.js" type="application/javascript"></script>
 </body>
+
 </html>

--- a/packages/firebase_database/firebase_database/example/web/index.html
+++ b/packages/firebase_database/firebase_database/example/web/index.html
@@ -1,13 +1,15 @@
 <!DOCTYPE html>
 <html>
+
 <head>
   <meta charset="UTF-8">
   <title>example</title>
 </head>
+
 <body>
   <script src="https://www.gstatic.com/firebasejs/8.6.1/firebase-app.js"></script>
   <script src="https://www.gstatic.com/firebasejs/8.6.1/firebase-database.js"></script>
-  <script>
+  <!-- <script>
     // Your web app's Firebase configuration
     var firebaseConfig = {
       apiKey: "AIzaSyAgUhHU8wSJgO5MVNy95tMT07NEjzMOfz0",
@@ -21,8 +23,8 @@
     };
     // Initialize Firebase
     firebase.initializeApp(firebaseConfig);
-  </script>
+  </script> -->
   <script src="main.dart.js" type="application/javascript"></script>
 </body>
-</html>
 
+</html>

--- a/packages/firebase_database/firebase_database_web/lib/firebase_database_web.dart
+++ b/packages/firebase_database/firebase_database_web/lib/firebase_database_web.dart
@@ -21,7 +21,16 @@ part './src/utils/snapshot_utils.dart';
 /// delegates calls to firebase web plugin
 class FirebaseDatabaseWeb extends DatabasePlatform {
   /// Instance of Database from web plugin
-  final database_interop.Database _firebaseDatabase;
+  database_interop.Database? _firebaseDatabase;
+
+  /// Lazily initialize [_firebaseDatabase] on first method call
+  database_interop.Database get _delegate {
+    return _firebaseDatabase ??=
+        _firebaseDatabase = database_interop.getDatabaseInstance(
+      database_interop.getApp(app?.name),
+      databaseURL,
+    );
+  }
 
   /// Called by PluginRegistry to register this plugin for Flutter Web
   static void registerWith(Registrar registrar) {
@@ -31,11 +40,7 @@ class FirebaseDatabaseWeb extends DatabasePlatform {
   /// Builds an instance of [DatabaseWeb] with an optional [FirebaseApp] instance
   /// If [app] is null then the created instance will use the default [FirebaseApp]
   FirebaseDatabaseWeb({FirebaseApp? app, String? databaseURL})
-      : _firebaseDatabase = database_interop.getDatabaseInstance(
-          database_interop.getApp(app?.name),
-          databaseURL,
-        ),
-        super(app: app, databaseURL: databaseURL);
+      : super(app: app, databaseURL: databaseURL);
 
   @override
   DatabasePlatform withApp(FirebaseApp? app, String? databaseURL) =>
@@ -46,7 +51,7 @@ class FirebaseDatabaseWeb extends DatabasePlatform {
 
   @override
   DatabaseReferencePlatform reference() {
-    return DatabaseReferenceWeb(_firebaseDatabase, this, <String>[]);
+    return DatabaseReferenceWeb(_delegate, this, <String>[]);
   }
 
   /// This is not supported on web. However,
@@ -76,12 +81,12 @@ class FirebaseDatabaseWeb extends DatabasePlatform {
 
   @override
   Future<void> goOnline() async {
-    _firebaseDatabase.goOnline();
+    _delegate.goOnline();
   }
 
   @override
   Future<void> goOffline() async {
-    _firebaseDatabase.goOffline();
+    _delegate.goOffline();
   }
 
   @override

--- a/packages/firebase_messaging/firebase_messaging/example/web/index.html
+++ b/packages/firebase_messaging/firebase_messaging/example/web/index.html
@@ -1,13 +1,15 @@
 <!DOCTYPE html>
 <html>
+
 <head>
   <meta charset="UTF-8">
   <title>example</title>
 </head>
+
 <body>
   <script src="https://www.gstatic.com/firebasejs/8.6.1/firebase-app.js"></script>
   <script src="https://www.gstatic.com/firebasejs/8.6.1/firebase-messaging.js"></script>
-  <script>
+  <!-- <script>
     // Your web app's Firebase configuration
     var firebaseConfig = {
       apiKey: "AIzaSyAgUhHU8wSJgO5MVNy95tMT07NEjzMOfz0",
@@ -21,7 +23,7 @@
     };
   // Initialize Firebase
   firebase.initializeApp(firebaseConfig);
-  </script>
+  </script> -->
   <script src="main.dart.js" type="application/javascript"></script>
   <script>
     var serviceWorkerVersion = null;
@@ -91,4 +93,5 @@
     }
   </script>
 </body>
+
 </html>

--- a/packages/firebase_performance/firebase_performance_web/lib/firebase_performance_web.dart
+++ b/packages/firebase_performance/firebase_performance_web/lib/firebase_performance_web.dart
@@ -9,11 +9,16 @@ import 'src/http_metric.dart';
 /// Web implementation for [FirebasePerformancePlatform]
 class FirebasePerformanceWeb extends FirebasePerformancePlatform {
   /// Instance of Performance from the web plugin.
-  final firebase.Performance _performance;
+  firebase.Performance? _performance;
+
+  /// Lazily initialize [_webRemoteConfig] on first method call
+  firebase.Performance get _delegate {
+    return _performance ??= firebase.performance();
+  }
 
   /// A constructor that allows tests to override the firebase.Performance object.
   FirebasePerformanceWeb({firebase.Performance? performance})
-      : _performance = performance ?? firebase.performance(),
+      : _performance = performance,
         super();
 
   /// Called by PluginRegistry to register this plugin for Flutter Web
@@ -41,7 +46,7 @@ class FirebasePerformanceWeb extends FirebasePerformancePlatform {
 
   @override
   TracePlatform newTrace(String name) {
-    return TraceWeb(_performance.trace(name), name);
+    return TraceWeb(_delegate.trace(name), name);
   }
 
   @override

--- a/packages/firebase_remote_config/firebase_remote_config_web/lib/firebase_remote_config_web.dart
+++ b/packages/firebase_remote_config/firebase_remote_config_web/lib/firebase_remote_config_web.dart
@@ -12,11 +12,7 @@ import 'src/interop/firebase_remote_config.dart' as remote_config_interop;
 /// Web implementation of [FirebaseRemoteConfigPlatform].
 class FirebaseRemoteConfigWeb extends FirebaseRemoteConfigPlatform {
   /// The entry point for the [FirebaseRemoteConfigWeb] class.
-  FirebaseRemoteConfigWeb({FirebaseApp? app})
-      : _webRemoteConfig = remote_config_interop.getRemoteConfigInstance(
-          core_interop.app(app?.name),
-        ),
-        super(appInstance: app);
+  FirebaseRemoteConfigWeb({FirebaseApp? app}) : super(appInstance: app);
 
   /// Stub initializer to allow the [registerWith] to create an instance without
   /// registering the web delegates or listeners.
@@ -25,7 +21,14 @@ class FirebaseRemoteConfigWeb extends FirebaseRemoteConfigPlatform {
         super(appInstance: null);
 
   /// Instance of functions from the web plugin
-  final remote_config_interop.RemoteConfig? _webRemoteConfig;
+  remote_config_interop.RemoteConfig? _webRemoteConfig;
+
+  /// Lazily initialize [_webRemoteConfig] on first method call
+  remote_config_interop.RemoteConfig get _delegate {
+    return _webRemoteConfig ??= remote_config_interop.getRemoteConfigInstance(
+      core_interop.app(app.name),
+    );
+  }
 
   /// Create the default instance of the [FirebaseRemoteConfigPlatform] as a [FirebaseRemoteConfigWeb]
   static void registerWith(Registrar registrar) {
@@ -55,13 +58,13 @@ class FirebaseRemoteConfigWeb extends FirebaseRemoteConfigPlatform {
   /// the epoch (1970-01-01 UTC) is returned.
   @override
   DateTime get lastFetchTime {
-    return _webRemoteConfig!.fetchTime;
+    return _delegate.fetchTime;
   }
 
   /// Returns the status of the last fetch attempt.
   @override
   RemoteConfigFetchStatus get lastFetchStatus {
-    switch (_webRemoteConfig!.lastFetchStatus) {
+    switch (_delegate.lastFetchStatus) {
       case remote_config_interop.RemoteConfigFetchStatus.failure:
         return RemoteConfigFetchStatus.failure;
       case remote_config_interop.RemoteConfigFetchStatus.success:
@@ -77,8 +80,8 @@ class FirebaseRemoteConfigWeb extends FirebaseRemoteConfigPlatform {
   @override
   RemoteConfigSettings get settings {
     return RemoteConfigSettings(
-      fetchTimeout: _webRemoteConfig!.settings.fetchTimeoutMillis,
-      minimumFetchInterval: _webRemoteConfig!.settings.minimumFetchInterval,
+      fetchTimeout: _delegate.settings.fetchTimeoutMillis,
+      minimumFetchInterval: _delegate.settings.minimumFetchInterval,
     );
   }
 
@@ -89,19 +92,19 @@ class FirebaseRemoteConfigWeb extends FirebaseRemoteConfigPlatform {
   /// config parameters were already activated.
   @override
   Future<bool> activate() {
-    return _webRemoteConfig!.activate();
+    return _delegate.activate();
   }
 
   /// Ensures the last activated config are available to getters.
   @override
   Future<void> ensureInitialized() {
-    return _webRemoteConfig!.ensureInitialized();
+    return _delegate.ensureInitialized();
   }
 
   /// Fetches and caches configuration from the Remote Config service.
   @override
   Future<void> fetch() {
-    return _webRemoteConfig!.fetch();
+    return _delegate.fetch();
   }
 
   /// Performs a fetch and activate operation, as a convenience.
@@ -109,59 +112,58 @@ class FirebaseRemoteConfigWeb extends FirebaseRemoteConfigPlatform {
   /// Returns [bool] in the same way that is done for [activate].
   @override
   Future<bool> fetchAndActivate() {
-    return _webRemoteConfig!.fetchAndActivate();
+    return _delegate.fetchAndActivate();
   }
 
   /// Returns a Map of all Remote Config parameters.
   @override
   Map<String, RemoteConfigValue> getAll() {
-    return _webRemoteConfig!.getAll();
+    return _delegate.getAll();
   }
 
   /// Gets the value for a given key as a bool.
   @override
   bool getBool(String key) {
-    return _webRemoteConfig!.getBoolean(key);
+    return _delegate.getBoolean(key);
   }
 
   /// Gets the value for a given key as an int.
   @override
   int getInt(String key) {
-    return _webRemoteConfig!.getNumber(key).toInt();
+    return _delegate.getNumber(key).toInt();
   }
 
   /// Gets the value for a given key as a double.
   @override
   double getDouble(String key) {
-    return _webRemoteConfig!.getNumber(key).toDouble();
+    return _delegate.getNumber(key).toDouble();
   }
 
   /// Gets the value for a given key as a String.
   @override
   String getString(String key) {
-    return _webRemoteConfig!.getString(key);
+    return _delegate.getString(key);
   }
 
   /// Gets the [RemoteConfigValue] for a given key.
   @override
   RemoteConfigValue getValue(String key) {
-    return _webRemoteConfig!.getValue(key);
+    return _delegate.getValue(key);
   }
 
   /// Sets the [RemoteConfigSettings] for the current instance.
   @override
   Future<void> setConfigSettings(RemoteConfigSettings remoteConfigSettings) {
-    _webRemoteConfig!.settings.minimumFetchInterval =
+    _delegate.settings.minimumFetchInterval =
         remoteConfigSettings.minimumFetchInterval;
-    _webRemoteConfig!.settings.fetchTimeoutMillis =
-        remoteConfigSettings.fetchTimeout;
+    _delegate.settings.fetchTimeoutMillis = remoteConfigSettings.fetchTimeout;
     return Future<void>.value();
   }
 
   /// Sets the default parameter values for the current instance.
   @override
   Future<void> setDefaults(Map<String, dynamic> defaultParameters) {
-    _webRemoteConfig!.defaultConfig = defaultParameters;
+    _delegate.defaultConfig = defaultParameters;
     return Future<void>.value();
   }
 }

--- a/packages/firebase_storage/firebase_storage/example/web/index.html
+++ b/packages/firebase_storage/firebase_storage/example/web/index.html
@@ -1,14 +1,16 @@
 <!DOCTYPE html>
 <html>
+
 <head>
   <meta charset="UTF-8">
   <title>Firebase Storage Web Example</title>
 </head>
+
 <body>
   <script src="https://www.gstatic.com/firebasejs/8.6.1/firebase-app.js"></script>
   <script src="https://www.gstatic.com/firebasejs/8.6.1/firebase-storage.js"></script>
   <script src="https://www.gstatic.com/firebasejs/8.6.1/firebase-analytics.js"></script>
-  <script>
+  <!-- <script>
     var firebaseConfig = {
       apiKey: "AIzaSyAgUhHU8wSJgO5MVNy95tMT07NEjzMOfz0",
       authDomain: "react-native-firebase-testing.firebaseapp.com",
@@ -22,8 +24,8 @@
     // Initialize Firebase
     firebase.initializeApp(firebaseConfig);
     firebase.analytics();
-  </script>
+  </script> -->
   <script src="main.dart.js" type="application/javascript"></script>
 </body>
-</html>
 
+</html>

--- a/packages/firebase_storage/firebase_storage_web/lib/src/reference_web.dart
+++ b/packages/firebase_storage/firebase_storage_web/lib/src/reference_web.dart
@@ -28,9 +28,9 @@ class ReferenceWeb extends ReferencePlatform {
       : _path = path,
         super(storage, path) {
     if (_path.startsWith(_storageUrlPrefix)) {
-      _ref = storage.webStorage!.refFromURL(_path);
+      _ref = storage.delegate.refFromURL(_path);
     } else {
-      _ref = storage.webStorage!.ref(_path);
+      _ref = storage.delegate.ref(_path);
     }
   }
 


### PR DESCRIPTION
## Description

Allow web plugins to register without crashing on missing initialization script, and allow to initialize web plugins only from Dart lazily.

## Related Issues

Possibly fixes #3962

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [ ] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
