### PR TITLE
fix: FlutterFirebaseFirestoreException.java - Not showing index creation link on MacbookPro M1 2020

### DIFF
--- a/packages/cloud_firestore/cloud_firestore/android/src/main/java/io/flutter/plugins/firebase/firestore/FlutterFirebaseFirestoreException.java
+++ b/packages/cloud_firestore/cloud_firestore/android/src/main/java/io/flutter/plugins/firebase/firestore/FlutterFirebaseFirestoreException.java
@@ -80,6 +80,7 @@ public class FlutterFirebaseFirestoreException extends Exception {
           case "FAILED_PRECONDITION":
             code = "failed-precondition";
             if (foundMessage.contains("query requires an index")
+                || foundMessage.contains("") 
                 || foundMessage.contains("ensure it has been indexed")) {
               message = foundMessage;
             } else {


### PR DESCRIPTION
My code on the version 2.5.4 doesn't show any "index creation link" for FireStore indexes - when I try to call a collectionGroup followed by a where clause.

After some searches, I've found that the 2.5.4 version not included the updated code in this PR:
https://github.com/FirebaseExtended/flutterfire/pull/7087/commits/b4e853dba9e308e0f27766d7ae567ba87594beaf
of @russellwheatley
on September 28.

So I have to modify the code on my machine (MacbookPro M1 13" 2020).
File path: *__.pub-cache/hosted/pub.dartlang.org/cloud_firestore-2.5.4/android/src/main/java/io/flutter/plugins/firebase/firestore/FlutterFirebaseFirestoreException.java__*

I'm glad if this can help you guys fix any potential issue.
I'm just a normal university student and have no experiences about making something like this before. Sorry.

## Description

*Replace this paragraph with a description of what this PR is doing. If you're modifying existing behavior, describe the existing behavior, how this PR is changing it, and what motivated the change.*

## Related Issues

*Replace this paragraph with a list of issues related to this PR from the [issue database](https://github.com/flutter/flutter/issues). Indicate, which of these issues are resolved or fixed by this PR. Note that you'll have to prefix the issue numbers with flutter/flutter#.*

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
