### PR TITLE
fix(functions,web): correctly pass `region` to JS functions interop instance

### DIFF
--- a/packages/cloud_functions/cloud_functions_web/lib/cloud_functions_web.dart
+++ b/packages/cloud_functions/cloud_functions_web/lib/cloud_functions_web.dart
@@ -15,9 +15,7 @@ import 'interop/functions.dart' as functions_interop;
 class FirebaseFunctionsWeb extends FirebaseFunctionsPlatform {
   /// The entry point for the [FirebaseFunctionsWeb] class.
   FirebaseFunctionsWeb({FirebaseApp? app, required String region})
-      : _webFunctions = functions_interop.getFunctionsInstance(
-            core_interop.app(app?.name), region),
-        super(app, region);
+      : super(app, region);
 
   /// Stub initializer to allow the [registerWith] to create an instance without
   /// registering the web delegates or listeners.
@@ -28,8 +26,10 @@ class FirebaseFunctionsWeb extends FirebaseFunctionsPlatform {
   /// Instance of functions from the web plugin
   functions_interop.Functions? _webFunctions;
 
+  /// Lazily initialize [_webFunctions] on first method call
   functions_interop.Functions get _delegate {
-    return _webFunctions!;
+    return _webFunctions ??= functions_interop.getFunctionsInstance(
+        core_interop.app(app?.name), region);
   }
 
   /// Create the default instance of the [FirebaseFunctionsPlatform] as a [FirebaseFunctionsWeb]

--- a/packages/cloud_functions/cloud_functions_web/lib/cloud_functions_web.dart
+++ b/packages/cloud_functions/cloud_functions_web/lib/cloud_functions_web.dart
@@ -15,7 +15,9 @@ import 'interop/functions.dart' as functions_interop;
 class FirebaseFunctionsWeb extends FirebaseFunctionsPlatform {
   /// The entry point for the [FirebaseFunctionsWeb] class.
   FirebaseFunctionsWeb({FirebaseApp? app, required String region})
-      : super(app, region);
+      : _webFunctions = functions_interop.getFunctionsInstance(
+      core_interop.app(app?.name), region),
+        super(app, region);
 
   /// Stub initializer to allow the [registerWith] to create an instance without
   /// registering the web delegates or listeners.
@@ -26,10 +28,8 @@ class FirebaseFunctionsWeb extends FirebaseFunctionsPlatform {
   /// Instance of functions from the web plugin
   functions_interop.Functions? _webFunctions;
 
-  /// Lazily initialize [_webFunctions] on first method call
   functions_interop.Functions get _delegate {
-    return _webFunctions ??=
-        functions_interop.getFunctionsInstance(core_interop.app(app?.name));
+    return _webFunctions!;
   }
 
   /// Create the default instance of the [FirebaseFunctionsPlatform] as a [FirebaseFunctionsWeb]

--- a/packages/cloud_functions/cloud_functions_web/lib/cloud_functions_web.dart
+++ b/packages/cloud_functions/cloud_functions_web/lib/cloud_functions_web.dart
@@ -16,7 +16,7 @@ class FirebaseFunctionsWeb extends FirebaseFunctionsPlatform {
   /// The entry point for the [FirebaseFunctionsWeb] class.
   FirebaseFunctionsWeb({FirebaseApp? app, required String region})
       : _webFunctions = functions_interop.getFunctionsInstance(
-      core_interop.app(app?.name), region),
+            core_interop.app(app?.name), region),
         super(app, region);
 
   /// Stub initializer to allow the [registerWith] to create an instance without


### PR DESCRIPTION
## Description

Allow region to be set on cloud functions web.

## Related Issues

fixes https://github.com/FirebaseExtended/flutterfire/issues/7318

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [X] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
