### PR TITLE
Fix broken `firebase_core` link in `README`

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ videos. [[Learn More][storage_product]]
 
 ### `firebase_core`
 
-> ![firebase_core][core_badge_ci] ![firebase_core][core_badge_pub] [![pub points][core_badge_pub_points]][core_pub_points]
+> ![firebase_core][core_badge_ci] [![firebase_core][core_badge_pub]][core_pub] [![pub points][core_badge_pub_points]][core_pub_points]
 
 Firebase Core provides APIs to manage your Firebase application instances and credentials. This plugin is required by
 all FlutterFire plugins.


### PR DESCRIPTION
## Description
The current README has the link to pub.dev that is broken for `firebase_core`. In this PR I fixed it. (One line change)

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.
