### PR TITLE
feat(firebase_messaging): add support for `RemoteMessage` on web

### DIFF
--- a/packages/firebase_messaging/firebase_messaging_platform_interface/lib/src/remote_notification.dart
+++ b/packages/firebase_messaging/firebase_messaging_platform_interface/lib/src/remote_notification.dart
@@ -15,6 +15,7 @@ class RemoteNotification {
   const RemoteNotification(
       {this.android,
       this.apple,
+      this.web,
       this.title,
       this.titleLocArgs = const <String>[],
       this.titleLocKey,
@@ -26,6 +27,7 @@ class RemoteNotification {
   factory RemoteNotification.fromMap(Map<String, dynamic> map) {
     AndroidNotification? _android;
     AppleNotification? _apple;
+    WebNotification? _web;
 
     if (map['android'] != null) {
       _android = AndroidNotification(
@@ -63,6 +65,14 @@ class RemoteNotification {
       );
     }
 
+    if (map['web'] != null) {
+      _web = WebNotification(
+        analyticsLabel: map['web']['analyticsLabel'],
+        image: map['web']['image'],
+        link: map['web']['link'],
+      );
+    }
+
     return RemoteNotification(
       title: map['title'],
       titleLocArgs: _toList(map['titleLocArgs']),
@@ -72,6 +82,7 @@ class RemoteNotification {
       bodyLocKey: map['bodyLocKey'],
       android: _android,
       apple: _apple,
+      web: _web,
     );
   }
 
@@ -80,6 +91,9 @@ class RemoteNotification {
 
   /// Apple specific notification properties.
   final AppleNotification? apple;
+
+  /// Web specific notification properties.
+  final WebNotification? web;
 
   /// The notification title.
   final String? title;
@@ -222,4 +236,24 @@ List<String> _toList(dynamic value) {
   }
 
   return List<String>.from(value);
+}
+
+/// Web specific properties of a [RemoteNotification].
+class WebNotification {
+  const WebNotification({
+    this.analyticsLabel,
+    this.image,
+    this.link,
+  });
+
+  /// Optional message label for custom analytics.
+  final String? analyticsLabel;
+
+  /// The image URL for the notification.
+  ///
+  /// Will be `null` if the notification did not include an image.
+  final String? image;
+
+  /// The url which is typically being navigated to when the notification is clicked.
+  final String? link;
 }


### PR DESCRIPTION
## Description

On cloud messaging web, one can optionally deliver `fcmOptions` (containing image link, analyticsLabel and link) to the client app, which has already been implemented for the most part. However, there was a missing link so that the info could be extracted from the `RemoteMessage` to, e.g., register the analytics event, navigate to the url or extract and display the image within the Flutter app. This is being added here.

## Related Issues

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
