### PR TITLE
docs(remote_config): remove legacy instructions

### DIFF
--- a/docs/remote-config/overview.mdx
+++ b/docs/remote-config/overview.mdx
@@ -3,11 +3,7 @@ title: Remote Config
 sidebar_label: Overview
 ---
 
-:::caution
-This is a beta FlutterFire plugin and therefore is not yet production quality.
-:::
-
-##  What does it do?
+## What does it do?
 
 Firebase Remote Config is a cloud service that lets you change the behavior and appearance of your app without requiring users to
 download an app update. When using Remote Config, you create in-app default values that control the behavior and appearance of your
@@ -15,99 +11,23 @@ app. Then, you can later use the Firebase console or the Remote Config backend A
 users or for segments of your user base. Your app controls when updates are applied, and it can frequently check for updates and
 apply them with a negligible impact on performance.
 
-<YouTube id="_CXXVFPO6f0"/>
+<YouTube id="_CXXVFPO6f0" />
 
 ## Installation
 
-<Tabs
-groupId="legacy-or-nullsafe"
-defaultValue="legacy"
-values={[
-    { label: "Legacy", value: "legacy" },
-    { label: "Null safety", value: "null-safe" },
-]}
->
-<TabItem value="legacy">
-</TabItem>
-<TabItem value="null-safe">
+### 1. Make sure to initialize Firebase
 
-Ensure you're using the Flutter `stable` channel:
+[Follow this guide](../overview.mdx) to install `firebase_core` and initialize Firebase if you haven't already.
 
-```bash
-$ flutter channel stable
+### 2. Add dependency
+
+On the root of your Flutter project, run the following command to install the plugin:
+
+```bash {5}
+flutter pub add firebase_remote_config
 ```
 
-If your app is mixing legacy and null-safe packages, use the `--no-sound-null-safety` flag:
-```bash
-$ flutter run --no-sound-null-safety
-```
-
-For legacy package imports, place the following ignore comment to hide Dart analyzer warnings:
-
-```dart
-// ignore: import_of_legacy_library_into_null_safe
-import 'package:firebase_remote_config/firebase_remote_config.dart';
-```
-</TabItem>
-</Tabs>
-
-### 1. Add dependency
-
-<Tabs
-  groupId="legacy-or-nullsafe"
-  defaultValue="legacy"
-  values={[
-    { label: "Legacy", value: "legacy" },
-    { label: "Null safety", value: "null-safe" },
-  ]}
->
-<TabItem value="legacy">
-
-```yaml {5} title="pubspec.yaml"
-dependencies:
-  flutter:
-    sdk: flutter
-  firebase_core: "^{{ plugins.firebase_core }}"
-  firebase_remote_config: "^{{ plugins.firebase_remote_config }}"
-```
-
-</TabItem>
-<TabItem value="null-safe">
-
-```yaml {5} title="pubspec.yaml"
-dependencies:
-  flutter:
-    sdk: flutter
-  firebase_core: "^{{ plugins.firebase_core_ns }}"
-  firebase_remote_config: "^{{ plugins.firebase_remote_config_ns }}"
-```
-
-</TabItem>
-</Tabs>
-
-
-
-### 2. Download dependency
-
-```
-$ flutter pub get
-```
-
-### 3. (Web Only) Add the SDK
-
-If using FlutterFire on the web, add the `firebase-remote-config` JavaScript SDK to your `index.html` file:
-
-```html {5} title="web/index.html"
-<html>
-  ...
-  <body>
-    <script src="https://www.gstatic.com/firebasejs/{{ web.firebase_cdn }}/firebase-app.js"></script>
-    <script src="https://www.gstatic.com/firebasejs/{{ web.firebase_cdn }}/firebase-remote-config.js"></script>
-  </body>
-</html>
-```
-
-### 4. Rebuild your app
+### 3. Rebuild your app
 
 Once complete, rebuild your Flutter application:
 

--- a/docs/remote-config/overview.mdx
+++ b/docs/remote-config/overview.mdx
@@ -23,7 +23,7 @@ apply them with a negligible impact on performance.
 
 On the root of your Flutter project, run the following command to install the plugin:
 
-```bash {5}
+```bash
 flutter pub add firebase_remote_config
 ```
 


### PR DESCRIPTION
## Description
Docs updates to `firebase_remote_config`:
1. Remove legacy instructions, now assumes the project is null-safe.
2. Add command-line installation.
3. Remove the web-only section since the SDKs is now auto injected.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
