### PR TITLE
docs(firebase_in_app_messaging): remove legacy instructions

### DIFF
--- a/docs/in-app-messaging/overview.mdx
+++ b/docs/in-app-messaging/overview.mdx
@@ -18,82 +18,16 @@ your social media app.
 
 ## Installation
 
-Before installing the In-App Messaging for Firebase plugin, ensure that you have followed the [Getting Started](../overview.mdx) documentation
-and have initialized FlutterFire.
+### 1. Make sure to initialize Firebase
 
-<Tabs
-groupId="legacy-or-nullsafe"
-defaultValue="legacy"
-values={[
-    { label: "Legacy", value: "legacy" },
-    { label: "Null safety", value: "null-safe" },
-]}
->
-<TabItem value="legacy">
+[Follow this guide](../overview.mdx) to install `firebase_core` and initialize Firebase if you haven't already.
 
-For legacy package imports, place the following ignore comment to hide Dart analyzer warnings:
+### 2. Add dependency
 
-```dart
-// ignore: import_of_legacy_library_into_null_safe
-import 'package:firebase-in-app-messaging/firebase-in-app-messaging.dart';
-```
+On the root of your Flutter project, run the following command to install the plugin:
 
-</TabItem>
-<TabItem value="null-safe">
-
-Ensure you're using the Flutter `stable` channel:
-
-```bash
-$ flutter channel stable
-```
-
-If your app is mixing legacy and null-safe packages, use the `--no-sound-null-safety` flag:
-
-```bash
-$ flutter run --no-sound-null-safety
-```
-
-</TabItem>
-</Tabs>
-
-### 1. Add dependency
-
-<Tabs
-  groupId="legacy-or-nullsafe"
-  defaultValue="legacy"
-  values={[
-    { label: "Legacy", value: "legacy" },
-    { label: "Null safety", value: "null-safe" },
-  ]}
->
-<TabItem value="legacy">
-
-```yaml {5} title="pubspec.yaml"
-dependencies:
-  flutter:
-    sdk: flutter
-  firebase_core: '^{{ plugins.firebase_core }}'
-  firebase_in_app_messaging: '^{{ plugins.firebase_in_app_messaging }}'
-```
-
-</TabItem>
-<TabItem value="null-safe">
-
-```yaml {5} title="pubspec.yaml"
-dependencies:
-  flutter:
-    sdk: flutter
-  firebase_core: '^{{ plugins.firebase_core_ns }}'
-  firebase_in_app_messaging: '^{{ plugins.firebase_in_app_messaging_ns }}'
-```
-
-</TabItem>
-</Tabs>
-
-### 2. Download dependency
-
-```
-$ flutter pub get
+```bash {5}
+flutter pub add firebase_in_app_messaging
 ```
 
 ### 3. Rebuild your app

--- a/website/plugins.js
+++ b/website/plugins.js
@@ -161,8 +161,7 @@ module.exports = [
     pub: 'firebase_in_app_messaging',
     firebase: 'in-app-messaging',
     status: 'Stable',
-    documentation:
-      'https://github.com/FirebaseExtended/flutterfire/blob/master/packages/firebase_in_app_messaging/README.md',
+    documentation: 'https://firebase.flutter.dev/docs/in-app-messaging/overview',
     support: {
       web: 'N/A',
       mobile: true,


### PR DESCRIPTION
## Description

Docs updates to firebase_in_app_messaging:
1. Remove legacy instructions, now assumes the project is null-safe.
2. Add command-line installation.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
