### PR TITLE
docs(firebase_analytics): remove legacy instructions

### DIFF
--- a/docs/analytics/overview.mdx
+++ b/docs/analytics/overview.mdx
@@ -42,8 +42,6 @@ $FirebaseAnalyticsWithoutAdIdSupport = true
 
 ## Next Steps
 
-Once installed, you're ready to start using Firebase Analytics in your Flutter Project.
+Once installed, you're ready to start using Analytics in your Flutter Project.
 
-> Additional documentation will be available once the Firebase Analytics plugin update lands as part of the [FlutterFire roadmap](https://github.com/FirebaseExtended/flutterfire/issues/2582).
-
-<!-- View the [Usage documentation](usage.mdx) to get started. -->
+View the [Usage documentation](usage.mdx) to get started.

--- a/docs/analytics/overview.mdx
+++ b/docs/analytics/overview.mdx
@@ -3,109 +3,36 @@ title: Google Analytics for Firebase
 sidebar_label: Overview
 ---
 
-##  What does it do?
+## What does it do?
 
 Google Analytics is a free app measurement solution that provides insight on app usage and user engagement.
 Analytics reports help you understand clearly how your users behave, which enables you to make informed decisions regarding app marketing and performance optimizations.
 
-<YouTube id="8iZpH7O6zXo"/>
+<YouTube id="8iZpH7O6zXo" />
 
 ## Installation
 
-<Tabs
-groupId="legacy-or-nullsafe"
-defaultValue="legacy"
-values={[
-    { label: "Legacy", value: "legacy" },
-    { label: "Null safety", value: "null-safe" },
-]}
->
-<TabItem value="legacy">
-</TabItem>
-<TabItem value="null-safe">
+### 1. Make sure to initialize Firebase
 
-Ensure you're using the Flutter `stable` channel:
+[Follow this guide](../overview.mdx) to install `firebase_core` and initialize Firebase if you haven't already.
 
-```bash
-$ flutter channel stable
+### 2. Add dependency
+
+On the root of your Flutter project, run the following command to install the plugin:
+
+```bash {5}
+flutter pub add firebase_analytics
 ```
 
-If your app is mixing legacy and null-safe packages, use the `--no-sound-null-safety` flag:
-```bash
-$ flutter run --no-sound-null-safety
-```
-
-For legacy package imports, place the following ignore comment to hide Dart analyzer warnings:
-
-```dart
-// ignore: import_of_legacy_library_into_null_safe
-import 'package:firebase_analytics/firebase_analytics.dart';
-```
-</TabItem>
-</Tabs>
-
-### 1. Add dependency
-
-<Tabs
-  groupId="legacy-or-nullsafe"
-  defaultValue="legacy"
-  values={[
-    { label: "Legacy", value: "legacy" },
-    { label: "Null safety", value: "null-safe" },
-  ]}
->
-<TabItem value="legacy">
-
-```yaml {5} title="pubspec.yaml"
-dependencies:
-  flutter:
-    sdk: flutter
-  firebase_core: "^{{ plugins.firebase_core }}"
-  firebase_analytics: "^{{ plugins.firebase_analytics }}"
-```
-
-</TabItem>
-<TabItem value="null-safe">
-
-```yaml {5} title="pubspec.yaml"
-dependencies:
-  flutter:
-    sdk: flutter
-  firebase_core: "^{{ plugins.firebase_core }}"
-  firebase_analytics: "^{{ plugins.firebase_analytics_ns }}"
-```
-
-</TabItem>
-</Tabs>
-
-### 2. Download dependency
-
-```
-$ flutter pub get
-```
-
-### 3. (Web Only) Add the SDK
-
-If using FlutterFire on the web, add the `firebase-analytics` JavaScript SDK to your `index.html` file:
-
-```html {5} title="web/index.html"
-<html>
-  ...
-  <body>
-    <script src="https://www.gstatic.com/firebasejs/{{ web.firebase_cdn }}/firebase-app.js"></script>
-    <script src="https://www.gstatic.com/firebasejs/{{ web.firebase_cdn }}/firebase-analytics.js"></script>
-  </body>
-</html>
-```
-### 4. Rebuild your app
+### 3. Rebuild your app
 
 Once complete, rebuild your Flutter application:
 
 ```bash
-$ flutter run
+flutter run
 ```
 
-### 5. (optional) Apple [App Tracking Transparency](https://developer.apple.com/documentation/apptrackingtransparency)
+### 4. (optional) Apple [App Tracking Transparency](https://developer.apple.com/documentation/apptrackingtransparency)
 
 If you wish to use Firebase Analytics without IDFA collection capability, open your `/{ios|macos}/Podfile` and add the following global variable to the top of the file:
 


### PR DESCRIPTION
## Description

Docs updates to `firebase_analytics`:
1. Remove legacy instructions, now assumes the project is null-safe.
2. Add command-line installation.
3. Remove the web-only section since the SDKs is now auto injected.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
