### PR TITLE
fix(firebase_ml_model_downloader): listDownloadedModels cast error

### DIFF
--- a/packages/firebase_ml_model_downloader/firebase_ml_model_downloader/example/test_driver/firebase_ml_model_downloader_e2e.dart
+++ b/packages/firebase_ml_model_downloader/firebase_ml_model_downloader/example/test_driver/firebase_ml_model_downloader_e2e.dart
@@ -38,10 +38,7 @@ void testsMain() {
 
     group('listDownloadedModels', () {
       test('should return successfully', () async {
-        expectLater(
-            mlModelDownloader.getModel(
-                kModelName, FirebaseModelDownloadType.latestModel),
-            completes);
+        expectLater(mlModelDownloader.listDownloadedModels(), completes);
       });
     });
 

--- a/packages/firebase_ml_model_downloader/firebase_ml_model_downloader_platform_interface/lib/src/method_channel/method_channel_firebase_ml_model_downloader.dart
+++ b/packages/firebase_ml_model_downloader/firebase_ml_model_downloader_platform_interface/lib/src/method_channel/method_channel_firebase_ml_model_downloader.dart
@@ -64,7 +64,7 @@ class MethodChannelFirebaseModelDownloader
   @override
   Future<List<FirebaseCustomModel>> listDownloadedModels() async {
     try {
-      final result = await channel.invokeListMethod<Map<String, dynamic>>(
+      final result = await channel.invokeListMethod<Map>(
           'FirebaseModelDownloader#listDownloadedModels', {
         'appName': app.name,
       });
@@ -89,7 +89,7 @@ class MethodChannelFirebaseModelDownloader
   }
 
   FirebaseCustomModel _resultToFirebaseCustomModel(
-    Map<dynamic, dynamic> result,
+    Map result,
   ) {
     return FirebaseCustomModel(
       file: File(result['filePath']),


### PR DESCRIPTION
## Description

Fixes a cast error with method `listDownloadedModels`.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
