### PR TITLE
docs(firebase_app_installations): remove legacy instructions + update plugin name

### DIFF
--- a/docs/installations/overview.mdx
+++ b/docs/installations/overview.mdx
@@ -26,42 +26,24 @@ Typically, Firebase services use the Firebase installations service without requ
 
 ## Installation
 
-Add the `flutterfire_installations` dependency to your projects `pubspec.yaml` file:
+### 1. Make sure to initialize Firebase
 
-```yaml {5} title="pubspec.yaml"
-dependencies:
-  flutter:
-    sdk: flutter
-  firebase_core: "^{{ plugins.firebase_core_ns }}"
-  flutterfire_installations: "^{{ plugins.flutterfire_installations_ns }}"
+[Follow this guide](../overview.mdx) to install `firebase_core` and initialize Firebase if you haven't already.
+
+### 2. Add dependency
+
+On the root of your Flutter project, run the following command to install the plugin:
+
+```bash
+flutter pub add firebase_app_installations
 ```
 
-### 2. Download dependency
-
-```
-$ flutter pub get
-```
-
-### 3. (Web Only) Add the SDK
-
-If using FlutterFire on the web, add the `firebase-installations` JavaScript SDK to your `index.html` file:
-
-```html {5} title="web/index.html"
-<html>
-  ...
-  <body>
-    <script src="https://www.gstatic.com/firebasejs/{{ web.firebase_cdn }}/firebase-app.js"></script>
-    <script src="https://www.gstatic.com/firebasejs/{{ web.firebase_cdn }}/firebase-installations.js"></script>
-  </body>
-</html>
-```
-
-### 4. Rebuild your app
+### 3. Rebuild your app
 
 Once complete, rebuild your Flutter application:
 
 ```bash
-$ flutter run
+flutter run
 ```
 
 ## Next Steps

--- a/docs/remote-config/overview.mdx
+++ b/docs/remote-config/overview.mdx
@@ -32,7 +32,7 @@ flutter pub add firebase_remote_config
 Once complete, rebuild your Flutter application:
 
 ```bash
-$ flutter run
+flutter run
 ```
 
 ## Next Steps


### PR DESCRIPTION
## Description

Docs updates to `firebase_app_installations `:
1. Remove legacy instructions, now assumes the project is null-safe.
2. Add command-line installation.
3. Rename the plugin.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
