### PR TITLE
fix(firebase_core): loosen duplicate app detection checks to allow unset options not to cause a duplicate app exception

### DIFF
--- a/packages/firebase_core/firebase_core_platform_interface/lib/src/method_channel/method_channel_firebase.dart
+++ b/packages/firebase_core/firebase_core_platform_interface/lib/src/method_channel/method_channel_firebase.dart
@@ -105,10 +105,10 @@ class MethodChannelFirebase extends FirebasePlatform {
       // e.g. hot reloads/restarts).
       if (defaultApp != null && options != null) {
         if (options.apiKey != defaultApp.options.apiKey ||
-            options.databaseURL != null &&
-                options.databaseURL != defaultApp.options.databaseURL ||
-            options.storageBucket != null &&
-                options.storageBucket != defaultApp.options.storageBucket) {
+            (options.databaseURL != null &&
+                options.databaseURL != defaultApp.options.databaseURL) ||
+            (options.storageBucket != null &&
+                options.storageBucket != defaultApp.options.storageBucket)) {
           // Options are different; throw.
           throw duplicateApp(defaultFirebaseAppName);
         }

--- a/packages/firebase_core/firebase_core_platform_interface/lib/src/method_channel/method_channel_firebase.dart
+++ b/packages/firebase_core/firebase_core_platform_interface/lib/src/method_channel/method_channel_firebase.dart
@@ -105,8 +105,10 @@ class MethodChannelFirebase extends FirebasePlatform {
       // e.g. hot reloads/restarts).
       if (defaultApp != null && options != null) {
         if (options.apiKey != defaultApp.options.apiKey ||
-            options.databaseURL != defaultApp.options.databaseURL ||
-            options.storageBucket != defaultApp.options.storageBucket) {
+            options.databaseURL != null &&
+                options.databaseURL != defaultApp.options.databaseURL ||
+            options.storageBucket != null &&
+                options.storageBucket != defaultApp.options.storageBucket) {
           // Options are different; throw.
           throw duplicateApp(defaultFirebaseAppName);
         }


### PR DESCRIPTION
## Description

see title.

## Related Issues

*Replace this paragraph with a list of issues related to this PR from the [issue database](https://github.com/flutter/flutter/issues). Indicate, which of these issues are resolved or fixed by this PR. Note that you'll have to prefix the issue numbers with flutter/flutter#.*

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
