### PR TITLE
docs(dynamic_links): correct the return type of `buildShortLink`

### DIFF
--- a/docs/dynamic-links/usage.mdx
+++ b/docs/dynamic-links/usage.mdx
@@ -96,7 +96,8 @@ final DynamicLinkParameters parameters = DynamicLinkParameters(
   ),
 );
 
-final Uri uri = await FirebaseDynamicLinks.instance.buildShortLink(parameters);
+final ShortDynamicLink shortDynamicLink = await FirebaseDynamicLinks.instance.buildShortLink(parameters);
+final Uri uri = shortDynamicLink.shortUrl;
 ```
 
 ## Handling Dynamic Links


### PR DESCRIPTION
the correct return type of 'buildShortLink' is 'ShortDynamicLink' not 'Uri'

## Description

*The return type of `await FirebaseDynamicLinks.instance.buildShortLink(parameters)` is `ShortDynamicLink` not `Uri` as the documentation stated. To get the uri of the ShortDynamicLink is ```final Uri uri = shortDynamicLink.shortUrl;``` therefore, the final code looks like this:*

*```final ShortDynamicLink shortDynamicLink = await FirebaseDynamicLinks.instance.buildShortLink(parameters);```*

*```final Uri uri = shortDynamicLink.shortUrl;```*

## Related Issues

*This PR does not fix any existing known issue.*

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
