### PR TITLE
fix: messaging `isSupported()` check on web should be used lazily in `_delegate`

### DIFF
--- a/packages/firebase_core/firebase_core_platform_interface/lib/src/firebase_core_exceptions.dart
+++ b/packages/firebase_core/firebase_core_platform_interface/lib/src/firebase_core_exceptions.dart
@@ -35,33 +35,16 @@ FirebaseException noDefaultAppInitialization() {
   );
 }
 
-/// Throws a consistent platform specific error message if the user attempts to
+/// Throws a consistent error message if the user attempts to
 /// initializes core without it being available on the underlying platform.
 FirebaseException coreNotInitialized() {
-  String message;
-
-  if (kIsWeb) {
-    message = '''
+  String message = '''
 Firebase has not been correctly initialized.
 
-View the Web Installation documentation for more information: https://firebase.flutter.dev/docs/installation/web
+Usually this means you've attempted to use a Firebase service before calling `Firebase.initializeApp`.
+
+View the documentation for more information: https://firebase.flutter.dev/docs/overview#initialization
     ''';
-  } else if (defaultTargetPlatform == TargetPlatform.android) {
-    message = '''
-Firebase has not been correctly initialized. Have you added the "google-services.json" file to the project?
-
-View the Android Installation documentation for more information: https://firebase.flutter.dev/docs/installation/android
-''';
-  } else if (defaultTargetPlatform == TargetPlatform.iOS) {
-    message = '''
-Firebase has not been correctly initialized. Have you added the "GoogleService-Info.plist" file to the project?
-
-View the iOS Installation documentation for more information: https://firebase.flutter.dev/docs/installation/ios
-''';
-  } else {
-    message = 'Firebase has not been initialized. '
-        'Please check the documentation for your platform.';
-  }
 
   return FirebaseException(
       plugin: 'core', code: 'not-initialized', message: message);

--- a/packages/firebase_core/firebase_core_web/lib/src/firebase_core_web.dart
+++ b/packages/firebase_core/firebase_core_web/lib/src/firebase_core_web.dart
@@ -331,7 +331,9 @@ class FirebaseCoreWeb extends FirebasePlatform {
     try {
       app = firebase.app(name);
     } catch (e) {
-      if (e.toString().contains("Cannot read property 'app' of undefined")) {
+      if ((e.toString().contains('Cannot read property') ||
+              e.toString().contains('Cannot read properties')) &&
+          e.toString().contains("'app'")) {
         throw coreNotInitialized();
       }
 

--- a/packages/firebase_messaging/firebase_messaging_web/lib/firebase_messaging_web.dart
+++ b/packages/firebase_messaging/firebase_messaging_web/lib/firebase_messaging_web.dart
@@ -27,7 +27,7 @@ class FirebaseMessagingWeb extends FirebaseMessagingPlatform {
     _webMessaging ??=
         messaging_interop.getMessagingInstance(core_interop.app(app.name));
 
-    if (!_initialized) {
+    if (!_initialized && messaging_interop.isSupported()) {
       _webMessaging!.onMessage
           .listen((messaging_interop.MessagePayload webMessagePayload) {
         RemoteMessage remoteMessage =
@@ -53,12 +53,7 @@ class FirebaseMessagingWeb extends FirebaseMessagingPlatform {
 
   /// Builds an instance of [FirebaseMessagingWeb] with an optional [FirebaseApp] instance
   /// If [app] is null then the created instance will use the default [FirebaseApp]
-  FirebaseMessagingWeb({FirebaseApp? app}) : super(appInstance: app) {
-    if (!messaging_interop.isSupported()) {
-      // The browser is not supported (Safari). Initialize a full no-op FirebaseMessagingWeb
-      return;
-    }
-  }
+  FirebaseMessagingWeb({FirebaseApp? app}) : super(appInstance: app);
 
   /// Updates user on browser support for Firebase.Messaging
   @override


### PR DESCRIPTION
## Description

Additionally, correctly detect not-initialized errors and provide a better error message.

Fixes #7511 

## Related Issues

*Replace this paragraph with a list of issues related to this PR from the [issue database](https://github.com/flutter/flutter/issues). Indicate, which of these issues are resolved or fixed by this PR. Note that you'll have to prefix the issue numbers with flutter/flutter#.*

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [ ] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
