### PR TITLE
fix(analytics, web): ensure `setDefaultEventParameters()` API throws stating not supported on web.

### DIFF
--- a/docs/analytics/usage.mdx
+++ b/docs/analytics/usage.mdx
@@ -132,9 +132,11 @@ await FirebaseAnalytics.instance
 
 ## Default Parameters
 
-Use the `setDefaultEventParameters` method if you have common parameters which need to be sent with each event:
+Use the `setDefaultEventParameters` method if you have common parameters which need to be sent with each event. Please
+note that this API is not supported on web.
 
 ```dart
+// Not supported on web
 await FirebaseAnalytics.instance
   .setDefaultEventParameters({
     version: '1.2.3'
@@ -168,9 +170,33 @@ You can provide a `null` value to remove any previous properties.
 
 ## Resetting data
 
-To clear all data associated with the current session, use the `resetAnalyticsData` method:
+To clear all data associated with the current session, use the `resetAnalyticsData` method. Please
+note that this API is not supported on web.
 
 ```dart
+// Not supported on web
 await FirebaseAnalytics.instance
   .resetAnalyticsData();
+```
+
+## Set user consent
+
+Set the applicable end user consent state. `default` value for adStorageConsentGranted` & analyticsStorageConsentGranted` is true`.
+Please note that this API is not supported on web.
+
+```dart
+// Not supported on web
+await FirebaseAnalytics.instance
+  setConsent(adStorageConsentGranted: false, analyticsStorageConsentGranted: true);
+```
+
+## Set session timeout duration
+
+Set the duration of inactivity that terminates the current session.
+Please note that this API is android only.
+
+```dart
+// android support only
+await FirebaseAnalytics.instance
+  setSessionTimeoutDuration(const Duration(minutes: 1))
 ```

--- a/packages/firebase_analytics/firebase_analytics/example/test_driver/firebase_analytics_e2e.dart
+++ b/packages/firebase_analytics/firebase_analytics/example/test_driver/firebase_analytics_e2e.dart
@@ -97,13 +97,20 @@ void testsMain() {
     test(
       'setSessionTimeoutDuration',
       () async {
-        await expectLater(
-          analytics
-              .setSessionTimeoutDuration(const Duration(milliseconds: 5000)),
-          completes,
-        );
+        if (kIsWeb) {
+          await expectLater(
+            analytics
+                .setSessionTimeoutDuration(const Duration(milliseconds: 5000)),
+            throwsA(isA<UnimplementedError>()),
+          );
+        } else {
+          await expectLater(
+            analytics
+                .setSessionTimeoutDuration(const Duration(milliseconds: 5000)),
+            completes,
+          );
+        }
       },
-      skip: kIsWeb,
     );
 
     test('setAnalyticsCollectionEnabled', () async {
@@ -134,23 +141,55 @@ void testsMain() {
     test(
       'resetAnalyticsData',
       () async {
-        await expectLater(analytics.resetAnalyticsData(), completes);
+        if (kIsWeb) {
+          await expectLater(
+            analytics.resetAnalyticsData(),
+            throwsA(isA<UnimplementedError>()),
+          );
+        } else {
+          await expectLater(analytics.resetAnalyticsData(), completes);
+        }
       },
-      skip: kIsWeb,
     );
 
     test(
       'setConsent',
       () async {
-        await expectLater(
-          analytics.setConsent(
-            analyticsStorageConsentGranted: false,
-            adStorageConsentGranted: true,
-          ),
-          completes,
-        );
+        if (kIsWeb) {
+          await expectLater(
+            analytics.setConsent(
+              analyticsStorageConsentGranted: false,
+              adStorageConsentGranted: true,
+            ),
+            throwsA(isA<UnimplementedError>()),
+          );
+        } else {
+          await expectLater(
+            analytics.setConsent(
+              analyticsStorageConsentGranted: false,
+              adStorageConsentGranted: true,
+            ),
+            completes,
+          );
+        }
       },
-      skip: kIsWeb,
+    );
+
+    test(
+      'setDefaultEventParameters',
+      () async {
+        if (kIsWeb) {
+          await expectLater(
+            analytics.setDefaultEventParameters({'default': 'parameters'}),
+            throwsA(isA<UnimplementedError>()),
+          );
+        } else {
+          await expectLater(
+            analytics.setDefaultEventParameters({'default': 'parameters'}),
+            completes,
+          );
+        }
+      },
     );
   });
 }

--- a/packages/firebase_analytics/firebase_analytics_web/lib/firebase_analytics_web.dart
+++ b/packages/firebase_analytics/firebase_analytics_web/lib/firebase_analytics_web.dart
@@ -121,4 +121,13 @@ class FirebaseAnalyticsWeb extends FirebaseAnalyticsPlatform {
       'setSessionTimeoutDuration() is not supported on Web.',
     );
   }
+
+  @override
+  Future<void> setDefaultEventParameters(
+    Map<String, Object> defaultParameters,
+  ) async {
+    throw UnimplementedError(
+      'setDefaultEventParameters() is not supported on web',
+    );
+  }
 }


### PR DESCRIPTION
## Description

See title.

## Related Issues

fixes https://github.com/FirebaseExtended/flutterfire/issues/7521

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
