### PR TITLE
fix(analytics): reinstate Analytics screen navigation observer.

### DIFF
--- a/packages/firebase_analytics/firebase_analytics/example/lib/main.dart
+++ b/packages/firebase_analytics/firebase_analytics/example/lib/main.dart
@@ -32,11 +32,10 @@ class MyApp extends StatelessWidget {
 
   static FirebaseAnalytics analytics = FirebaseAnalytics.instance;
   static FirebaseAnalyticsObserver observer =
-  FirebaseAnalyticsObserver(analytics: analytics);
+      FirebaseAnalyticsObserver(analytics: analytics);
 
   @override
   Widget build(BuildContext context) {
-
     return MaterialApp(
       title: 'Firebase Analytics Demo',
       theme: ThemeData(
@@ -78,7 +77,6 @@ class _MyHomePageState extends State<MyHomePage> {
   }
 
   Future<void> _sendAnalyticsEvent() async {
-
     await widget.analytics.logEvent(
       name: 'test_event',
       parameters: <String, dynamic>{

--- a/packages/firebase_analytics/firebase_analytics/example/lib/main.dart
+++ b/packages/firebase_analytics/firebase_analytics/example/lib/main.dart
@@ -31,17 +31,22 @@ class MyApp extends StatelessWidget {
   const MyApp({Key? key}) : super(key: key);
 
   static FirebaseAnalytics analytics = FirebaseAnalytics.instance;
+  static FirebaseAnalyticsObserver observer =
+  FirebaseAnalyticsObserver(analytics: analytics);
 
   @override
   Widget build(BuildContext context) {
+
     return MaterialApp(
       title: 'Firebase Analytics Demo',
       theme: ThemeData(
         primarySwatch: Colors.blue,
       ),
+      navigatorObservers: <NavigatorObserver>[observer],
       home: MyHomePage(
         title: 'Firebase Analytics Demo',
         analytics: analytics,
+        observer: observer,
       ),
     );
   }
@@ -52,10 +57,12 @@ class MyHomePage extends StatefulWidget {
     Key? key,
     required this.title,
     required this.analytics,
+    required this.observer,
   }) : super(key: key);
 
   final String title;
   final FirebaseAnalytics analytics;
+  final FirebaseAnalyticsObserver observer;
 
   @override
   _MyHomePageState createState() => _MyHomePageState();
@@ -71,6 +78,7 @@ class _MyHomePageState extends State<MyHomePage> {
   }
 
   Future<void> _sendAnalyticsEvent() async {
+
     await widget.analytics.logEvent(
       name: 'test_event',
       parameters: <String, dynamic>{
@@ -319,7 +327,7 @@ class _MyHomePageState extends State<MyHomePage> {
             MaterialPageRoute<TabsPage>(
               settings: const RouteSettings(name: TabsPage.routeName),
               builder: (BuildContext context) {
-                return const TabsPage();
+                return TabsPage(widget.observer);
               },
             ),
           );

--- a/packages/firebase_analytics/firebase_analytics/example/lib/tabs_page.dart
+++ b/packages/firebase_analytics/firebase_analytics/example/lib/tabs_page.dart
@@ -6,11 +6,11 @@ import 'package:flutter/material.dart';
 import 'package:firebase_analytics/firebase_analytics.dart';
 
 class TabsPage extends StatefulWidget {
-   TabsPage(this.observer, {Key? key}) : super(key: key);
+  TabsPage(this.observer, {Key? key}) : super(key: key);
 
-   final FirebaseAnalyticsObserver observer;
+  final FirebaseAnalyticsObserver observer;
 
-   static const String routeName = '/tab';
+  static const String routeName = '/tab';
 
   @override
   State<StatefulWidget> createState() => _TabsPageState();

--- a/packages/firebase_analytics/firebase_analytics/example/lib/tabs_page.dart
+++ b/packages/firebase_analytics/firebase_analytics/example/lib/tabs_page.dart
@@ -6,9 +6,11 @@ import 'package:flutter/material.dart';
 import 'package:firebase_analytics/firebase_analytics.dart';
 
 class TabsPage extends StatefulWidget {
-  const TabsPage({Key? key}) : super(key: key);
+   TabsPage(this.observer, {Key? key}) : super(key: key);
 
-  static const String routeName = '/tab';
+   final FirebaseAnalyticsObserver observer;
+
+   static const String routeName = '/tab';
 
   @override
   State<StatefulWidget> createState() => _TabsPageState();
@@ -36,10 +38,12 @@ class _TabsPageState extends State<TabsPage>
   @override
   void didChangeDependencies() {
     super.didChangeDependencies();
+    widget.observer.subscribe(this, ModalRoute.of(context)! as PageRoute);
   }
 
   @override
   void dispose() {
+    widget.observer.unsubscribe(this);
     super.dispose();
   }
 

--- a/packages/firebase_analytics/firebase_analytics/lib/firebase_analytics.dart
+++ b/packages/firebase_analytics/firebase_analytics/lib/firebase_analytics.dart
@@ -4,8 +4,11 @@
 
 library firebase_analytics;
 
+import 'package:meta/meta.dart';
+import 'package:flutter/cupertino.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';
+import 'package:flutter/widgets.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:firebase_core_platform_interface/firebase_core_platform_interface.dart'
     show FirebasePluginPlatform;
@@ -13,6 +16,6 @@ import 'package:flutter/foundation.dart' show kIsWeb;
 import 'package:firebase_analytics_platform_interface/firebase_analytics_platform_interface.dart';
 export 'package:firebase_analytics_platform_interface/firebase_analytics_platform_interface.dart'
     show AnalyticsEventItem, AnalyticsCallOptions;
-import 'package:flutter/widgets.dart';
 
 part 'src/firebase_analytics.dart';
+part 'src/observer.dart';

--- a/packages/firebase_analytics/firebase_analytics/lib/firebase_analytics.dart
+++ b/packages/firebase_analytics/firebase_analytics/lib/firebase_analytics.dart
@@ -4,7 +4,6 @@
 
 library firebase_analytics;
 
-import 'package:meta/meta.dart';
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/foundation.dart';
 import 'package:flutter/services.dart';

--- a/packages/firebase_analytics/firebase_analytics/lib/src/observer.dart
+++ b/packages/firebase_analytics/firebase_analytics/lib/src/observer.dart
@@ -1,0 +1,113 @@
+// Copyright 2021 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+part of firebase_analytics;
+
+/// Signature for a function that extracts a screen name from [RouteSettings].
+///
+/// Usually, the route name is not a plain string, and it may contains some
+/// unique ids that makes it difficult to aggregate over them in Firebase
+/// Analytics.
+typedef ScreenNameExtractor = String? Function(RouteSettings settings);
+
+String? defaultNameExtractor(RouteSettings settings) => settings.name;
+
+/// A [NavigatorObserver] that sends events to Firebase Analytics when the
+/// currently active [PageRoute] changes.
+///
+/// When a route is pushed or popped, [nameExtractor] is used to extract a name
+/// from [RouteSettings] of the now active route and that name is sent to
+/// Firebase.
+///
+/// The following operations will result in sending a screen view event:
+/// ```dart
+/// Navigator.pushNamed(context, '/contact/123');
+///
+/// Navigator.push<void>(context, MaterialPageRoute(
+///   settings: RouteSettings(name: '/contact/123'),
+///   builder: (_) => ContactDetail(123)));
+///
+/// Navigator.pushReplacement<void>(context, MaterialPageRoute(
+///   settings: RouteSettings(name: '/contact/123'),
+///   builder: (_) => ContactDetail(123)));
+///
+/// Navigator.pop(context);
+/// ```
+///
+/// To use it, add it to the `navigatorObservers` of your [Navigator], e.g. if
+/// you're using a [MaterialApp]:
+/// ```dart
+/// MaterialApp(
+///   home: MyAppHome(),
+///   navigatorObservers: [
+///     FirebaseAnalyticsObserver(analytics: service.analytics),
+///   ],
+/// );
+/// ```
+///
+/// You can also track screen views within your [PageRoute] by implementing
+/// [PageRouteAware] and subscribing it to [FirebaseAnalyticsObserver]. See the
+/// [PageRouteObserver] docs for an example.
+class FirebaseAnalyticsObserver extends RouteObserver<PageRoute<dynamic>> {
+  /// Creates a [NavigatorObserver] that sends events to [FirebaseAnalytics].
+  ///
+  /// When a route is pushed or popped, [nameExtractor] is used to extract a
+  /// name from [RouteSettings] of the now active route and that name is sent to
+  /// Firebase. Defaults to `defaultNameExtractor`.
+  ///
+  /// If a [PlatformException] is thrown while the observer attempts to send the
+  /// active route to [analytics], `onError` will be called with the
+  /// exception. If `onError` is omitted, the exception will be printed using
+  /// `debugPrint()`.
+  FirebaseAnalyticsObserver({
+    required this.analytics,
+    this.nameExtractor = defaultNameExtractor,
+    Function(PlatformException error)? onError,
+  }) : _onError = onError;
+
+  final FirebaseAnalytics analytics;
+  final ScreenNameExtractor nameExtractor;
+  final void Function(PlatformException error)? _onError;
+
+  void _sendScreenView(PageRoute<dynamic> route) {
+    final String? screenName = nameExtractor(route.settings);
+    if (screenName != null) {
+      analytics.setCurrentScreen(screenName: screenName).catchError(
+            (Object error) {
+          final _onError = this._onError;
+          if (_onError == null) {
+            debugPrint('$FirebaseAnalyticsObserver: $error');
+          } else {
+            _onError(error as PlatformException);
+          }
+        },
+        test: (Object error) => error is PlatformException,
+      );
+    }
+  }
+
+  @override
+  void didPush(Route<dynamic> route, Route<dynamic>? previousRoute) {
+    super.didPush(route, previousRoute);
+    if (route is PageRoute) {
+      _sendScreenView(route);
+    }
+  }
+
+  @override
+  void didReplace({Route<dynamic>? newRoute, Route<dynamic>? oldRoute}) {
+    super.didReplace(newRoute: newRoute, oldRoute: oldRoute);
+    if (newRoute is PageRoute) {
+      _sendScreenView(newRoute);
+    }
+  }
+
+  @override
+  void didPop(Route<dynamic> route, Route<dynamic>? previousRoute) {
+    super.didPop(route, previousRoute);
+    if (previousRoute is PageRoute && route is PageRoute) {
+      _sendScreenView(previousRoute);
+    }
+  }
+}

--- a/packages/firebase_analytics/firebase_analytics/lib/src/observer.dart
+++ b/packages/firebase_analytics/firebase_analytics/lib/src/observer.dart
@@ -74,7 +74,7 @@ class FirebaseAnalyticsObserver extends RouteObserver<PageRoute<dynamic>> {
     final String? screenName = nameExtractor(route.settings);
     if (screenName != null) {
       analytics.setCurrentScreen(screenName: screenName).catchError(
-            (Object error) {
+        (Object error) {
           final _onError = this._onError;
           if (_onError == null) {
             debugPrint('$FirebaseAnalyticsObserver: $error');


### PR DESCRIPTION
## Description

Reinstate analytics observer.

## Related Issues

fixes https://github.com/FirebaseExtended/flutterfire/issues/7526

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
