### PR TITLE
fix(firebase_database): downgrade the Android min SDK to 19

### DIFF
--- a/packages/firebase_database/firebase_database/android/build.gradle
+++ b/packages/firebase_database/firebase_database/android/build.gradle
@@ -38,7 +38,7 @@ android {
     compileSdkVersion 30
 
     defaultConfig {
-        minSdkVersion 21
+        minSdkVersion 19
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }
     lintOptions {

--- a/packages/firebase_database/firebase_database/example/android/app/build.gradle
+++ b/packages/firebase_database/firebase_database/example/android/app/build.gradle
@@ -34,7 +34,7 @@ android {
 
   defaultConfig {
     applicationId 'com.invertase.testing'
-    minSdkVersion 21
+    minSdkVersion 19
     targetSdkVersion 30
     versionCode flutterVersionCode.toInteger()
     versionName flutterVersionName


### PR DESCRIPTION
## Description

Don't know the reason Why the minSdkVersion is 21 from version `9.0.0`. So making it 19 similar to most of the other firebase packages.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
