### PR TITLE
docs: firebase_auth -> firebase_messaging in overview

### DIFF
--- a/docs/messaging/overview.mdx
+++ b/docs/messaging/overview.mdx
@@ -24,7 +24,7 @@ a payload of up to 4 KB to a client app.
 On the root of your Flutter project, run the following command to install the plugin:
 
 ```bash {5}
-flutter pub add firebase_auth
+flutter pub add firebase_messaging
 ```
 
 ### 3. Android Integration


### PR DESCRIPTION
## Description

In the docs for Firebase Cloud Messaging, the installation references `firebase_auth`. It should reference `firebase_messaging `

## Checklist

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [X] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [X] All existing and new tests are passing.
- [X] I updated/added relevant documentation (doc comments with `///`).
- [X] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [X] I read and followed the [Flutter Style Guide].
- [X] I signed the [CLA].
- [X] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [X] No, this is *not* a breaking change.
