### PR TITLE
docs(ui): fix twitter provider typo

### DIFF
--- a/docs/ui/auth/building-a-custom-ui.mdx
+++ b/docs/ui/auth/building-a-custom-ui.mdx
@@ -167,6 +167,6 @@ Here's a list of all auth controllers provided by the FlutterFire UI library:
   - [`GoogleProviderConfiguration`](https://pub.dev/documentation/flutterfire_ui/latest/auth/GoogleProviderConfiguration-class.html) – Google sign in
   - [`FacebookProviderConfiguration`](https://pub.dev/documentation/flutterfire_ui/latest/auth/FacebookProviderConfiguration-class.html) – Facebook sign in
   - [`AppleProviderConfiguration`](https://pub.dev/documentation/flutterfire_ui/latest/auth/AppleProviderConfiguration-class.html) – Apple sign in
-  - [`TwitterProviderConfiguration`](https://pub.dev/documentation/flutterfire_ui/latest/auth/TwitterProviderConfiguration-class.html) – Google sign in
+  - [`TwitterProviderConfiguration`](https://pub.dev/documentation/flutterfire_ui/latest/auth/TwitterProviderConfiguration-class.html) – Twitter sign in
 
 - [`PhoneAuthController`](https://pub.dev/documentation/flutterfire_ui/latest/auth/PhoneAuthController-class.html) – sign in with phone number


### PR DESCRIPTION
## Description

Twitter Provider info was mislabeled as Google.


