### PR TITLE
fix: Make Firebase UI Sign In Screen demo work

### DIFF
--- a/docs/ui/auth/integrating-your-first-screen.mdx
+++ b/docs/ui/auth/integrating-your-first-screen.mdx
@@ -70,7 +70,7 @@ class AuthGate extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return StreamBuilder<FirebaseUser?>(
+    return StreamBuilder<User?>(
       stream: FirebaseAuth.instance.authStateChanges(),
       builder: (context, snapshot) {
         // ...
@@ -110,7 +110,7 @@ Screens are customizable fully styled widgets designed to be rendered as a singl
 import the FlutterFire UI package:
 
 ```dart
-import 'package:flutterfire_ui/flutterfire_ui.dart';
+import 'package:flutterfire_ui/auth.dart';
 ```
 
 Next, go ahead and return a new `SignInScreen` from the builder if the user is not signed in:

--- a/docs/ui/auth/integrating-your-first-screen.mdx
+++ b/docs/ui/auth/integrating-your-first-screen.mdx
@@ -82,11 +82,11 @@ class AuthGate extends StatelessWidget {
 
 Our application starts by subscribing to the users authentication state, which is provided as the
 `snapshot` to the Stream builder. To check whether the user is authenticated, the snapshot will contain
-a `FirebaseUser` instance, or `null` if they are not. Using the snapshots [`hasData`](https://api.flutter.dev/flutter/widgets/AsyncSnapshot/hasData.html)
+a `User` instance, or `null` if they are not. Using the snapshots [`hasData`](https://api.flutter.dev/flutter/widgets/AsyncSnapshot/hasData.html)
 property we can conditionally display the sign in screen if no user is signed in:
 
 ```dart
-return StreamBuilder<FirebaseUser?>(
+return StreamBuilder<User?>(
   stream: FirebaseAuth.instance.authStateChanges(),
   builder: (context, snapshot) {
     // User is not signed in
@@ -116,7 +116,7 @@ import 'package:flutterfire_ui/auth.dart';
 Next, go ahead and return a new `SignInScreen` from the builder if the user is not signed in:
 
 ```dart
-return StreamBuilder<FirebaseUser?>(
+return StreamBuilder<User?>(
   stream: FirebaseAuth.instance.authStateChanges(),
   builder: (context, snapshot) {
     // User is not signed in


### PR DESCRIPTION
## Description

It seems like some class and file names have changed since the demo code was written.  This changes fixes those so that the demo code compiles and works by itself.

## Related Issues


## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
