### PR TITLE
docs: broken link in cloud_firestore_odm

### DIFF
--- a/docs/firestore-odm/overview.mdx
+++ b/docs/firestore-odm/overview.mdx
@@ -62,4 +62,4 @@ flutter pub add --dev json_serializable
 
 ## Next Steps
 
-Once installed, read the documentation on [defining models](./defining-models).
+Once installed, read the documentation on [defining models](./defining-models.mdx).


### PR DESCRIPTION
## Description

Link at the bottom of [flutterfire cloud_firestore_odm](https://firebase.flutter.dev/docs/firestore-odm/overview/#next-steps) is broken. Clicking "defining models" under "Next steps" returns 404. (NB: There are 2 "defining models" links). One returns 404 while the other goes to the right page.)

## Related Issues

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
