### PR TITLE
docs: Fixed validator names in cloud_firestore_odm to start with an uppercase letters

### DIFF
--- a/docs/firestore-odm/defining-models.mdx
+++ b/docs/firestore-odm/defining-models.mdx
@@ -48,7 +48,7 @@ but what about more bespoke validation?
 For example, a users age cannot be a negative value, so how do we validate against this?
 
 The ODM provides some basic annotation validators which can be used on model properties. In this
-example, we can take advantage of the `min` validator:
+example, we can take advantage of the `Min` validator:
 
 ```dart
 @JsonSerializable()
@@ -65,13 +65,13 @@ class User {
   final String name;
   final String email;
 
-  // Apply the `min` validator
-  @min(0)
+  // Apply the `Min` validator
+  @Min(0)
   final int age;
 }
 ```
 
-The `min` annotation ensures that any value for the `age` property is always positive, otherwise an
+The `Min` annotation ensures that any value for the `age` property is always positive, otherwise an
 error will be thrown.
 
 To ensure validators are applied, the model instance is provided to the generated `$asserUser`
@@ -86,8 +86,8 @@ The following annotations are available for `int` properties:
 
 | Annotation | Description                                        |
 |------------|----------------------------------------------------|
-| `min`      | Validates a number is not less than this value.    |
-| `max`      | Validates a number is not greater than this value. |
+| `Min`      | Validates a number is not less than this value.    |
+| `Max`      | Validates a number is not greater than this value. |
 
 ### Custom validators
 


### PR DESCRIPTION
## Description

The example of the cloud_firestore_odm validator starts with a lowercase letter. Corrected `min` to `Min` and `max` to `Max`.

## Related Issues

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
