### PR TITLE
fix(ui): some OAuth providers now work on macOS & web

### DIFF
--- a/packages/flutterfire_ui/lib/src/auth/oauth/providers/facebook_provider.dart
+++ b/packages/flutterfire_ui/lib/src/auth/oauth/providers/facebook_provider.dart
@@ -90,6 +90,7 @@ class FacebookProviderConfiguration extends OAuthProviderConfiguration {
   bool isSupportedPlatform(TargetPlatform platform) {
     return platform == TargetPlatform.android ||
         platform == TargetPlatform.iOS ||
-        platform == TargetPlatform.macOS;
+        platform == TargetPlatform.macOS ||
+        kIsWeb;
   }
 }

--- a/packages/flutterfire_ui/lib/src/auth/oauth/providers/google_provider.dart
+++ b/packages/flutterfire_ui/lib/src/auth/oauth/providers/google_provider.dart
@@ -91,6 +91,7 @@ class GoogleProviderConfiguration extends OAuthProviderConfiguration {
   bool isSupportedPlatform(TargetPlatform platform) {
     return platform == TargetPlatform.android ||
         platform == TargetPlatform.iOS ||
-        platform == TargetPlatform.macOS;
+        platform == TargetPlatform.macOS ||
+        kIsWeb;
   }
 }


### PR DESCRIPTION
## Description

I just found that some `flutterfire_ui` oauth providers work under mobile web, but platform detection gives incorrect result when running under desktop web.

[google_sign_in](https://pub.dev/packages/google_sign_in), [sign_in_with_apple](https://pub.dev/packages/sign_in_with_apple), [flutter_facebook_auth](https://pub.dev/packages/flutter_facebook_auth) work on web as noted on `pub.dev`.

We could use `os_detect` package for better platform detection but I am not sure about that and decided to start with a simplest change.

Note:
- I not added tests - currently I don't see any existing tests for `flutterfire_ui` package.
- `melos run analyze` is failing on my machine with several `depend_on_referenced_packages` issues. I am not sure if I should use older Dart SDK, I did not found anything about this in Contributor Guide.  This is my first contribution to this FlutterFire, am I missing something?

## Related Issues

I tried to search but not found any issues about this.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] All existing and new tests are passing.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
