### PR TITLE
bugfix: uncaught exception 'NSInvalidArgumentException', reason: '-[NSNull longValue]

### DIFF
--- a/packages/firebase_performance/firebase_performance/ios/Classes/FLTHttpMetric.m
+++ b/packages/firebase_performance/firebase_performance/ios/Classes/FLTHttpMetric.m
@@ -45,16 +45,16 @@
         [_metric setValue:value forAttribute:attributeName];
       }];
 
-  if (httpResponseCode != nil) {
+  if (![httpResponseCode isKindOfClass:[NSNull class]] && httpResponseCode != nil) {
     _metric.responseCode = [httpResponseCode integerValue];
   }
-  if (responseContentType != nil) {
+  if (![responseContentType isKindOfClass:[NSNull class]] && responseContentType != nil) {
     _metric.responseContentType = responseContentType;
   }
-  if (requestPayloadSize != nil) {
+  if (![requestPayloadSize isKindOfClass:[NSNull class]] && requestPayloadSize != nil) {
     _metric.requestPayloadSize = [requestPayloadSize longValue];
   }
-  if (responsePayloadSize != nil) {
+  if (![responsePayloadSize isKindOfClass:[NSNull class]] && responsePayloadSize != nil) {
     _metric.responsePayloadSize = [responsePayloadSize longValue];
   }
 


### PR DESCRIPTION
Terminating app due to uncaught exception 'NSInvalidArgumentException', reason: '-[NSNull longValue]

## Description

* fix app crash

```shell
*** Terminating app due to uncaught exception 'NSInvalidArgumentException', reason: '-[NSNull longValue]: unrecognized selector sent to instance 0x111df2fb0'
*** First throw call stack:
(
	0   CoreFoundation                      0x0000000111b01bb4 __exceptionPreprocess + 242
	1   libobjc.A.dylib                     0x000000010f7f7be7 objc_exception_throw + 48
	2   CoreFoundation                      0x0000000111b10821 +[NSObject(NSObject) instanceMethodSignatureForSelector:] + 0
	3   CoreFoundation                      0x0000000111b060bc ___forwarding___ + 1433
	4   CoreFoundation                      0x0000000111b081e8 _CF_forwarding_prep_0 + 120
	5   flip                                0x000000010c440d7b -[FLTHttpMetric stop:result:] + 530
	6   flip                                0x000000010c440aec -[FLTHttpMetric handleMethodCall:result:] + 220
	7   flip                                0x000000010c44081b -[FLTFirebasePerformancePlugin handleMethodCall:result:] + 376
	8   Flutter                             0x00000001168948a1 __45-[FlutterMethodChannel setMethodCallHandler:]_block_invoke + 104
	9   Flutter                             0x000000011633dc4d _ZNK7flutter21PlatformMessageRouter21HandlePlatformMessageENSt3__110unique_ptrINS_15PlatformMessageENS1_14default_deleteIS3_EEEE + 193
	10  Flutter                             0x0000000116343307 _ZN7flutter15PlatformViewIOS21HandlePlatformMessageENSt3__110unique_ptrINS_15PlatformMessageENS1_14default_deleteIS3_EEEE + 35
	11  Flutter                             0x000000011676e6c9 _ZNSt3__110__function6__funcIN3fml8internal14CopyableLambdaIZN7flutter5Shell29OnEngineHandlePlatformMessageENS_10unique_ptrINS5_15PlatformMessageENS_14default_deleteIS8_EEEEE4$_16EENS_9allocatorISD_EEFvvEEclEv + 81
	12  Flutter                             0x0000000116673866 _ZN3fml15MessageLoopImpl10FlushTasksENS_9FlushTypeE + 164
	13  Flutter                             0x0000000116679d18 _ZN3fml17MessageLoopDarwin11OnTimerFireEP16__CFRunLoopTimerPS0_ + 26
	14  CoreFoundation                      0x0000000111a706c6 __CFRUNLOOP_IS_CALLING_OUT_TO_A_TIMER_CALLBACK_FUNCTION__ + 20
	15  CoreFoundation                      0x0000000111a701c2 __CFRunLoopDoTimer + 923
	16  CoreFoundation                      0x0000000111a6f781 __CFRunLoopDoTimers + 265
	17  CoreFoundation                      0x0000000111a69dc0 __CFRunLoopRun + 2010
	18  CoreFoundation                      0x0000000111a69103 CFRunLoopRunSpecific + 567
	19  GraphicsServices                    0x0000000119b93cd3 GSEventRunModal + 139
	20  UIKitCore                           0x000000012a694e63 -[UIApplication _run] + 928
	21  UIKitCore                           0x000000012a699a53 UIApplicationMain + 101
	22  flip                                0x000000010c24ffdf main + 63
	23  dyld                                0x000000010c6abe1e start_sim + 10
	24  ???                                 0x0000000000000001 0x0 + 1
)
libc++abi: terminating with uncaught exception of type NSException
```

## Related Issues

*Replace this paragraph with a list of issues related to this PR from the [issue database](https://github.com/flutter/flutter/issues). Indicate, which of these issues are resolved or fixed by this PR. Note that you'll have to prefix the issue numbers with flutter/flutter#.*

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
