### PR TITLE
fix(firebase_messaging, firebase_crashlytics): Return app constants for default app only on `Android`.

### DIFF
--- a/packages/firebase_crashlytics/firebase_crashlytics/android/src/main/java/io/flutter/plugins/firebase/crashlytics/FlutterFirebaseCrashlyticsPlugin.java
+++ b/packages/firebase_crashlytics/firebase_crashlytics/android/src/main/java/io/flutter/plugins/firebase/crashlytics/FlutterFirebaseCrashlyticsPlugin.java
@@ -336,9 +336,10 @@ public class FlutterFirebaseCrashlyticsPlugin
         () ->
             new HashMap<String, Object>() {
               {
-                put(
-                    Constants.IS_CRASHLYTICS_COLLECTION_ENABLED,
-                    isCrashlyticsCollectionEnabled(FirebaseApp.getInstance()));
+                if (firebaseApp.getName().equals("[DEFAULT]"))
+                  put(
+                      Constants.IS_CRASHLYTICS_COLLECTION_ENABLED,
+                      isCrashlyticsCollectionEnabled(FirebaseApp.getInstance()));
               }
             });
   }

--- a/packages/firebase_messaging/firebase_messaging/android/src/main/java/io/flutter/plugins/firebase/messaging/FlutterFirebaseMessagingPlugin.java
+++ b/packages/firebase_messaging/firebase_messaging/android/src/main/java/io/flutter/plugins/firebase/messaging/FlutterFirebaseMessagingPlugin.java
@@ -409,8 +409,10 @@ public class FlutterFirebaseMessagingPlugin extends BroadcastReceiver
         cachedThreadPool,
         () -> {
           Map<String, Object> constants = new HashMap<>();
-          FirebaseMessaging firebaseMessaging = FirebaseMessaging.getInstance();
-          constants.put("AUTO_INIT_ENABLED", firebaseMessaging.isAutoInitEnabled());
+          if (firebaseApp.getName().equals("[DEFAULT]")) {
+            FirebaseMessaging firebaseMessaging = FirebaseMessaging.getInstance();
+            constants.put("AUTO_INIT_ENABLED", firebaseMessaging.isAutoInitEnabled());
+          }
           return constants;
         });
   }


### PR DESCRIPTION
## Description

See title.

## Related Issues

*Replace this paragraph with a list of issues related to this PR from the [issue database](https://github.com/flutter/flutter/issues). Indicate, which of these issues are resolved or fixed by this PR. Note that you'll have to prefix the issue numbers with flutter/flutter#.*

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
