### PR TITLE
chore: exclude generated_plugin_registrant.dart from anlaysis

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -11,6 +11,8 @@ analyzer:
     # We explicitly enabled even conflicting rules and are fixing the conflict
     # in this file
     included_file_warning: ignore
+  exclude:
+    - packages/**/example/lib/generated_plugin_registrant.dart
 
 linter:
   rules:


### PR DESCRIPTION
## Description

This PR makes analyzer ignore `generated_plugin_registrant.dart` in web examples

## Related Issues

#7576

> melos run analyze is failing on my machine with several depend_on_referenced_packages issues. I am not sure if I should use older Dart SDK, I did not found anything about this in Contributor Guide. This is my first contribution to this FlutterFire, am I missing something?

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
