### PR TITLE
fix(firebase_messaging): Ensure correct `sentTime` date is passed with `RemoteMessage` on iOS.

### DIFF
--- a/packages/firebase_messaging/firebase_messaging/ios/Classes/FLTFirebaseMessagingPlugin.m
+++ b/packages/firebase_messaging/firebase_messaging/ios/Classes/FLTFirebaseMessagingPlugin.m
@@ -948,9 +948,9 @@ NSString *const kMessagingPresentationOptionsUserDefaults =
   }
 
   if (message[@"sentTime"] == nil && notificationDate != nil) {
-    NSNumber *milliSeconds =
-        [NSNumber numberWithDouble:[notificationDate timeIntervalSinceReferenceDate] * 1000];
-    message[@"sentTime"] = @([milliSeconds doubleValue]);
+    NSTimeInterval seconds = [notificationDate timeIntervalSince1970];
+    NSNumber *milliseconds = [NSNumber numberWithDouble:seconds * 1000];
+    message[@"sentTime"] = @([milliseconds doubleValue]);
   }
 
   return message;

--- a/packages/firebase_messaging/firebase_messaging_platform_interface/lib/src/remote_message.dart
+++ b/packages/firebase_messaging/firebase_messaging_platform_interface/lib/src/remote_message.dart
@@ -25,6 +25,10 @@ class RemoteMessage {
 
   /// Constructs a [RemoteMessage] from a raw Map.
   factory RemoteMessage.fromMap(Map<String, dynamic> map) {
+    if (map['sentTime'] is double) {
+      map['sentTime'] = (map['sentTime'] as double).round();
+    }
+
     return RemoteMessage(
       senderId: map['senderId'],
       category: map['category'],


### PR DESCRIPTION
## Description

See title. 

Xcode console log of correct value sent as double in milliseconds since epoch (1970)  from iOS side:

<img width="673" alt="Screenshot 2021-12-16 at 10 42 39" src="https://user-images.githubusercontent.com/16018629/146357488-9b44705a-fa48-4da1-bcc1-42476533ae77.png">


## Related Issues

fixes https://github.com/FirebaseExtended/flutterfire/issues/7434

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
