### PR TITLE
fix(flutterfire_ui): not working onTap in OAuthProviderButtonWidget

### DIFF
--- a/packages/flutterfire_ui/lib/src/auth/widgets/internal/oauth_provider_button.dart
+++ b/packages/flutterfire_ui/lib/src/auth/widgets/internal/oauth_provider_button.dart
@@ -272,6 +272,7 @@ abstract class OAuthProviderButtonWidget extends StatelessWidget {
       action: action,
       auth: auth,
       size: size ?? 19,
+      onTap: onTap,
     );
   }
 }


### PR DESCRIPTION
## Description

I fixed not working onTap in OAuthProviderButtonWidget (flutterfire_ui)
I added the 'onTap' to 'OAuthProviderButton' where are in 'build' method in 'OAuthProviderButtonWidget' 

Because "GoogleSignInButton Widget's onTap function" wasn't working.
I found no 'onTap' in 'OAuthProviderButton' where are in 'build' method in 'OAuthProviderButtonWidget',
so, I think this is the reason.

I'm sure 'GoogleSignInButton' works correctly with this change.

Hopefully you can review this PR and if something is wrong I would be glad to hear this.

I hope this will help for many as well as for me. Thank you!

## Related Issues

nothing

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
Sorry, I couldn't test this change because there isn't 'GoogleSignInButton' widget or else with 'onTap' property in example App .
I tried widget test, but I can't test this change because 'OAuthProviderButton' need 'Firebase.initializeApp'.
But, this change is so small and I'm sure 'GoogleSignInButton' works correctly with this change.

- [x] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
I think this change don't need it.

- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
