### PR TITLE
docs(firebase_crashlytics): Fix step numbering in crashlytics/overview.mdx.

### DIFF
--- a/docs/crashlytics/overview.mdx
+++ b/docs/crashlytics/overview.mdx
@@ -71,7 +71,7 @@ $PODS_ROOT/FirebaseCrashlytics/upload-symbols --build-phase -ai <googleAppId>
 
 Retrieve your `<googleAppId>` from your generated `DefaultFirebaseOptions` file (`appId`) or from the Firebase Console -> Project Settings -> Your apps.
 
-### 4. Rebuild your app
+### 3. Rebuild your app
 
 Once complete, rebuild your Flutter application:
 


### PR DESCRIPTION
## Description

Fixes the incorrect step numbering:

![Screenshot 2021-12-29 at 12 26 57](https://user-images.githubusercontent.com/40776291/147657621-d9293680-cc29-4744-90cc-bb0e39b4cff1.png)

