### PR TITLE
fix(dynamic_links): Ensure Dynamic link is retrieved from the Intent just once for `getInitialLink()` on Android as per the documentation.

### DIFF
--- a/packages/firebase_dynamic_links/firebase_dynamic_links/android/src/main/java/io/flutter/plugins/firebase/dynamiclinks/FlutterFirebaseDynamicLinksPlugin.java
+++ b/packages/firebase_dynamic_links/firebase_dynamic_links/android/src/main/java/io/flutter/plugins/firebase/dynamiclinks/FlutterFirebaseDynamicLinksPlugin.java
@@ -220,13 +220,13 @@ public class FlutterFirebaseDynamicLinksPlugin
             // If there's no activity or initial Intent, then there's no initial dynamic link.
             if (activity.get() == null
                 || activity.get().getIntent() == null
-                || activity.get().getIntent().getBooleanExtra("used-link", false)) {
+                || activity.get().getIntent().getBooleanExtra("flutterfire-used-link", false)) {
               return null;
             }
             pendingDynamicLink =
                 Tasks.await(dynamicLinks.getDynamicLink(activity.get().getIntent()));
 
-            activity.get().getIntent().putExtra("used-link", true);
+            activity.get().getIntent().putExtra("flutterfire-used-link", true);
           }
 
           return Utils.getMapFromPendingDynamicLinkData(pendingDynamicLink);

--- a/packages/firebase_dynamic_links/firebase_dynamic_links/android/src/main/java/io/flutter/plugins/firebase/dynamiclinks/FlutterFirebaseDynamicLinksPlugin.java
+++ b/packages/firebase_dynamic_links/firebase_dynamic_links/android/src/main/java/io/flutter/plugins/firebase/dynamiclinks/FlutterFirebaseDynamicLinksPlugin.java
@@ -218,11 +218,15 @@ public class FlutterFirebaseDynamicLinksPlugin
             pendingDynamicLink = Tasks.await(dynamicLinks.getDynamicLink(Uri.parse(url)));
           } else {
             // If there's no activity or initial Intent, then there's no initial dynamic link.
-            if (activity.get() == null || activity.get().getIntent() == null) {
+            if (activity.get() == null
+                || activity.get().getIntent() == null
+                || activity.get().getIntent().getBooleanExtra("used-link", false)) {
               return null;
             }
             pendingDynamicLink =
                 Tasks.await(dynamicLinks.getDynamicLink(activity.get().getIntent()));
+
+            activity.get().getIntent().putExtra("used-link", true);
           }
 
           return Utils.getMapFromPendingDynamicLinkData(pendingDynamicLink);


### PR DESCRIPTION
## Description

See title.

## Related Issues

fixes https://github.com/FirebaseExtended/flutterfire/issues/6784

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
