### PR TITLE
docs(firebase_auth): add missing word to auth getting started page.

### DIFF
--- a/docs/ui/auth.mdx
+++ b/docs/ui/auth.mdx
@@ -5,7 +5,7 @@ sidebar_label: Getting Started
 
 FlutterFire UI for Auth provides a simple and easy way to implement authentication in your Flutter app.
 The library provides fully featured UI screens to drop into new or existing applications, along with
-lower level implementation details for developers looking tighter control.
+lower level implementation details for developers looking for tighter control.
 
 ## Installation
 


### PR DESCRIPTION
## Description

Add in a missing 'for' in the auth 'Getting Started' section.

## Related Issues

No related issues.

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
