### PR TITLE
fix(flutterfire_ui): Fix incorrect state when country code is null.

### DIFF
--- a/packages/flutterfire_ui/lib/src/auth/widgets/phone_input.dart
+++ b/packages/flutterfire_ui/lib/src/auth/widgets/phone_input.dart
@@ -135,6 +135,7 @@ class PhoneInputState extends State<PhoneInput> {
         (element) =>
             element.countryCode == countryCode ||
             element.phoneCode == phoneCode,
+        orElse: () => countries.first,
       );
 
       if (phoneCode != null &&


### PR DESCRIPTION
## Description

Currently on phone auth, when the user deletes country code it fires an error bad state, which is normal behavior of  countries.firstWhere( 

## Related Issues

Fixes *https://github.com/FirebaseExtended/flutterfire/issues/7694*

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x]  I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x]  I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
