### PR TITLE
fix(ui): validate email with the library instead of the RegExp

### DIFF
--- a/packages/flutterfire_ui/lib/src/auth/validators.dart
+++ b/packages/flutterfire_ui/lib/src/auth/validators.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/widgets.dart';
+import 'package:email_validator/email_validator.dart' as e;
 
 abstract class Validator {
   final String errorText;
@@ -42,15 +43,13 @@ class NotEmpty extends Validator {
   }
 }
 
-final _emailRegexp = RegExp(r'^[a-zA-Z0-9.]+@[a-zA-Z0-9]+\.[a-zA-Z]+');
-
 class EmailValidator extends Validator {
   EmailValidator(String errorText) : super(errorText, []);
 
   @override
   String? validate(String? value) {
     if (value == null) return errorText;
-    return _emailRegexp.hasMatch(value) ? null : errorText;
+    return e.EmailValidator.validate(value) ? null : errorText;
   }
 }
 

--- a/packages/flutterfire_ui/pubspec.yaml
+++ b/packages/flutterfire_ui/pubspec.yaml
@@ -16,6 +16,7 @@ dependencies:
   collection: ^1.15.0
   crypto: ^3.0.1
   desktop_webview_auth: ^0.0.2
+  email_validator: ^2.0.1
   firebase_auth: ^3.3.4
   firebase_core: ^1.10.2
   firebase_database: ^9.0.4


### PR DESCRIPTION
## Description

This PR changes the RegExp based email validator to [email_validator](https://pub.dev/packages/email_validator) package

## Related Issues

Closes #7761
Closes #7680 

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.