### PR TITLE
docs: update repository and homepage url

### DIFF
--- a/packages/flutterfire_ui/pubspec.yaml
+++ b/packages/flutterfire_ui/pubspec.yaml
@@ -1,8 +1,8 @@
 name: flutterfire_ui
 description: UI library built on top of firebase services
 version: 0.3.0
-repository: https://github.com/FirebaseExtended/flutterfire/tree/%40invertase/ui/packages
-homepage: https://github.com/FirebaseExtended/flutterfire/tree/%40invertase/ui/packages
+repository: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/flutterfire_ui
+homepage: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/flutterfire_ui
 
 false_secrets:
  - example/**


### PR DESCRIPTION
## Description

The repository url in the pubspec is broken. I updated it to the master channel of the flutterfire_ui package.

![image](https://user-images.githubusercontent.com/15101411/148111474-a6c9ac39-11a8-4a9e-9ab0-c34a40c85786.png)

## Related Issues

Didn't make an issue for this

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
