### PR TITLE
chore(firebase_crashlytics): Update example app to use Firebase app initialization from native service files.

### DIFF
--- a/packages/firebase_crashlytics/firebase_crashlytics/example/android/app/build.gradle
+++ b/packages/firebase_crashlytics/firebase_crashlytics/example/android/app/build.gradle
@@ -22,6 +22,7 @@ if (flutterVersionName == null) {
 }
 
 apply plugin: 'com.android.application'
+apply plugin: 'com.google.gms.google-services'
 apply from: "$flutterRoot/packages/flutter_tools/gradle/flutter.gradle"
 
 android {

--- a/packages/firebase_crashlytics/firebase_crashlytics/example/lib/main.dart
+++ b/packages/firebase_crashlytics/firebase_crashlytics/example/lib/main.dart
@@ -21,15 +21,7 @@ const _kTestingCrashlytics = true;
 Future<void> main() async {
   await runZonedGuarded(() async {
     WidgetsFlutterBinding.ensureInitialized();
-    await Firebase.initializeApp(
-      options: const FirebaseOptions(
-        apiKey: 'AIzaSyAHAsf51D0A407EklG1bs-5wA7EbyfNFg0',
-        appId: '1:448618578101:ios:2bc5c1fe2ec336f8ac3efc',
-        messagingSenderId: '448618578101',
-        authDomain: 'react-native-firebase-testing.firebaseapp.com',
-        projectId: 'react-native-firebase-testing',
-      ),
-    );
+    await Firebase.initializeApp();
     FlutterError.onError = FirebaseCrashlytics.instance.recordFlutterError;
     runApp(MyApp());
   }, (error, stackTrace) {


### PR DESCRIPTION
## Description

Crashlytics still requires the Firebase APP_ID in native service file according to issue reports. 
There is also another problem running from `runZonedGuarded` as the initialization is occurring too late and causes the app to throw an exception.

So Crashlytics still needs native initialization for now.

## Related Issues

none.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
