### PR TITLE
fix(firebase_analytics): user id and user properties can be null so `NSNull` should be converted to `nil` on iOS/macOS

### DIFF
--- a/packages/firebase_analytics/firebase_analytics/ios/Classes/FLTFirebaseAnalyticsPlugin.m
+++ b/packages/firebase_analytics/firebase_analytics/ios/Classes/FLTFirebaseAnalyticsPlugin.m
@@ -92,7 +92,7 @@ NSString *const FLTFirebaseAnalyticsChannelName = @"plugins.flutter.io/firebase_
 
 - (void)setUserId:(id)arguments withMethodCallResult:(FLTFirebaseMethodCallResult *)result {
   NSString *userId = arguments[kFLTFirebaseAnalyticsUserId];
-  [FIRAnalytics setUserID:userId];
+  [FIRAnalytics setUserID:[userId isKindOfClass:[NSNull class]] ? nil : userId];
 
   result.success(nil);
 }
@@ -100,7 +100,8 @@ NSString *const FLTFirebaseAnalyticsChannelName = @"plugins.flutter.io/firebase_
 - (void)setUserProperty:(id)arguments withMethodCallResult:(FLTFirebaseMethodCallResult *)result {
   NSString *name = arguments[kFLTFirebaseAnalyticsName];
   NSString *value = arguments[kFLTFirebaseAnalyticsValue];
-  [FIRAnalytics setUserPropertyString:value forName:name];
+  [FIRAnalytics setUserPropertyString:[value isKindOfClass:[NSNull class]] ? nil : value
+                              forName:name];
   result.success(nil);
 }
 


### PR DESCRIPTION
## Description

This PR adds the equivalent fixes for iOS described in #7662

Without these changes the null value is converted to NSNull in iOS MethodChannel and we see the following messages in log when setting user property or user id to null on iOS:

> User ID must be NSString. User ID: (nil)
> User property must be NSString. Value: (nil)

## Related Issues

#7662 (is already fixed for Android with #7735)

## Related pull requests

#7545 (allows to set user id to null on Android)

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.
