### PR TITLE
feat: throw if query.where is used with no filter

### DIFF
--- a/packages/cloud_firestore/cloud_firestore/example/test_driver/query_e2e.dart
+++ b/packages/cloud_firestore/cloud_firestore/example/test_driver/query_e2e.dart
@@ -973,7 +973,7 @@ void runQueryTests() {
 
         expect(
           () => collection.where('foo'),
-          throwsA(isA<FirebaseException>()),
+          throwsA(isA<AssertionError>()),
         );
       });
 

--- a/packages/cloud_firestore/cloud_firestore/example/test_driver/query_e2e.dart
+++ b/packages/cloud_firestore/cloud_firestore/example/test_driver/query_e2e.dart
@@ -967,6 +967,16 @@ void runQueryTests() {
      */
 
     group('Query.where()', () {
+      test('throws if where is used with no parameter', () async {
+        CollectionReference<Map<String, dynamic>> collection =
+            await initializeTest('where()');
+
+        expect(
+          () => collection.where('foo'),
+          throwsA(isA<FirebaseException>()),
+        );
+      });
+
       test('returns documents when querying for properties that are not null',
           () async {
         CollectionReference<Map<String, dynamic>> collection =

--- a/packages/cloud_firestore/cloud_firestore/lib/src/query.dart
+++ b/packages/cloud_firestore/cloud_firestore/lib/src/query.dart
@@ -599,6 +599,21 @@ class _JsonQuery implements Query<Map<String, dynamic>> {
     List<Object?>? whereNotIn,
     bool? isNull,
   }) {
+    assert(
+      isEqualTo != null ||
+          isNotEqualTo != null ||
+          isLessThan != null ||
+          isLessThanOrEqualTo != null ||
+          isGreaterThan != null ||
+          isGreaterThanOrEqualTo != null ||
+          arrayContains != null ||
+          arrayContainsAny != null ||
+          whereIn != null ||
+          whereNotIn != null ||
+          isNull != null,
+      'The operator `where` must be used with at least one filter.',
+    );
+
     _assertValidFieldType(field);
 
     const ListEquality<dynamic> equality = ListEquality<dynamic>();


### PR DESCRIPTION
## Description

Related to https://stackoverflow.com/questions/68357522/firestore-null-query-returns-non-nullable-field/70642105

## Related Issues


## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [ ] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
