### PR TITLE
Handle potential typecast error

### DIFF
--- a/packages/firebase_messaging/firebase_messaging_platform_interface/lib/src/method_channel/utils/exception.dart
+++ b/packages/firebase_messaging/firebase_messaging_platform_interface/lib/src/method_channel/utils/exception.dart
@@ -5,6 +5,7 @@
 
 import 'package:firebase_core/firebase_core.dart';
 import 'package:flutter/services.dart';
+import 'package:logging/logging.dart';
 
 /// Catches a [PlatformException] and converts it into a [FirebaseException] if
 /// it was intentionally caught on the native platform.
@@ -23,9 +24,16 @@ Exception convertPlatformException(Object exception) {
 /// which can be converted into user friendly exceptions.
 FirebaseException platformExceptionToFirebaseException(
     PlatformException platformException) {
-  Map<String, String>? details = platformException.details != null
+  Map<String, String>? details;
+  try {
+    details = platformException.details != null
       ? Map<String, String>.from(platformException.details)
       : null;
+  } on Error catch (error) {
+    final _logger = Logger('FirebaseMessagingExceptionUtil');
+    _logger.severe(
+      'Failed to parse PlatformException details', error, error.stackTrace);
+  }
 
   String code = 'unknown';
   String? message = platformException.message;


### PR DESCRIPTION
While the error returned from native is usually a valid Map<String, String>, it isn't guaranteed. So, we should handle the potential TypeError.

## Description

Handling a potential TypeError from an unsafe cast.

## Related Issues

None.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
