### PR TITLE
feat(ui): Sign in theme

### DIFF
--- a/packages/flutterfire_ui/example/pubspec.yaml
+++ b/packages/flutterfire_ui/example/pubspec.yaml
@@ -30,7 +30,7 @@ dependencies:
   firebase_dynamic_links: ^4.0.4
   flutter:
     sdk: flutter
-  flutter_facebook_auth: '^3.5.0'
+  flutter_facebook_auth: '^4.0.1'
   flutter_svg: ^1.0.0
   flutterfire_ui:
     path: ../

--- a/packages/flutterfire_ui/lib/auth.dart
+++ b/packages/flutterfire_ui/lib/auth.dart
@@ -91,3 +91,5 @@ export 'src/auth/configs/phone_provider_configuration.dart';
 export 'src/auth/configs/oauth_provider_configuration.dart';
 export 'src/auth/configs/email_link_provider_configuration.dart';
 export 'src/auth/configs/provider_configuration.dart';
+
+export 'src/auth/theme/sign_in_screen_theme.dart' show SignInScreenTheme;

--- a/packages/flutterfire_ui/lib/src/auth/screens/internal/login_screen.dart
+++ b/packages/flutterfire_ui/lib/src/auth/screens/internal/login_screen.dart
@@ -1,7 +1,6 @@
 import 'package:flutter/widgets.dart';
 import 'package:flutterfire_ui/auth.dart';
 import 'package:firebase_auth/firebase_auth.dart' show FirebaseAuth;
-import 'package:flutterfire_ui/src/auth/theme/sign_in_screen_theme.dart';
 
 import '../../widgets/internal/universal_scaffold.dart';
 

--- a/packages/flutterfire_ui/lib/src/auth/screens/internal/login_screen.dart
+++ b/packages/flutterfire_ui/lib/src/auth/screens/internal/login_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/widgets.dart';
 import 'package:flutterfire_ui/auth.dart';
 import 'package:firebase_auth/firebase_auth.dart' show FirebaseAuth;
+import 'package:flutterfire_ui/src/auth/theme/sign_in_screen_theme.dart';
 
 import '../../widgets/internal/universal_scaffold.dart';
 
@@ -20,6 +21,7 @@ class LoginScreen extends StatelessWidget {
   final AuthViewContentBuilder? subtitleBuilder;
   final AuthViewContentBuilder? footerBuilder;
   final Key? loginViewKey;
+  final SignInScreenTheme? signInScreenTheme;
 
   const LoginScreen({
     Key? key,
@@ -36,6 +38,7 @@ class LoginScreen extends StatelessWidget {
     this.subtitleBuilder,
     this.footerBuilder,
     this.loginViewKey,
+    this.signInScreenTheme,
   }) : super(key: key);
 
   @override
@@ -54,6 +57,7 @@ class LoginScreen extends StatelessWidget {
           showAuthActionSwitch: showAuthActionSwitch,
           subtitleBuilder: subtitleBuilder,
           footerBuilder: footerBuilder,
+          signInScreenTheme: signInScreenTheme,
         ),
       ),
     );
@@ -64,6 +68,7 @@ class LoginScreen extends StatelessWidget {
       headerBuilder: headerBuilder,
       headerMaxExtent: headerMaxExtent,
       sideBuilder: sideBuilder,
+      signInScreenTheme: signInScreenTheme,
       child: loginContent,
     );
 

--- a/packages/flutterfire_ui/lib/src/auth/screens/internal/responsive_page.dart
+++ b/packages/flutterfire_ui/lib/src/auth/screens/internal/responsive_page.dart
@@ -1,4 +1,6 @@
-import 'package:flutter/widgets.dart';
+import 'package:flutter/material.dart';
+import 'package:flutterfire_ui/src/auth/theme/sign_in_screen_theme.dart';
+// import 'package:flutter/widgets.dart';
 
 import '../../widgets/internal/keyboard_appearence_listener.dart';
 
@@ -58,6 +60,7 @@ class ResponsivePage extends StatefulWidget {
   final double? breakpoint;
   final int? contentFlex;
   final double? maxWidth;
+  final SignInScreenTheme? signInScreenTheme;
 
   const ResponsivePage({
     Key? key,
@@ -69,6 +72,7 @@ class ResponsivePage extends StatefulWidget {
     this.breakpoint,
     this.contentFlex,
     this.maxWidth,
+    this.signInScreenTheme,
   }) : super(key: key);
 
   @override
@@ -94,83 +98,87 @@ class _ResponsivePageState extends State<ResponsivePage> {
   Widget build(BuildContext context) {
     final breakpoint = widget.breakpoint ?? 800;
 
-    return LayoutBuilder(
-      builder: (context, constraints) {
-        if (constraints.biggest.width > breakpoint) {
-          return Center(
-            child: ConstrainedBox(
-              constraints: BoxConstraints(
-                maxWidth: widget.maxWidth ?? constraints.biggest.width,
-              ),
-              child: Row(
-                textDirection: widget.desktopLayoutDirection,
-                children: <Widget>[
-                  if (widget.sideBuilder != null)
-                    Expanded(
-                      child: LayoutBuilder(
-                        builder: (context, constraints) {
-                          return widget.sideBuilder!(context, constraints);
-                        },
+    return Container(
+      color: widget.signInScreenTheme?.backgroundColor,
+      child: LayoutBuilder(
+        builder: (context, constraints) {
+          if (constraints.biggest.width > breakpoint) {
+            return Center(
+              child: ConstrainedBox(
+                constraints: BoxConstraints(
+                  maxWidth: widget.maxWidth ?? constraints.biggest.width,
+                ),
+                child: Row(
+                  textDirection: widget.desktopLayoutDirection,
+                  children: <Widget>[
+                    if (widget.sideBuilder != null)
+                      Expanded(
+                        child: LayoutBuilder(
+                          builder: (context, constraints) {
+                            return widget.sideBuilder!(context, constraints);
+                          },
+                        ),
                       ),
-                    ),
-                  Expanded(
-                    flex: widget.contentFlex ?? 1,
-                    child: Center(
-                      child: ListView(
-                        shrinkWrap: true,
-                        children: [
-                          Center(
-                            child: ConstrainedBox(
-                              constraints: BoxConstraints(maxWidth: breakpoint),
-                              child: IntrinsicHeight(
-                                child: widget.child,
+                    Expanded(
+                      flex: widget.contentFlex ?? 1,
+                      child: Center(
+                        child: ListView(
+                          shrinkWrap: true,
+                          children: [
+                            Center(
+                              child: ConstrainedBox(
+                                constraints:
+                                    BoxConstraints(maxWidth: breakpoint),
+                                child: IntrinsicHeight(
+                                  child: widget.child,
+                                ),
                               ),
                             ),
-                          ),
-                        ],
+                          ],
+                        ),
                       ),
-                    ),
-                  )
+                    )
+                  ],
+                ),
+              ),
+            );
+          } else if (widget.headerBuilder != null) {
+            return Padding(
+              padding: EdgeInsets.only(top: MediaQuery.of(context).padding.top),
+              child: KeyboardAppearenceListener(
+                listener: _onKeyboardPositionChanged,
+                child: CustomScrollView(
+                  controller: ctrl,
+                  slivers: [
+                    if (widget.headerBuilder != null)
+                      SliverPersistentHeader(
+                        delegate: LoginImageSliverDelegate(
+                          maxExtent: widget.headerMaxExtent ??
+                              defaultHeaderImageHeight,
+                          builder: widget.headerBuilder!,
+                        ),
+                      ),
+                    SliverList(
+                      delegate: SliverChildListDelegate.fixed(
+                        [widget.child],
+                      ),
+                    )
+                  ],
+                ),
+              ),
+            );
+          } else {
+            return Center(
+              child: ListView(
+                shrinkWrap: true,
+                children: [
+                  widget.child,
                 ],
               ),
-            ),
-          );
-        } else if (widget.headerBuilder != null) {
-          return Padding(
-            padding: EdgeInsets.only(top: MediaQuery.of(context).padding.top),
-            child: KeyboardAppearenceListener(
-              listener: _onKeyboardPositionChanged,
-              child: CustomScrollView(
-                controller: ctrl,
-                slivers: [
-                  if (widget.headerBuilder != null)
-                    SliverPersistentHeader(
-                      delegate: LoginImageSliverDelegate(
-                        maxExtent:
-                            widget.headerMaxExtent ?? defaultHeaderImageHeight,
-                        builder: widget.headerBuilder!,
-                      ),
-                    ),
-                  SliverList(
-                    delegate: SliverChildListDelegate.fixed(
-                      [widget.child],
-                    ),
-                  )
-                ],
-              ),
-            ),
-          );
-        } else {
-          return Center(
-            child: ListView(
-              shrinkWrap: true,
-              children: [
-                widget.child,
-              ],
-            ),
-          );
-        }
-      },
+            );
+          }
+        },
+      ),
     );
   }
 }

--- a/packages/flutterfire_ui/lib/src/auth/screens/sign_in_screen.dart
+++ b/packages/flutterfire_ui/lib/src/auth/screens/sign_in_screen.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
 import 'package:firebase_auth/firebase_auth.dart' show FirebaseAuth;
 import 'package:flutterfire_ui/auth.dart';
+import 'package:flutterfire_ui/src/auth/theme/sign_in_screen_theme.dart';
 
 import 'internal/login_screen.dart';
 
@@ -25,6 +26,7 @@ class SignInScreen extends StatelessWidget {
   final AuthViewContentBuilder? footerBuilder;
   final Key? loginViewKey;
   final List<FlutterFireUIAction> actions;
+  final SignInScreenTheme? signInScreenTheme;
 
   const SignInScreen({
     Key? key,
@@ -41,6 +43,7 @@ class SignInScreen extends StatelessWidget {
     this.footerBuilder,
     this.loginViewKey,
     this.actions = const [],
+    this.signInScreenTheme
   }) : super(key: key);
 
   Future<void> _signInWithDifferentProvider(
@@ -88,6 +91,7 @@ class SignInScreen extends StatelessWidget {
         showAuthActionSwitch: showAuthActionSwitch,
         subtitleBuilder: subtitleBuilder,
         footerBuilder: footerBuilder,
+        signInScreenTheme: signInScreenTheme,
       ),
     );
   }

--- a/packages/flutterfire_ui/lib/src/auth/screens/sign_in_screen.dart
+++ b/packages/flutterfire_ui/lib/src/auth/screens/sign_in_screen.dart
@@ -2,7 +2,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
 import 'package:firebase_auth/firebase_auth.dart' show FirebaseAuth;
 import 'package:flutterfire_ui/auth.dart';
-import 'package:flutterfire_ui/src/auth/theme/sign_in_screen_theme.dart';
 
 import 'internal/login_screen.dart';
 

--- a/packages/flutterfire_ui/lib/src/auth/theme/sign_in_screen_theme.dart
+++ b/packages/flutterfire_ui/lib/src/auth/theme/sign_in_screen_theme.dart
@@ -1,0 +1,11 @@
+import 'package:flutter/material.dart';
+
+class SignInScreenTheme {
+  Color? backgroundColor;
+  Color? textColor;
+
+  SignInScreenTheme({
+    this.backgroundColor = Colors.white,
+    this.textColor = Colors.black,
+  });
+}

--- a/packages/flutterfire_ui/lib/src/auth/theme/sign_in_screen_theme.dart
+++ b/packages/flutterfire_ui/lib/src/auth/theme/sign_in_screen_theme.dart
@@ -1,7 +1,13 @@
 import 'package:flutter/material.dart';
+import 'package:flutterfire_ui/auth.dart';
 
+
+///Provides a theme to style the [SignInScreen] and [LoginView]
+///Does not change the the [InputDecoration], this is still managed by your [ThemeData]
 class SignInScreenTheme {
+  ///Changes the background color
   Color? backgroundColor;
+  ///Updates the text color on the [SignInScreen] and [LoginView]
   Color? textColor;
 
   SignInScreenTheme({

--- a/packages/flutterfire_ui/lib/src/auth/views/login_view.dart
+++ b/packages/flutterfire_ui/lib/src/auth/views/login_view.dart
@@ -24,7 +24,7 @@ class LoginView extends StatefulWidget {
   final bool? showAuthActionSwitch;
   final AuthViewContentBuilder? footerBuilder;
   final AuthViewContentBuilder? subtitleBuilder;
-
+  final SignInScreenTheme? signInScreenTheme;
   final List<ProviderConfiguration> providerConfigs;
 
   const LoginView({
@@ -38,6 +38,7 @@ class LoginView extends StatefulWidget {
     this.showAuthActionSwitch,
     this.footerBuilder,
     this.subtitleBuilder,
+    this.signInScreenTheme,
   }) : super(key: key);
 
   @override
@@ -128,16 +129,16 @@ class LoginViewState extends State<LoginView> {
 
     if (isCupertino) {
       final theme = CupertinoTheme.of(context);
-      registerTextColor = theme.primaryColor;
-      hintStyle = theme.textTheme.textStyle.copyWith(fontSize: 12);
+      registerTextColor = widget.signInScreenTheme?.textColor ?? theme.primaryColor;
+      hintStyle = theme.textTheme.textStyle.copyWith(fontSize: 12, color: widget.signInScreenTheme?.textColor);
     } else {
       final theme = Theme.of(context);
-      hintStyle = Theme.of(context).textTheme.caption;
-      registerTextColor = theme.colorScheme.primary;
+      hintStyle = Theme.of(context).textTheme.caption?.copyWith(color: widget.signInScreenTheme?.textColor);
+      registerTextColor = widget.signInScreenTheme?.textColor ?? theme.colorScheme.primary;
     }
 
     return [
-      Title(text: title),
+      Title(text: title, color: widget.signInScreenTheme?.textColor),
       const SizedBox(height: 16),
       if (widget.subtitleBuilder != null)
         widget.subtitleBuilder!(
@@ -198,6 +199,7 @@ class LoginViewState extends State<LoginView> {
                   action: _action,
                   config: config,
                   email: widget.email,
+                  signInScreenTheme: widget.signInScreenTheme,
                 )
               ] else if (config is PhoneProviderConfiguration) ...[
                 const SizedBox(height: 8),

--- a/packages/flutterfire_ui/lib/src/auth/widgets/email_form.dart
+++ b/packages/flutterfire_ui/lib/src/auth/widgets/email_form.dart
@@ -27,6 +27,7 @@ class EmailForm extends StatelessWidget {
   final EmailProviderConfiguration? config;
   final EmailSubmitCallback? onSubmit;
   final String? email;
+  final SignInScreenTheme? signInScreenTheme;
 
   const EmailForm({
     Key? key,
@@ -35,6 +36,7 @@ class EmailForm extends StatelessWidget {
     this.config,
     this.onSubmit,
     this.email,
+    this.signInScreenTheme,
   }) : super(key: key);
 
   @override
@@ -48,6 +50,7 @@ class EmailForm extends StatelessWidget {
         action: action,
         onSubmit: onSubmit,
         email: email,
+        signInScreenTheme: signInScreenTheme,
       ),
     );
   }
@@ -58,6 +61,7 @@ class _SignInFormContent extends StatefulWidget {
   final EmailSubmitCallback? onSubmit;
   final AuthAction? action;
   final String? email;
+  final SignInScreenTheme? signInScreenTheme;
 
   const _SignInFormContent({
     Key? key,
@@ -65,6 +69,7 @@ class _SignInFormContent extends StatefulWidget {
     this.onSubmit,
     this.action,
     this.email,
+    this.signInScreenTheme,
   }) : super(key: key);
 
   @override
@@ -125,6 +130,7 @@ class _SignInFormContentState extends State<_SignInFormContent> {
             formKey.currentState?.validate();
             FocusScope.of(context).requestFocus(passwordFocusNode);
           },
+          signInScreenTheme: widget.signInScreenTheme,
         ),
         spacer,
       ],
@@ -133,6 +139,7 @@ class _SignInFormContentState extends State<_SignInFormContent> {
         controller: passwordCtrl,
         onSubmit: _submit,
         label: l.passwordInputLabel,
+        signInScreenTheme: widget.signInScreenTheme,
       ),
       if (widget.action == AuthAction.signIn) ...[
         const SizedBox(height: 8),
@@ -153,6 +160,7 @@ class _SignInFormContentState extends State<_SignInFormContent> {
                 );
               }
             },
+            signInScreenTheme: widget.signInScreenTheme,
           ),
         ),
       ],

--- a/packages/flutterfire_ui/lib/src/auth/widgets/email_input.dart
+++ b/packages/flutterfire_ui/lib/src/auth/widgets/email_input.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutterfire_ui/i10n.dart';
+import 'package:flutterfire_ui/src/auth/theme/sign_in_screen_theme.dart';
 import '../widgets/internal/universal_text_form_field.dart';
 
 import '../validators.dart';
@@ -11,6 +12,7 @@ class EmailInput extends StatelessWidget {
   final TextEditingController controller;
   final String? initialValue;
   final void Function(String value) onSubmitted;
+  final SignInScreenTheme? signInScreenTheme;
 
   const EmailInput({
     Key? key,
@@ -19,6 +21,7 @@ class EmailInput extends StatelessWidget {
     this.focusNode,
     this.autofocus,
     this.initialValue,
+    this.signInScreenTheme,
   }) : super(key: key);
 
   @override
@@ -37,6 +40,7 @@ class EmailInput extends StatelessWidget {
         EmailValidator(l.isNotAValidEmailErrorText),
       ]),
       onSubmitted: (v) => onSubmitted(v!),
+      signInScreenTheme: signInScreenTheme,
     );
   }
 }

--- a/packages/flutterfire_ui/lib/src/auth/widgets/forgot_password_button.dart
+++ b/packages/flutterfire_ui/lib/src/auth/widgets/forgot_password_button.dart
@@ -1,12 +1,14 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutterfire_ui/i10n.dart';
+import 'package:flutterfire_ui/src/auth/theme/sign_in_screen_theme.dart';
 
 import 'internal/universal_button.dart';
 
 class ForgotPasswordButton extends StatelessWidget {
   final VoidCallback onPressed;
-  const ForgotPasswordButton({Key? key, required this.onPressed})
+  final SignInScreenTheme? signInScreenTheme;
+  const ForgotPasswordButton({Key? key, required this.onPressed, this.signInScreenTheme})
       : super(key: key);
 
   @override
@@ -17,6 +19,7 @@ class ForgotPasswordButton extends StatelessWidget {
       variant: ButtonVariant.text,
       text: l.forgotPasswordButtonLabel,
       onPressed: onPressed,
+      signInScreenTheme: signInScreenTheme,
     );
   }
 }

--- a/packages/flutterfire_ui/lib/src/auth/widgets/internal/title.dart
+++ b/packages/flutterfire_ui/lib/src/auth/widgets/internal/title.dart
@@ -5,7 +5,8 @@ import 'platform_widget.dart';
 
 class Title extends PlatformWidget {
   final String text;
-  const Title({Key? key, required this.text}) : super(key: key);
+  final Color? color;
+  const Title({Key? key, required this.text, this.color}) : super(key: key);
 
   @override
   Widget buildCupertino(BuildContext context) {
@@ -19,7 +20,7 @@ class Title extends PlatformWidget {
   Widget buildMaterial(BuildContext context) {
     return Text(
       text,
-      style: Theme.of(context).textTheme.headline5,
+      style: Theme.of(context).textTheme.headline5?.copyWith(color: color),
     );
   }
 }

--- a/packages/flutterfire_ui/lib/src/auth/widgets/internal/universal_button.dart
+++ b/packages/flutterfire_ui/lib/src/auth/widgets/internal/universal_button.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
+import 'package:flutterfire_ui/src/auth/theme/sign_in_screen_theme.dart';
 
 import 'platform_widget.dart';
 
@@ -14,6 +15,7 @@ class UniversalButton extends PlatformWidget {
   final IconData? icon;
   final TextDirection? direction;
   final ButtonVariant variant;
+  final SignInScreenTheme? signInScreenTheme;
 
   const UniversalButton({
     Key? key,
@@ -22,6 +24,7 @@ class UniversalButton extends PlatformWidget {
     this.icon,
     this.direction,
     this.variant = ButtonVariant.filled,
+    this.signInScreenTheme,
   }) : super(key: key);
 
   @override
@@ -30,7 +33,7 @@ class UniversalButton extends PlatformWidget {
       textDirection: direction,
       mainAxisAlignment: MainAxisAlignment.center,
       children: [
-        Text(text),
+        Text(text, style: TextStyle(color: signInScreenTheme?.textColor),),
         if (icon != null) ...[const SizedBox(width: 8), Icon(icon, size: 20)],
       ],
     );
@@ -51,7 +54,7 @@ class UniversalButton extends PlatformWidget {
 
   @override
   Widget buildMaterial(BuildContext context) {
-    final child = Text(text);
+    final child = Text(text, style: TextStyle(color: signInScreenTheme?.textColor),);
 
     if (icon != null) {
       if (variant == ButtonVariant.text) {

--- a/packages/flutterfire_ui/lib/src/auth/widgets/internal/universal_text_form_field.dart
+++ b/packages/flutterfire_ui/lib/src/auth/widgets/internal/universal_text_form_field.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:flutterfire_ui/src/auth/theme/sign_in_screen_theme.dart';
 import 'platform_widget.dart';
 
 class UniversalTextFormField extends PlatformWidget {
@@ -16,6 +17,7 @@ class UniversalTextFormField extends PlatformWidget {
   final bool? enableSuggestions;
   final bool? autocorrect;
   final Widget? prefix;
+  final SignInScreenTheme? signInScreenTheme;
 
   const UniversalTextFormField({
     Key? key,
@@ -31,16 +33,17 @@ class UniversalTextFormField extends PlatformWidget {
     this.focusNode,
     this.enableSuggestions,
     this.autocorrect,
+    this.signInScreenTheme,
   }) : super(key: key);
 
   @override
   Widget buildCupertino(BuildContext context) {
     return Container(
       padding: const EdgeInsets.only(bottom: 8),
-      decoration: const BoxDecoration(
+      decoration: BoxDecoration(
         border: Border(
           bottom: BorderSide(
-            color: CupertinoColors.inactiveGray,
+            color: signInScreenTheme?.textColor ?? CupertinoColors.inactiveGray,
           ),
         ),
       ),
@@ -66,9 +69,13 @@ class UniversalTextFormField extends PlatformWidget {
       autofocus: autofocus ?? false,
       focusNode: focusNode,
       controller: controller,
+      cursorColor: signInScreenTheme?.textColor,
+      style: TextStyle(color: signInScreenTheme?.textColor),
       decoration: InputDecoration(
-        labelText: placeholder,
-        prefix: prefix,
+          labelText: placeholder,
+          labelStyle: TextStyle(
+              color: signInScreenTheme?.textColor ?? Color(0xFF000000)),
+          prefix: prefix,
       ),
       validator: validator,
       onFieldSubmitted: onSubmitted,

--- a/packages/flutterfire_ui/lib/src/auth/widgets/password_input.dart
+++ b/packages/flutterfire_ui/lib/src/auth/widgets/password_input.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/widgets.dart';
 import 'package:flutterfire_ui/i10n.dart';
+import 'package:flutterfire_ui/src/auth/theme/sign_in_screen_theme.dart';
 
 import '../validators.dart';
 import 'internal/universal_text_form_field.dart';
@@ -10,6 +11,7 @@ class PasswordInput extends StatelessWidget {
   final void Function(String value) onSubmit;
   final String label;
   final String? Function(String? value)? validator;
+  final SignInScreenTheme? signInScreenTheme;
 
   const PasswordInput({
     Key? key,
@@ -18,6 +20,7 @@ class PasswordInput extends StatelessWidget {
     required this.onSubmit,
     required this.label,
     this.validator,
+    this.signInScreenTheme,
   }) : super(key: key);
 
   @override
@@ -33,6 +36,7 @@ class PasswordInput extends StatelessWidget {
       validator: validator ?? NotEmpty(l.passwordIsRequiredErrorText).validate,
       onSubmitted: (v) => onSubmit(v!),
       placeholder: label,
+      signInScreenTheme: signInScreenTheme,
     );
   }
 }

--- a/packages/flutterfire_ui/pubspec.yaml
+++ b/packages/flutterfire_ui/pubspec.yaml
@@ -23,7 +23,7 @@ dependencies:
   firebase_dynamic_links: ^4.0.4
   flutter:
     sdk: flutter
-  flutter_facebook_auth: ^3.5.7
+  flutter_facebook_auth: ^4.0.1
   flutter_localizations:
     sdk: flutter
   flutter_svg: ^1.0.0


### PR DESCRIPTION
## Description

This PR adds the basic functionality of changing the background colour, and text colour. This came out of trying to use the SignIn Screen, but couldn't match the theme of the app.

Input Decoration is still managed by ThemeData

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
