### PR TITLE
docs(firebase_Auth): Missing `await` for the `twitter_login` package `login()` API.

### DIFF
--- a/docs/auth/social.mdx
+++ b/docs/auth/social.mdx
@@ -358,7 +358,7 @@ Future<UserCredential> signInWithTwitter() async {
   );
 
   // Trigger the sign-in flow
-  final authResult = twitterLogin.login();
+  final authResult = await twitterLogin.login();
 
   // Create a credential from the access token
   final twitterAuthCredential = TwitterAuthProvider.credential(


### PR DESCRIPTION
## Description
Code snippet for the Twitter Login in the [**Social Auth**](https://firebase.flutter.dev/docs/auth/social#twitter) documentation updated with the missing `await` for the Login call.

## Breaking Change
None

