### PR TITLE
feature: missing Crashlytics_Platform.h file for macos

### DIFF
--- a/packages/firebase_crashlytics/firebase_crashlytics/macos/Classes/Crashlytics_Platform.h
+++ b/packages/firebase_crashlytics/firebase_crashlytics/macos/Classes/Crashlytics_Platform.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright 2021 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+//
+//  Crashlytics_Platform.h
+//  Crashlytics
+//
+
+#import <Firebase/Firebase.h>
+
+@interface FIRCrashlytics (Platform)
+
+@property(nonatomic, strong, nullable) NSString* developmentPlatformName;
+@property(nonatomic, strong, nullable) NSString* developmentPlatformVersion;
+
+@end
+
+void FIRCLSUserLoggingRecordInternalKeyValue(NSString* _Nullable key, id _Nullable value);


### PR DESCRIPTION
## Description

Included missing header file for macOS

## Related Issues

[discussions/7484](https://github.com/FirebaseExtended/flutterfire/discussions/7484)

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [X] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [X] I read and followed the [Flutter Style Guide].
- [X] I signed the [CLA].
- [X] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [X] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
