### PR TITLE
fix(firebase_core): allow secondary Firebase App initialization without duplicate app error on hot restart

### DIFF
--- a/packages/firebase_core/firebase_core_platform_interface/lib/src/method_channel/method_channel_firebase.dart
+++ b/packages/firebase_core/firebase_core_platform_interface/lib/src/method_channel/method_channel_firebase.dart
@@ -125,7 +125,17 @@ class MethodChannelFirebase extends FirebasePlatform {
 
     // Check whether the app has already been initialized
     if (appInstances.containsKey(name)) {
-      throw duplicateApp(name);
+      final existingApp = appInstances[name]!;
+      if (options!.apiKey != existingApp.options.apiKey ||
+          (options.databaseURL != null &&
+              options.databaseURL != existingApp.options.databaseURL) ||
+          (options.storageBucket != null &&
+              options.storageBucket != existingApp.options.storageBucket)) {
+        // Options are different; throw.
+        throw duplicateApp(name);
+      } else {
+        return existingApp;
+      }
     }
 
     _initializeFirebaseAppFromMap((await channel.invokeMapMethod(


### PR DESCRIPTION
## Description

See title.

## Related Issues

fixes https://github.com/FirebaseExtended/flutterfire/issues/7938

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [X] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
