### PR TITLE
fix(firebase_crashlytics): Fixed macOS project not compiling by symlinking missing header file: `Crashlytics_Platform.h`

### DIFF
--- a/packages/firebase_crashlytics/firebase_crashlytics/macos/Classes/Crashlytics_Platform.h
+++ b/packages/firebase_crashlytics/firebase_crashlytics/macos/Classes/Crashlytics_Platform.h
@@ -1,0 +1,1 @@
+./../../ios/Classes/Crashlytics_Platform.h


### PR DESCRIPTION
## Description

- Create symlink for Crashlytics_Platform.h file. This should fix the compilation error `'Crashlytics_Platform.h' file not found (macos)`

## Related Issues

* #7558

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
