### PR TITLE
fix(ui): make breakpoints of all screens configurable

### DIFF
--- a/packages/flutterfire_ui/lib/src/auth/screens/email_link_sign_in_screen.dart
+++ b/packages/flutterfire_ui/lib/src/auth/screens/email_link_sign_in_screen.dart
@@ -13,6 +13,7 @@ class EmailLinkSignInScreen extends StatelessWidget {
   final double? headerMaxExtent;
   final SideBuilder? sideBuilder;
   final TextDirection? desktoplayoutDirection;
+  final double breakpoint;
 
   const EmailLinkSignInScreen({
     Key? key,
@@ -23,6 +24,7 @@ class EmailLinkSignInScreen extends StatelessWidget {
     this.headerMaxExtent,
     this.sideBuilder,
     this.desktoplayoutDirection,
+    this.breakpoint = 500,
   }) : super(key: key);
 
   @override
@@ -31,7 +33,7 @@ class EmailLinkSignInScreen extends StatelessWidget {
       actions: actions ?? const [],
       child: UniversalScaffold(
         body: ResponsivePage(
-          breakpoint: 400,
+          breakpoint: breakpoint,
           headerBuilder: headerBuilder,
           headerMaxExtent: headerMaxExtent,
           maxWidth: 1200,

--- a/packages/flutterfire_ui/lib/src/auth/screens/forgot_password_screen.dart
+++ b/packages/flutterfire_ui/lib/src/auth/screens/forgot_password_screen.dart
@@ -14,6 +14,7 @@ class ForgotPasswordScreen extends StatelessWidget {
   final double? headerMaxExtent;
   final SideBuilder? sideBuilder;
   final TextDirection? desktopLayoutDirection;
+  final double breakpoint;
 
   const ForgotPasswordScreen({
     Key? key,
@@ -25,6 +26,7 @@ class ForgotPasswordScreen extends StatelessWidget {
     this.headerMaxExtent,
     this.sideBuilder,
     this.desktopLayoutDirection,
+    this.breakpoint = 600,
   }) : super(key: key);
 
   @override
@@ -42,7 +44,7 @@ class ForgotPasswordScreen extends StatelessWidget {
         headerBuilder: headerBuilder,
         headerMaxExtent: headerMaxExtent,
         sideBuilder: sideBuilder,
-        breakpoint: 600,
+        breakpoint: breakpoint,
         maxWidth: 1200,
         contentFlex: 1,
         child: Padding(

--- a/packages/flutterfire_ui/lib/src/auth/screens/internal/login_screen.dart
+++ b/packages/flutterfire_ui/lib/src/auth/screens/internal/login_screen.dart
@@ -20,6 +20,7 @@ class LoginScreen extends StatelessWidget {
   final AuthViewContentBuilder? subtitleBuilder;
   final AuthViewContentBuilder? footerBuilder;
   final Key? loginViewKey;
+  final double breakpoint;
 
   const LoginScreen({
     Key? key,
@@ -36,6 +37,7 @@ class LoginScreen extends StatelessWidget {
     this.subtitleBuilder,
     this.footerBuilder,
     this.loginViewKey,
+    this.breakpoint = 800,
   }) : super(key: key);
 
   @override
@@ -59,7 +61,7 @@ class LoginScreen extends StatelessWidget {
     );
 
     final body = ResponsivePage(
-      breakpoint: 800,
+      breakpoint: breakpoint,
       desktopLayoutDirection: desktopLayoutDirection,
       headerBuilder: headerBuilder,
       headerMaxExtent: headerMaxExtent,

--- a/packages/flutterfire_ui/lib/src/auth/screens/internal/responsive_page.dart
+++ b/packages/flutterfire_ui/lib/src/auth/screens/internal/responsive_page.dart
@@ -55,7 +55,7 @@ class ResponsivePage extends StatefulWidget {
   final SideBuilder? sideBuilder;
   final HeaderBuilder? headerBuilder;
   final double? headerMaxExtent;
-  final double? breakpoint;
+  final double breakpoint;
   final int? contentFlex;
   final double? maxWidth;
 
@@ -66,7 +66,7 @@ class ResponsivePage extends StatefulWidget {
     this.sideBuilder,
     this.headerBuilder,
     this.headerMaxExtent,
-    this.breakpoint,
+    this.breakpoint = 800,
     this.contentFlex,
     this.maxWidth,
   }) : super(key: key);
@@ -92,7 +92,7 @@ class _ResponsivePageState extends State<ResponsivePage> {
 
   @override
   Widget build(BuildContext context) {
-    final breakpoint = widget.breakpoint ?? 800;
+    final breakpoint = widget.breakpoint;
 
     return LayoutBuilder(
       builder: (context, constraints) {

--- a/packages/flutterfire_ui/lib/src/auth/screens/phone_input_screen.dart
+++ b/packages/flutterfire_ui/lib/src/auth/screens/phone_input_screen.dart
@@ -26,6 +26,7 @@ class PhoneInputScreen extends StatelessWidget {
   final double? headerMaxExtent;
   final SideBuilder? sideBuilder;
   final TextDirection? desktopLayoutDirection;
+  final double breakpoint;
 
   const PhoneInputScreen({
     Key? key,
@@ -38,6 +39,7 @@ class PhoneInputScreen extends StatelessWidget {
     this.headerMaxExtent,
     this.sideBuilder,
     this.desktopLayoutDirection,
+    this.breakpoint = 500,
   }) : super(key: key);
 
   void _next(BuildContext context, AuthAction? action, Object flowKey, _) {
@@ -68,7 +70,7 @@ class PhoneInputScreen extends StatelessWidget {
           sideBuilder: sideBuilder,
           headerBuilder: headerBuilder,
           headerMaxExtent: headerMaxExtent,
-          breakpoint: 400,
+          breakpoint: breakpoint,
           child: Padding(
             padding: const EdgeInsets.all(20),
             child: Column(

--- a/packages/flutterfire_ui/lib/src/auth/screens/register_screen.dart
+++ b/packages/flutterfire_ui/lib/src/auth/screens/register_screen.dart
@@ -22,6 +22,7 @@ class RegisterScreen extends StatelessWidget {
   final bool? showAuthActionSwitch;
   final AuthViewContentBuilder? subtitleBuilder;
   final AuthViewContentBuilder? footerBuilder;
+  final double breakpoint;
 
   const RegisterScreen({
     Key? key,
@@ -36,6 +37,7 @@ class RegisterScreen extends StatelessWidget {
     this.showAuthActionSwitch,
     this.subtitleBuilder,
     this.footerBuilder,
+    this.breakpoint = 800,
   }) : super(key: key);
 
   @override

--- a/packages/flutterfire_ui/lib/src/auth/screens/sign_in_screen.dart
+++ b/packages/flutterfire_ui/lib/src/auth/screens/sign_in_screen.dart
@@ -25,6 +25,7 @@ class SignInScreen extends StatelessWidget {
   final AuthViewContentBuilder? footerBuilder;
   final Key? loginViewKey;
   final List<FlutterFireUIAction> actions;
+  final double breakpoint;
 
   const SignInScreen({
     Key? key,
@@ -41,6 +42,7 @@ class SignInScreen extends StatelessWidget {
     this.footerBuilder,
     this.loginViewKey,
     this.actions = const [],
+    this.breakpoint = 800,
   }) : super(key: key);
 
   Future<void> _signInWithDifferentProvider(
@@ -88,6 +90,7 @@ class SignInScreen extends StatelessWidget {
         showAuthActionSwitch: showAuthActionSwitch,
         subtitleBuilder: subtitleBuilder,
         footerBuilder: footerBuilder,
+        breakpoint: breakpoint,
       ),
     );
   }

--- a/packages/flutterfire_ui/lib/src/auth/screens/sms_code_input_screen.dart
+++ b/packages/flutterfire_ui/lib/src/auth/screens/sms_code_input_screen.dart
@@ -23,9 +23,9 @@ class SMSCodeInputScreen extends StatelessWidget {
   final SideBuilder? sideBuilder;
   final HeaderBuilder? headerBuilder;
   final double? headerMaxExtent;
-  final double? breakpoint;
   final int? contentFlex;
   final double? maxWidth;
+  final double breakpoint;
 
   const SMSCodeInputScreen({
     Key? key,
@@ -37,7 +37,7 @@ class SMSCodeInputScreen extends StatelessWidget {
     this.sideBuilder,
     this.headerBuilder,
     this.headerMaxExtent,
-    this.breakpoint,
+    this.breakpoint = 500,
     this.contentFlex,
     this.maxWidth,
   }) : super(key: key);
@@ -61,7 +61,7 @@ class SMSCodeInputScreen extends StatelessWidget {
         child: UniversalScaffold(
           body: Center(
             child: ResponsivePage(
-              breakpoint: 400,
+              breakpoint: breakpoint,
               maxWidth: maxWidth,
               desktopLayoutDirection: desktopLayoutDirection,
               sideBuilder: sideBuilder,


### PR DESCRIPTION
## Description

This PR fixes this:

<img height="600" alt="android-wrong-breakpoint" src="https://user-images.githubusercontent.com/6261302/152208308-29370bc9-6d4a-4a79-ac80-0b4103f4b691.png">


## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
