### PR TITLE
feat(ui): Enhance the oauth provider button widget by showing error text underneath.

### DIFF
--- a/packages/flutterfire_ui/lib/src/auth/widgets/internal/oauth_provider_button.dart
+++ b/packages/flutterfire_ui/lib/src/auth/widgets/internal/oauth_provider_button.dart
@@ -27,7 +27,7 @@ class OAuthProviderButtonContent extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    bool isLoading = AuthState.of(context) is SigningIn;
+    final isLoading = AuthState.of(context) is SigningIn;
     late Widget content;
 
     if (isLoading) {
@@ -88,6 +88,23 @@ mixin SignInWithOAuthProviderMixin {
   }
 }
 
+class _ErrorListener extends StatelessWidget {
+  const _ErrorListener({Key? key}) : super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    final state = AuthState.of(context);
+    if (state is AuthFailed) {
+      return Padding(
+        padding: const EdgeInsets.symmetric(vertical: 4),
+        child: ErrorText(exception: state.exception),
+      );
+    }
+
+    return const SizedBox.shrink();
+  }
+}
+
 class OAuthProviderButton extends StatelessWidget
     with SignInWithOAuthProviderMixin {
   final double size;
@@ -128,53 +145,58 @@ class OAuthProviderButton extends StatelessWidget
         action: action,
         auth: auth,
         config: providerConfig,
-        child: Container(
-          margin: EdgeInsets.symmetric(vertical: margin),
-          child: CupertinoTheme(
-            data: CupertinoThemeData(
-              primaryColor: style.backgroundColor,
-            ),
-            child: Builder(
-              builder: (context) => CupertinoButton.filled(
-                padding: EdgeInsets.zero,
-                borderRadius: BorderRadius.circular(borderRadius),
-                child: SizedBox(
-                  height: _height,
-                  child: Row(
-                    children: [
-                      ClipRRect(
-                        borderRadius: BorderRadius.only(
-                          topLeft: Radius.circular(iconBorderRadius),
-                          bottomLeft: Radius.circular(iconBorderRadius),
-                        ),
-                        child: SizedBox(
-                          width: _height,
-                          height: _height,
-                          child: SvgPicture.asset(
-                            style.iconSrc,
-                            package: 'flutterfire_ui',
-                            width: size,
-                            height: size,
+        child: Column(
+          children: [
+            Container(
+              margin: EdgeInsets.symmetric(vertical: margin),
+              child: CupertinoTheme(
+                data: CupertinoThemeData(
+                  primaryColor: style.backgroundColor,
+                ),
+                child: Builder(
+                  builder: (context) => CupertinoButton.filled(
+                    padding: EdgeInsets.zero,
+                    borderRadius: BorderRadius.circular(borderRadius),
+                    child: SizedBox(
+                      height: _height,
+                      child: Row(
+                        children: [
+                          ClipRRect(
+                            borderRadius: BorderRadius.only(
+                              topLeft: Radius.circular(iconBorderRadius),
+                              bottomLeft: Radius.circular(iconBorderRadius),
+                            ),
+                            child: SizedBox(
+                              width: _height,
+                              height: _height,
+                              child: SvgPicture.asset(
+                                style.iconSrc,
+                                package: 'flutterfire_ui',
+                                width: size,
+                                height: size,
+                              ),
+                            ),
                           ),
-                        ),
+                          Expanded(
+                            child: OAuthProviderButtonContent(
+                              label: providerConfig.getLabel(l),
+                              style: style,
+                              size: size,
+                            ),
+                          ),
+                        ],
                       ),
-                      Expanded(
-                        child: OAuthProviderButtonContent(
-                          label: providerConfig.getLabel(l),
-                          style: style,
-                          size: size,
-                        ),
-                      ),
-                    ],
+                    ),
+                    onPressed: () {
+                      if (onTap != null) onTap!.call();
+                      signIn(context);
+                    },
                   ),
                 ),
-                onPressed: () {
-                  if (onTap != null) onTap!.call();
-                  signIn(context);
-                },
               ),
             ),
-          ),
+            const _ErrorListener(),
+          ],
         ),
       );
     }
@@ -183,73 +205,78 @@ class OAuthProviderButton extends StatelessWidget
       action: action,
       auth: auth,
       config: providerConfig,
-      child: Container(
-        margin: EdgeInsets.symmetric(vertical: margin),
-        child: Stack(
-          children: [
-            Material(
-              elevation: 1,
-              color: style.backgroundColor,
-              borderRadius: BorderRadius.circular(borderRadius),
-              child: Container(
-                decoration: BoxDecoration(
-                  border: Border.all(color: style.backgroundColor),
+      child: Column(
+        children: [
+          Container(
+            margin: EdgeInsets.symmetric(vertical: margin),
+            child: Stack(
+              children: [
+                Material(
+                  elevation: 1,
+                  color: style.backgroundColor,
                   borderRadius: BorderRadius.circular(borderRadius),
-                ),
-                child: ClipRRect(
-                  borderRadius: BorderRadius.circular(iconBorderRadius),
-                  child: SizedBox(
-                    height: _height,
-                    child: Row(
-                      children: [
-                        SizedBox(
-                          width: _height,
-                          height: _height,
-                          child: SvgPicture.asset(
-                            style.iconSrc,
-                            package: 'flutterfire_ui',
-                            width: size,
-                            height: size,
-                          ),
+                  child: Container(
+                    decoration: BoxDecoration(
+                      border: Border.all(color: style.backgroundColor),
+                      borderRadius: BorderRadius.circular(borderRadius),
+                    ),
+                    child: ClipRRect(
+                      borderRadius: BorderRadius.circular(iconBorderRadius),
+                      child: SizedBox(
+                        height: _height,
+                        child: Row(
+                          children: [
+                            SizedBox(
+                              width: _height,
+                              height: _height,
+                              child: SvgPicture.asset(
+                                style.iconSrc,
+                                package: 'flutterfire_ui',
+                                width: size,
+                                height: size,
+                              ),
+                            ),
+                            Expanded(
+                              child: OAuthProviderButtonContent(
+                                label: providerConfig.getLabel(l),
+                                style: style,
+                                size: size,
+                              ),
+                            ),
+                          ],
                         ),
-                        Expanded(
-                          child: OAuthProviderButtonContent(
-                            label: providerConfig.getLabel(l),
-                            style: style,
-                            size: size,
-                          ),
-                        ),
-                      ],
+                      ),
                     ),
                   ),
                 ),
-              ),
-            ),
-            Positioned.fill(
-              child: OAuthProviderButtonTapHandler(
-                borderRadius: borderRadius,
-                onTap: onTap != null ? (context) => onTap!() : signIn,
-              ),
-            ),
-            Builder(
-              builder: (context) {
-                bool isLoading = AuthState.of(context) is SigningIn;
+                Positioned.fill(
+                  child: OAuthProviderButtonTapHandler(
+                    borderRadius: borderRadius,
+                    onTap: onTap != null ? (context) => onTap!() : signIn,
+                  ),
+                ),
+                Builder(
+                  builder: (context) {
+                    bool isLoading = AuthState.of(context) is SigningIn;
 
-                if (isLoading) {
-                  return Positioned.fill(
-                    child: LoadingIndicator(
-                      size: size,
-                      borderWidth: borderWidth,
-                      color: style.color,
-                    ),
-                  );
-                } else {
-                  return const SizedBox.shrink();
-                }
-              },
-            )
-          ],
-        ),
+                    if (isLoading) {
+                      return Positioned.fill(
+                        child: LoadingIndicator(
+                          size: size,
+                          borderWidth: borderWidth,
+                          color: style.color,
+                        ),
+                      );
+                    } else {
+                      return const SizedBox.shrink();
+                    }
+                  },
+                )
+              ],
+            ),
+          ),
+          const _ErrorListener(),
+        ],
       ),
     );
   }


### PR DESCRIPTION
## Description

This PR adds an error text that is rendered under the oauth button when error occurs

<img height="650" src="https://user-images.githubusercontent.com/6261302/152819742-43e1ea3d-16ef-43ee-af61-a081d9e26637.jpg" />

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
