### PR TITLE
feat: made option arg optional for convert fn

### DIFF
--- a/packages/cloud_firestore/cloud_firestore/lib/src/document_snapshot.dart
+++ b/packages/cloud_firestore/cloud_firestore/lib/src/document_snapshot.dart
@@ -5,11 +5,11 @@
 part of cloud_firestore;
 
 typedef FromFirestore<T> = T Function(
-  DocumentSnapshot<Map<String, dynamic>> snapshot,[
+  DocumentSnapshot<Map<String, dynamic>> snapshot, [
   SnapshotOptions? options,
 ]);
 typedef ToFirestore<T> = Map<String, Object?> Function(
-  T value[,
+  T value, [
   SetOptions? options,
 ]);
 

--- a/packages/cloud_firestore/cloud_firestore/lib/src/document_snapshot.dart
+++ b/packages/cloud_firestore/cloud_firestore/lib/src/document_snapshot.dart
@@ -5,13 +5,13 @@
 part of cloud_firestore;
 
 typedef FromFirestore<T> = T Function(
-  DocumentSnapshot<Map<String, dynamic>> snapshot,
+  DocumentSnapshot<Map<String, dynamic>> snapshot,[
   SnapshotOptions? options,
-);
+]);
 typedef ToFirestore<T> = Map<String, Object?> Function(
-  T value,
+  T value[,
   SetOptions? options,
-);
+]);
 
 /// Options that configure how data is retrieved from a DocumentSnapshot
 /// (e.g. the desired behavior for server timestamps that have not yet been set to their final value).


### PR DESCRIPTION
Made the convert function option arguments optional. Not sure this is a valid change because it was made with VSCode remote repository. I assumed I could see that from the github workflow tests but I can't see any running. Maybe it requires approval to run ?