### PR TITLE
docs(cloud_firestore_odm): Update code snippets by removing incorrect forward slash for `@Collection` annotations.

### DIFF
--- a/docs/firestore-odm/references.mdx
+++ b/docs/firestore-odm/references.mdx
@@ -129,7 +129,7 @@ class User {
   final int age;
 }
 
-@Collection<User>('/users')
+@Collection<User>('users')
 final usersRef = UserCollectionReference();
 ```
 

--- a/packages/cloud_firestore_odm/cloud_firestore_odm/lib/annotation.dart
+++ b/packages/cloud_firestore_odm/cloud_firestore_odm/lib/annotation.dart
@@ -30,7 +30,7 @@ export 'src/validator.dart' show Min, Validator, Max;
 /// content:
 ///
 /// ```dart
-/// @Collection<Person>('/persons')
+/// @Collection<Person>('persons')
 /// final personsRef = PersonCollectionReference();
 /// ```
 ///
@@ -61,7 +61,7 @@ export 'src/validator.dart' show Min, Validator, Max;
 /// Assuming we have:
 ///
 /// ```dart
-/// @Collection<Person>('/persons')
+/// @Collection<Person>('persons')
 /// final personsRef = PersonCollectionReference();
 /// ```
 ///
@@ -84,8 +84,8 @@ export 'src/validator.dart' show Min, Validator, Max;
 /// for defining sub-collections:
 ///
 /// ```dart
-/// @Collection<Person>('/persons')
-/// @Collection<Friend>('/persons/*/friends', name: 'friends') // defines a sub-collection "friends"
+/// @Collection<Person>('persons')
+/// @Collection<Friend>('persons/*/friends', name: 'friends') // defines a sub-collection "friends"
 /// final personsRef = PersonCollectionReference();
 /// ```
 ///


### PR DESCRIPTION
## Description

The PR fixes an issue caused by following the demo code in this section of the firestore-odm docs: https://firebase.flutter.dev/docs/firestore-odm/references#performing-queries

Triggering code generation with `@Collection<User>('/users')` yields the following error:

_The annotation @Collection received "/users" as collection path,  but this path points to a document instead of a collection_

This can be fixed by using `@Collection<User>('users')`.

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
