### PR TITLE
docs(ui): Switched Twitter `apiSecretKey` examples that were in the incorrect position in the documentation.

### DIFF
--- a/docs/ui/auth/configuring-providers.mdx
+++ b/docs/ui/auth/configuring-providers.mdx
@@ -210,7 +210,6 @@ You can get the `apiKey` and `apiSecretKey` from the Firebase Console or [twitte
 Providing the `apiSecretKey` directly is not advised if you are building for the web. Instead, you can use "dart-define" to ensure that
 the value is omitted from web builds:
 
-
 ```bash
 flutter run --dart-define TWITTER_SECRET=<your-twitter-api-secret-key>
 ```

--- a/docs/ui/auth/configuring-providers.mdx
+++ b/docs/ui/auth/configuring-providers.mdx
@@ -210,14 +210,15 @@ You can get the `apiKey` and `apiSecretKey` from the Firebase Console or [twitte
 Providing the `apiSecretKey` directly is not advised if you are building for the web. Instead, you can use "dart-define" to ensure that
 the value is omitted from web builds:
 
-```dart
-apiSecretKey: String.fromEnvironment('TWITTER_SECRET', ''),
+
+```bash
+flutter run --dart-define TWITTER_SECRET=<your-twitter-api-secret-key>
 ```
 
 When building the app on platforms other than the web, the `TWITTER_SECRET` environment variable can be defined using:
 
-```bash
-flutter run --dart-define TWITTER_SECRET=<your-twitter-api-secret-key>
+```dart
+apiSecretKey: String.fromEnvironment('TWITTER_SECRET', ''),
 ```
 
 :::


### PR DESCRIPTION
It looks like the code examples are switched from their descriptions.

## Description

Fix documentation

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
