### PR TITLE
Add Environmental variables section

### DIFF
--- a/docs/cli.mdx
+++ b/docs/cli.mdx
@@ -14,6 +14,8 @@ If not, make sure you have [node.js](https://www.nodejs.org/) on your machine an
 npm install -g firebase-tools
 ```
 
+<!-- Please add here a section that informs the user to add the npm installation folder to environmental variables, this is because, the npm install -g firebase-tools commands doesn't write the path to environmental variables, I faced an issue when running the firebase commands and the only way to fix it was adding the path with npm to environmental variables. Thanks  -->
+
 **Learn more about the Firebase CLI in the [documentation](https://firebase.google.com/docs/cli)**.
 
 Next, install the FlutterFire CLI by running the following command:


### PR DESCRIPTION
Update this to contain a section that prompts the user to add npm installation folder to environmental variables

## Description

*Replace this paragraph with a description of what this PR is doing. If you're modifying existing behavior, describe the existing behavior, how this PR is changing it, and what motivated the change.*

## Related Issues

*Replace this paragraph with a list of issues related to this PR from the [issue database](https://github.com/flutter/flutter/issues). Indicate, which of these issues are resolved or fixed by this PR. Note that you'll have to prefix the issue numbers with flutter/flutter#.*

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [x] Yes, this is a breaking change.
- [ ] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
