### PR TITLE
feat(ui): Add support for configuring authentication providers globally (additionally fixes #7801)

### DIFF
--- a/docs/ui/auth/integrating-your-first-screen.mdx
+++ b/docs/ui/auth/integrating-your-first-screen.mdx
@@ -492,6 +492,65 @@ return ProfileScreen(
   style={{ maxHeight: 700 }}
 />
 
+## Configuring auth providers globally
+
+Instead of passing a list of providers to each screen, you can provide a list of provider configurations to the `FlutterFireUIAuth.configureProviders`:
+
+```dart
+Future<void> main() async {
+  // Firebase app should be initialized before calling configureProviders
+  await Firebase.initializeApp();
+
+  FlutterFireUIAuth.configureProviders([
+    const EmailProviderConfiguration(),
+    const PhoneProviderConfiguration(),
+    const GoogleProviderConfiguration(clientId: GOOGLE_CLIENT_ID),
+    const AppleProviderConfiguration(),
+    const FacebookProviderConfiguration(clientId: FACEBOOK_CLIENT_ID),
+    const TwitterProviderConfiguration(
+      apiKey: TWITTER_API_KEY,
+      apiSecretKey: TWITTER_API_SECRET_KEY,
+      redirectUri: TWITTER_REDIRECT_URI,
+    ),
+  ]);
+
+  runApp(MyApp());
+}
+
+class MyApp extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    final auth = FirebaseAuth.instance;
+
+    return MaterialApp(
+      initialRoute: auth.currentUser == null ? '/' : '/profile',
+      routes: {
+        '/': (context) {
+          return SignInScreen(
+            // no providerConfigs property - global configuration will be used instead
+            actions: [
+              AuthStateChangeAction<SignedIn>((context, state) {
+                Navigator.pushReplacementNamed(context, '/profile');
+              }),
+            ],
+          );
+        },
+        '/profile': (context) {
+          return ProfileScreen(
+            // no providerConfigs property here as well
+            actions: [
+              SignedOutAction((context) {
+                Navigator.pushReplacementNamed(context, '/');
+              }),
+            ],
+          );
+        },
+      },
+    );
+  }
+}
+```
+
 ## Next Steps
 
 With your first screen integrated, you can now start adding more providers and integrating more screens!

--- a/docs/ui/auth/integrating-your-first-screen.mdx
+++ b/docs/ui/auth/integrating-your-first-screen.mdx
@@ -494,7 +494,7 @@ return ProfileScreen(
 
 ## Configuring auth providers globally
 
-Instead of passing a list of providers to each screen, you can provide a list of provider configurations to the `FlutterFireUIAuth.configureProviders`:
+Instead of passing a list of providers to each screen, you can alternatively provide a list of provider configurations to the `FlutterFireUIAuth.configureProviders` method:
 
 ```dart
 Future<void> main() async {

--- a/packages/flutterfire_ui/example/lib/main.dart
+++ b/packages/flutterfire_ui/example/lib/main.dart
@@ -10,9 +10,35 @@ import 'init.dart'
 import 'config.dart';
 import 'decorations.dart';
 
+final emailLinkProviderConfig = EmailLinkProviderConfiguration(
+  actionCodeSettings: ActionCodeSettings(
+    url: 'https://reactnativefirebase.page.link',
+    handleCodeInApp: true,
+    androidMinimumVersion: '12',
+    androidPackageName:
+        'io.flutter.plugins.flutterfire_ui.flutterfire_ui_example',
+    iOSBundleId: 'io.flutter.plugins.flutterfireui.flutterfireUIExample',
+  ),
+);
+
 Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
   await initializeFirebase();
+
+  FlutterFireUIAuth.configureProviders([
+    const EmailProviderConfiguration(),
+    emailLinkProviderConfig,
+    const PhoneProviderConfiguration(),
+    const GoogleProviderConfiguration(clientId: GOOGLE_CLIENT_ID),
+    const AppleProviderConfiguration(),
+    const FacebookProviderConfiguration(clientId: FACEBOOK_CLIENT_ID),
+    const TwitterProviderConfiguration(
+      apiKey: TWITTER_API_KEY,
+      apiSecretKey: TWITTER_API_SECRET_KEY,
+      redirectUri: TWITTER_REDIRECT_URI,
+    ),
+  ]);
+
   runApp(FirebaseAuthUIExample());
 }
 
@@ -25,31 +51,6 @@ class LabelOverrides extends DefaultLocalizations {
   @override
   String get emailInputLabel => 'Enter your email';
 }
-
-final emailLinkProviderConfig = EmailLinkProviderConfiguration(
-  actionCodeSettings: ActionCodeSettings(
-    url: 'https://reactnativefirebase.page.link',
-    handleCodeInApp: true,
-    androidMinimumVersion: '12',
-    androidPackageName:
-        'io.flutter.plugins.flutterfire_ui.flutterfire_ui_example',
-    iOSBundleId: 'io.flutter.plugins.flutterfireui.flutterfireUIExample',
-  ),
-);
-
-final providerConfigs = [
-  const EmailProviderConfiguration(),
-  emailLinkProviderConfig,
-  const PhoneProviderConfiguration(),
-  const GoogleProviderConfiguration(clientId: GOOGLE_CLIENT_ID),
-  const AppleProviderConfiguration(),
-  const FacebookProviderConfiguration(clientId: FACEBOOK_CLIENT_ID),
-  const TwitterProviderConfiguration(
-    apiKey: TWITTER_API_KEY,
-    apiSecretKey: TWITTER_API_SECRET_KEY,
-    redirectUri: TWITTER_REDIRECT_URI,
-  ),
-];
 
 class FirebaseAuthUIExample extends StatelessWidget {
   @override
@@ -111,7 +112,6 @@ class FirebaseAuthUIExample extends StatelessWidget {
                 ),
               );
             },
-            providerConfigs: providerConfigs,
           );
         },
         '/phone': (context) {
@@ -150,7 +150,6 @@ class FirebaseAuthUIExample extends StatelessWidget {
         },
         '/profile': (context) {
           return ProfileScreen(
-            providerConfigs: providerConfigs,
             actions: [
               SignedOutAction((context) {
                 Navigator.pushReplacementNamed(context, '/');

--- a/packages/flutterfire_ui/lib/src/auth/configs/oauth_provider_configuration.dart
+++ b/packages/flutterfire_ui/lib/src/auth/configs/oauth_provider_configuration.dart
@@ -10,8 +10,11 @@ import '../widgets/internal/oauth_provider_button_style.dart';
 
 import '../flows/oauth_flow.dart';
 
-abstract class OAuthProviderConfiguration extends ProviderConfiguration {
+abstract class OAuthProviderConfiguration<T extends OAuthProvider>
+    extends ProviderConfiguration {
   const OAuthProviderConfiguration();
+
+  Type get providerType => T;
 
   String get defaultRedirectUri =>
       'https://${Firebase.apps.first.options.projectId}.firebaseapp.com/__/auth/handler';
@@ -27,7 +30,7 @@ abstract class OAuthProviderConfiguration extends ProviderConfiguration {
     );
   }
 
-  OAuthProvider createProvider();
+  T createProvider();
 
   String getLabel(FlutterFireUILocalizationLabels labels);
 }

--- a/packages/flutterfire_ui/lib/src/auth/flows/oauth_flow.dart
+++ b/packages/flutterfire_ui/lib/src/auth/flows/oauth_flow.dart
@@ -22,7 +22,12 @@ class OAuthFlow extends AuthFlow implements OAuthController {
 
   @override
   Future<void> signInWithProvider(TargetPlatform platform) async {
-    final provider = config.createProvider();
+    OAuthProvider? provider = OAuthProviders.resolve(auth, config.providerType);
+
+    if (provider == null) {
+      provider = config.createProvider();
+      OAuthProviders.register(auth, provider);
+    }
 
     try {
       value = const SigningIn();

--- a/packages/flutterfire_ui/lib/src/auth/oauth/providers/apple_provider.dart
+++ b/packages/flutterfire_ui/lib/src/auth/oauth/providers/apple_provider.dart
@@ -31,7 +31,9 @@ String sha256ofString(String input) {
   return digest.toString();
 }
 
-class AppleProviderImpl extends OAuthProvider {
+abstract class AppleProvider extends OAuthProvider {}
+
+class AppleProviderImpl extends AppleProvider {
   @override
   Future<fba.OAuthCredential> signIn() async {
     final rawNonce = generateNonce();
@@ -72,11 +74,12 @@ class AppleProviderImpl extends OAuthProvider {
   dynamic get firebaseAuthProvider => null;
 }
 
-class AppleProviderConfiguration extends OAuthProviderConfiguration {
+class AppleProviderConfiguration
+    extends OAuthProviderConfiguration<AppleProvider> {
   const AppleProviderConfiguration();
 
   @override
-  OAuthProvider createProvider() {
+  AppleProvider createProvider() {
     return AppleProviderImpl();
   }
 

--- a/packages/flutterfire_ui/lib/src/auth/oauth/providers/facebook_provider.dart
+++ b/packages/flutterfire_ui/lib/src/auth/oauth/providers/facebook_provider.dart
@@ -12,7 +12,9 @@ import '../../oauth/provider_resolvers.dart';
 import '../../auth_flow.dart';
 import '../oauth_providers.dart';
 
-class FacebookProviderImpl extends OAuthProvider {
+abstract class FacebookProvider extends OAuthProvider {}
+
+class FacebookProviderImpl extends FacebookProvider {
   final _provider = FacebookAuth.instance;
   final String clientId;
   final String redirectUri;
@@ -48,6 +50,11 @@ class FacebookProviderImpl extends OAuthProvider {
   }
 
   @override
+  Future<void> signOut() async {
+    await _provider.logOut();
+  }
+
+  @override
   OAuthCredential fromDesktopAuthResult(AuthResult result) {
     return FacebookAuthProvider.credential(result.accessToken);
   }
@@ -56,7 +63,8 @@ class FacebookProviderImpl extends OAuthProvider {
   FacebookAuthProvider get firebaseAuthProvider => FacebookAuthProvider();
 }
 
-class FacebookProviderConfiguration extends OAuthProviderConfiguration {
+class FacebookProviderConfiguration
+    extends OAuthProviderConfiguration<FacebookProvider> {
   final String clientId;
   final String? redirectUri;
 
@@ -65,7 +73,7 @@ class FacebookProviderConfiguration extends OAuthProviderConfiguration {
     this.redirectUri,
   });
 
-  OAuthProvider get _provider => FacebookProviderImpl(
+  FacebookProvider get _provider => FacebookProviderImpl(
         clientId: clientId,
         redirectUri: redirectUri ?? defaultRedirectUri,
       );
@@ -74,7 +82,7 @@ class FacebookProviderConfiguration extends OAuthProviderConfiguration {
   String get providerId => FACEBOOK_PROVIDER_ID;
 
   @override
-  OAuthProvider createProvider() {
+  FacebookProvider createProvider() {
     return _provider;
   }
 

--- a/packages/flutterfire_ui/lib/src/auth/oauth/providers/google_provider.dart
+++ b/packages/flutterfire_ui/lib/src/auth/oauth/providers/google_provider.dart
@@ -17,7 +17,9 @@ const _firebaseAuthProviderParameters = {
   'prompt': 'select_account',
 };
 
-class GoogleProviderImpl extends OAuthProvider {
+abstract class GoogleProvider extends OAuthProvider {}
+
+class GoogleProviderImpl extends GoogleProvider {
   String clientId;
   String redirectUri;
 
@@ -58,12 +60,19 @@ class GoogleProviderImpl extends OAuthProvider {
   }
 
   @override
+  Future<void> signOut() async {
+    await _provider.signOut();
+    await super.signOut();
+  }
+
+  @override
   OAuthCredential fromDesktopAuthResult(AuthResult result) {
     return GoogleAuthProvider.credential(accessToken: result.accessToken);
   }
 }
 
-class GoogleProviderConfiguration extends OAuthProviderConfiguration {
+class GoogleProviderConfiguration
+    extends OAuthProviderConfiguration<GoogleProvider> {
   final String clientId;
   final String? redirectUri;
 
@@ -81,7 +90,7 @@ class GoogleProviderConfiguration extends OAuthProviderConfiguration {
   String get providerId => GOOGLE_PROVIDER_ID;
 
   @override
-  OAuthProvider createProvider() {
+  GoogleProvider createProvider() {
     return _provider;
   }
 

--- a/packages/flutterfire_ui/lib/src/auth/oauth/providers/twitter_provider.dart
+++ b/packages/flutterfire_ui/lib/src/auth/oauth/providers/twitter_provider.dart
@@ -12,7 +12,9 @@ import '../../widgets/internal/oauth_provider_button_style.dart';
 import '../../auth_flow.dart';
 import '../oauth_providers.dart';
 
-class TwitterProviderImpl extends OAuthProvider {
+abstract class TwitterProvider extends OAuthProvider {}
+
+class TwitterProviderImpl extends TwitterProvider {
   final String apiKey;
   final String apiSecretKey;
   final String redirectUri;
@@ -67,12 +69,13 @@ class TwitterProviderImpl extends OAuthProvider {
   TwitterAuthProvider get firebaseAuthProvider => TwitterAuthProvider();
 }
 
-class TwitterProviderConfiguration extends OAuthProviderConfiguration {
+class TwitterProviderConfiguration
+    extends OAuthProviderConfiguration<TwitterProvider> {
   final String apiKey;
   final String apiSecretKey;
   final String redirectUri;
 
-  OAuthProvider get _provider => TwitterProviderImpl(
+  TwitterProvider get _provider => TwitterProviderImpl(
         apiKey: apiKey,
         apiSecretKey: apiSecretKey,
         redirectUri: redirectUri,
@@ -88,7 +91,7 @@ class TwitterProviderConfiguration extends OAuthProviderConfiguration {
   String get providerId => TWITTER_PROVIDER_ID;
 
   @override
-  OAuthProvider createProvider() {
+  TwitterProvider createProvider() {
     return _provider;
   }
 

--- a/packages/flutterfire_ui/lib/src/auth/screens/email_link_sign_in_screen.dart
+++ b/packages/flutterfire_ui/lib/src/auth/screens/email_link_sign_in_screen.dart
@@ -2,12 +2,12 @@ import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutterfire_ui/auth.dart';
 
+import 'internal/provider_screen.dart';
 import 'internal/responsive_page.dart';
 import '../widgets/internal/universal_scaffold.dart';
 
-class EmailLinkSignInScreen extends StatelessWidget {
-  final FirebaseAuth? auth;
-  final EmailLinkProviderConfiguration config;
+class EmailLinkSignInScreen
+    extends ProviderScreen<EmailLinkProviderConfiguration> {
   final List<FlutterFireUIAction>? actions;
   final HeaderBuilder? headerBuilder;
   final double? headerMaxExtent;
@@ -17,15 +17,15 @@ class EmailLinkSignInScreen extends StatelessWidget {
 
   const EmailLinkSignInScreen({
     Key? key,
-    this.auth,
+    FirebaseAuth? auth,
     this.actions,
-    required this.config,
+    EmailLinkProviderConfiguration? config,
     this.headerBuilder,
     this.headerMaxExtent,
     this.sideBuilder,
     this.desktoplayoutDirection,
     this.breakpoint = 500,
-  }) : super(key: key);
+  }) : super(key: key, auth: auth, config: config);
 
   @override
   Widget build(BuildContext context) {

--- a/packages/flutterfire_ui/lib/src/auth/screens/internal/multi_provider_screen.dart
+++ b/packages/flutterfire_ui/lib/src/auth/screens/internal/multi_provider_screen.dart
@@ -1,0 +1,57 @@
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:flutter/material.dart';
+import 'package:flutterfire_ui/auth.dart';
+
+abstract class MultiProviderScreen extends Widget {
+  final List<ProviderConfiguration>? _providerConfigs;
+  final FirebaseAuth? _auth;
+  FirebaseAuth get auth {
+    return _auth ?? FirebaseAuth.instance;
+  }
+
+  const MultiProviderScreen({
+    Key? key,
+    FirebaseAuth? auth,
+    List<ProviderConfiguration>? providerConfigs,
+  })  : _auth = auth,
+        _providerConfigs = providerConfigs,
+        super(key: key);
+
+  List<ProviderConfiguration> get providerConfigs {
+    if (_providerConfigs != null) {
+      return _providerConfigs!;
+    } else {
+      return FlutterFireUIAuth.configsFor(auth.app);
+    }
+  }
+
+  Widget build(BuildContext context);
+
+  @override
+  ScreenElement createElement() {
+    return ScreenElement(this);
+  }
+}
+
+class ScreenElement extends ComponentElement {
+  ScreenElement(Widget widget) : super(widget);
+
+  @override
+  MultiProviderScreen get widget => super.widget as MultiProviderScreen;
+
+  @override
+  void mount(Element? parent, Object? newSlot) {
+    if (widget._providerConfigs != null) {
+      if (!FlutterFireUIAuth.isAppConfigured(widget.auth.app)) {
+        FlutterFireUIAuth.configureProviders(widget._providerConfigs!);
+      }
+    }
+
+    super.mount(parent, newSlot);
+  }
+
+  @override
+  Widget build() {
+    return widget.build(this);
+  }
+}

--- a/packages/flutterfire_ui/lib/src/auth/screens/internal/provider_screen.dart
+++ b/packages/flutterfire_ui/lib/src/auth/screens/internal/provider_screen.dart
@@ -1,0 +1,28 @@
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:flutter/widgets.dart';
+import 'package:flutterfire_ui/auth.dart';
+
+abstract class ProviderScreen<T extends ProviderConfiguration>
+    extends StatelessWidget {
+  final T? _config;
+  final FirebaseAuth? auth;
+
+  static final _cache = <Type, ProviderConfiguration>{};
+
+  T get config {
+    if (_config != null) return _config!;
+    if (_cache.containsKey(T)) {
+      return _cache[T]! as T;
+    }
+
+    final _auth = auth ?? FirebaseAuth.instance;
+    final configs = FlutterFireUIAuth.configsFor(_auth.app);
+    final config = configs.firstWhere((element) => element is T) as T;
+    _cache[T] = config;
+    return config;
+  }
+
+  const ProviderScreen({Key? key, T? config, this.auth})
+      : _config = config,
+        super(key: key);
+}

--- a/packages/flutterfire_ui/lib/src/auth/screens/profile_screen.dart
+++ b/packages/flutterfire_ui/lib/src/auth/screens/profile_screen.dart
@@ -4,6 +4,9 @@ import 'package:flutterfire_ui/i10n.dart';
 import 'package:flutter/material.dart' hide Title;
 import 'package:flutterfire_ui/auth.dart';
 
+import 'internal/multi_provider_screen.dart';
+
+import '../widgets/internal/rebuild_scope.dart';
 import '../widgets/internal/subtitle.dart';
 
 class AvailableProvidersRow extends StatelessWidget {
@@ -141,10 +144,8 @@ class LinkedProvidersRow extends StatelessWidget {
   }
 }
 
-class ProfileScreen extends StatefulWidget {
-  final List<ProviderConfiguration> providerConfigs;
+class ProfileScreen extends MultiProviderScreen {
   final List<Widget> children;
-  final FirebaseAuth? auth;
   final Color? avatarPlaceholderColor;
   final ShapeBorder? avatarShape;
   final double? avatarSize;
@@ -152,32 +153,20 @@ class ProfileScreen extends StatefulWidget {
 
   const ProfileScreen({
     Key? key,
-    required this.providerConfigs,
-    this.auth,
+    FirebaseAuth? auth,
+    List<ProviderConfiguration>? providerConfigs,
     this.avatarPlaceholderColor,
     this.avatarShape,
     this.avatarSize,
     this.children = const [],
     this.actions,
-  }) : super(key: key);
-
-  @override
-  State<ProfileScreen> createState() => _ProfileScreenState();
-}
-
-class _ProfileScreenState extends State<ProfileScreen> {
-  Future<void> _logout(BuildContext context) async {
-    await (widget.auth ?? FirebaseAuth.instance).signOut();
-    final action = FlutterFireUIAction.ofType<SignedOutAction>(context);
-
-    action?.callback(context);
-  }
+  }) : super(key: key, providerConfigs: providerConfigs, auth: auth);
 
   Future<bool> _reauthenticate(BuildContext context) {
     return showReauthenticateDialog(
       context: context,
-      providerConfigs: widget.providerConfigs,
-      auth: widget.auth,
+      providerConfigs: providerConfigs,
+      auth: auth,
       onSignedIn: () => Navigator.of(context).pop(true),
     );
   }
@@ -187,50 +176,74 @@ class _ProfileScreenState extends State<ProfileScreen> {
     final l = FlutterFireUILocalizations.labelsOf(context);
     final isCupertino = CupertinoUserInterfaceLevel.maybeOf(context) != null;
     final platform = Theme.of(context).platform;
-    final _auth = widget.auth ?? FirebaseAuth.instance;
-    final _user = _auth.currentUser!;
-
-    final linkedProviders = widget.providerConfigs
-        .where((config) => _user.isProviderLinked(config.providerId))
-        .toList();
-
-    final availableProviders = widget.providerConfigs
-        .where((config) => !_user.isProviderLinked(config.providerId))
-        .where((config) => config.isSupportedPlatform(platform))
-        .toList();
+    final scopeKey = RebuildScopeKey();
 
     final content = Column(
       crossAxisAlignment: CrossAxisAlignment.stretch,
       children: [
         Align(
           child: UserAvatar(
-            auth: widget.auth,
-            placeholderColor: widget.avatarPlaceholderColor,
-            shape: widget.avatarShape,
-            size: widget.avatarSize,
+            auth: auth,
+            placeholderColor: avatarPlaceholderColor,
+            shape: avatarShape,
+            size: avatarSize,
           ),
         ),
         const SizedBox(height: 16),
-        Align(child: EditableUserDisplayName(auth: widget.auth)),
-        if (linkedProviders.isNotEmpty) ...[
-          const SizedBox(height: 32),
-          LinkedProvidersRow(
-            auth: widget.auth,
-            providerConfigs: linkedProviders,
-          ),
-        ],
-        if (availableProviders.isNotEmpty) ...[
-          const SizedBox(height: 32),
-          AvailableProvidersRow(
-            auth: widget.auth,
-            providerConfigs: availableProviders,
-            onProviderLinked: () => setState(() {}),
-          ),
-        ],
-        ...widget.children,
+        Align(child: EditableUserDisplayName(auth: auth)),
+        RebuildScope(
+          builder: (context) {
+            final user = auth.currentUser!;
+
+            final linkedProviders = providerConfigs
+                .where(
+                  (config) => user.isProviderLinked(config.providerId),
+                )
+                .toList();
+
+            if (linkedProviders.isNotEmpty) {
+              return Padding(
+                padding: const EdgeInsets.only(top: 32),
+                child: LinkedProvidersRow(
+                  auth: auth,
+                  providerConfigs: linkedProviders,
+                ),
+              );
+            } else {
+              return const SizedBox.shrink();
+            }
+          },
+          scopeKey: scopeKey,
+        ),
+        RebuildScope(
+          builder: (context) {
+            final availableProviders = providerConfigs
+                .where(
+                  (config) =>
+                      !auth.currentUser!.isProviderLinked(config.providerId),
+                )
+                .where((config) => config.isSupportedPlatform(platform))
+                .toList();
+
+            if (availableProviders.isNotEmpty) {
+              return Padding(
+                padding: const EdgeInsets.only(top: 32),
+                child: AvailableProvidersRow(
+                  auth: auth,
+                  providerConfigs: availableProviders,
+                  onProviderLinked: scopeKey.rebuild,
+                ),
+              );
+            } else {
+              return const SizedBox.shrink();
+            }
+          },
+          scopeKey: scopeKey,
+        ),
+        ...children,
         const SizedBox(height: 16),
         DeleteAccountButton(
-          auth: widget.auth,
+          auth: auth,
           onSignInRequired: () {
             return _reauthenticate(context);
           },
@@ -257,7 +270,7 @@ class _ProfileScreenState extends State<ProfileScreen> {
 
     if (isCupertino) {
       return FlutterFireUIActions(
-        actions: widget.actions ?? const [],
+        actions: actions ?? const [],
         child: Builder(
           builder: (context) => CupertinoPageScaffold(
             navigationBar: CupertinoNavigationBar(
@@ -265,7 +278,10 @@ class _ProfileScreenState extends State<ProfileScreen> {
               trailing: Transform.translate(
                 offset: const Offset(0, -6),
                 child: CupertinoButton(
-                  onPressed: () => _logout(context),
+                  onPressed: () => FlutterFireUIAuth.signOut(
+                    context: context,
+                    auth: auth,
+                  ),
                   child: const Icon(CupertinoIcons.arrow_right_circle),
                 ),
               ),
@@ -276,14 +292,17 @@ class _ProfileScreenState extends State<ProfileScreen> {
       );
     } else {
       return FlutterFireUIActions(
-        actions: widget.actions ?? const [],
+        actions: actions ?? const [],
         child: Builder(
           builder: (context) => Scaffold(
             appBar: AppBar(
               title: Text(l.profile),
               actions: [
                 IconButton(
-                  onPressed: () => _logout(context),
+                  onPressed: () => FlutterFireUIAuth.signOut(
+                    context: context,
+                    auth: auth,
+                  ),
                   icon: const Icon(
                     Icons.logout_outlined,
                   ),

--- a/packages/flutterfire_ui/lib/src/auth/screens/register_screen.dart
+++ b/packages/flutterfire_ui/lib/src/auth/screens/register_screen.dart
@@ -3,6 +3,7 @@ import 'package:firebase_auth/firebase_auth.dart' show FirebaseAuth;
 import 'package:flutterfire_ui/auth.dart';
 
 import 'internal/login_screen.dart';
+import 'internal/multi_provider_screen.dart';
 
 /// A screen displaying a fully styled Registration flow for Authentication.
 ///
@@ -10,9 +11,7 @@ import 'internal/login_screen.dart';
 /// {@subCategory type:screen}
 /// {@subCategory description:A screen displaying a fully styled Registration flow for Authentication.}
 /// {@subCategory img:https://place-hold.it/400x150}
-class RegisterScreen extends StatelessWidget {
-  final FirebaseAuth? auth;
-  final List<ProviderConfiguration> providerConfigs;
+class RegisterScreen extends MultiProviderScreen {
   final double? headerMaxExtent;
   final HeaderBuilder? headerBuilder;
   final SideBuilder? sideBuilder;
@@ -26,8 +25,8 @@ class RegisterScreen extends StatelessWidget {
 
   const RegisterScreen({
     Key? key,
-    required this.providerConfigs,
-    this.auth,
+    FirebaseAuth? auth,
+    List<ProviderConfiguration>? providerConfigs,
     this.headerMaxExtent,
     this.headerBuilder,
     this.sideBuilder,
@@ -38,7 +37,7 @@ class RegisterScreen extends StatelessWidget {
     this.subtitleBuilder,
     this.footerBuilder,
     this.breakpoint = 800,
-  }) : super(key: key);
+  }) : super(key: key, auth: auth, providerConfigs: providerConfigs);
 
   @override
   Widget build(BuildContext context) {

--- a/packages/flutterfire_ui/lib/src/auth/screens/sign_in_screen.dart
+++ b/packages/flutterfire_ui/lib/src/auth/screens/sign_in_screen.dart
@@ -4,6 +4,7 @@ import 'package:firebase_auth/firebase_auth.dart' show FirebaseAuth;
 import 'package:flutterfire_ui/auth.dart';
 
 import 'internal/login_screen.dart';
+import 'internal/multi_provider_screen.dart';
 
 /// A screen displaying a fully styled Sign In flow for Authentication.
 ///
@@ -11,9 +12,7 @@ import 'internal/login_screen.dart';
 /// {@subCategory type:screen}
 /// {@subCategory description:A screen displaying a fully styled Sign In flow for Authentication.}
 /// {@subCategory img:https://place-hold.it/400x150}
-class SignInScreen extends StatelessWidget {
-  final FirebaseAuth? auth;
-  final List<ProviderConfiguration> providerConfigs;
+class SignInScreen extends MultiProviderScreen {
   final double? headerMaxExtent;
   final HeaderBuilder? headerBuilder;
   final SideBuilder? sideBuilder;
@@ -29,8 +28,8 @@ class SignInScreen extends StatelessWidget {
 
   const SignInScreen({
     Key? key,
-    required this.providerConfigs,
-    this.auth,
+    List<ProviderConfiguration>? providerConfigs,
+    FirebaseAuth? auth,
     this.headerMaxExtent,
     this.headerBuilder,
     this.sideBuilder,
@@ -43,7 +42,7 @@ class SignInScreen extends StatelessWidget {
     this.loginViewKey,
     this.actions = const [],
     this.breakpoint = 800,
-  }) : super(key: key);
+  }) : super(key: key, providerConfigs: providerConfigs, auth: auth);
 
   Future<void> _signInWithDifferentProvider(
     BuildContext context,
@@ -58,8 +57,8 @@ class SignInScreen extends StatelessWidget {
         Navigator.of(context).pop();
       },
     );
-    final _auth = auth ?? FirebaseAuth.instance;
-    await _auth.currentUser!.linkWithCredential(state.credential!);
+
+    await auth.currentUser!.linkWithCredential(state.credential!);
   }
 
   @override

--- a/packages/flutterfire_ui/lib/src/auth/screens/universal_email_sign_in_screen.dart
+++ b/packages/flutterfire_ui/lib/src/auth/screens/universal_email_sign_in_screen.dart
@@ -1,22 +1,21 @@
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
 import 'package:flutterfire_ui/auth.dart';
+import 'package:flutterfire_ui/src/auth/screens/internal/multi_provider_screen.dart';
 
 import '../widgets/internal/universal_page_route.dart';
 import '../widgets/internal/universal_scaffold.dart';
 
-class UniversalEmailSignInScreen extends StatelessWidget {
-  final FirebaseAuth? auth;
+class UniversalEmailSignInScreen extends MultiProviderScreen {
   final ProvidersFoundCallback? onProvidersFound;
-  final List<ProviderConfiguration>? providerConfigs;
 
   const UniversalEmailSignInScreen({
     Key? key,
-    this.auth,
+    FirebaseAuth? auth,
+    List<ProviderConfiguration>? providerConfigs,
     this.onProvidersFound,
-    this.providerConfigs,
   })  : assert(onProvidersFound != null || providerConfigs != null),
-        super(key: key);
+        super(key: key, auth: auth, providerConfigs: providerConfigs);
 
   Widget _wrap(BuildContext context, Widget child) {
     return AuthStateListener(
@@ -47,7 +46,7 @@ class UniversalEmailSignInScreen extends StatelessWidget {
           context,
           RegisterScreen(
             showAuthActionSwitch: false,
-            providerConfigs: providerConfigs!,
+            providerConfigs: providerConfigs,
             auth: auth,
             email: email,
           ),
@@ -57,7 +56,7 @@ class UniversalEmailSignInScreen extends StatelessWidget {
       final List<ProviderConfiguration> finalProviders = [];
       final providersSet = Set.from(providers);
 
-      for (final p in providerConfigs!) {
+      for (final p in providerConfigs) {
         if (providersSet.contains(p.providerId)) {
           finalProviders.add(p);
         }

--- a/packages/flutterfire_ui/lib/src/auth/widgets/delete_account_button.dart
+++ b/packages/flutterfire_ui/lib/src/auth/widgets/delete_account_button.dart
@@ -1,11 +1,10 @@
 import 'package:firebase_auth/firebase_auth.dart'
     show FirebaseAuth, FirebaseAuthException;
 import 'package:flutter/cupertino.dart';
+import 'package:flutterfire_ui/auth.dart';
 import 'package:flutterfire_ui/i10n.dart';
 import '../widgets/internal/loading_button.dart';
 import 'package:flutter/material.dart';
-
-import '../actions.dart';
 
 typedef DeleteFailedCallback = void Function(Exception exception);
 typedef SignInRequiredCallback = Future<bool> Function();
@@ -38,7 +37,7 @@ class _DeleteAccountButtonState extends State<DeleteAccountButton> {
 
     try {
       await auth.currentUser?.delete();
-      FlutterFireUIAction.ofType<SignedOutAction>(context)?.callback(context);
+      await FlutterFireUIAuth.signOut(context: context, auth: auth);
     } on FirebaseAuthException catch (err) {
       if (err.code == 'requires-recent-login') {
         if (widget.onSignInRequired != null) {

--- a/packages/flutterfire_ui/lib/src/auth/widgets/internal/rebuild_scope.dart
+++ b/packages/flutterfire_ui/lib/src/auth/widgets/internal/rebuild_scope.dart
@@ -1,0 +1,63 @@
+import 'package:flutter/widgets.dart';
+
+class RebuildScopeKey {
+  RebuildScopeKey();
+
+  final _elements = <RebuildScopeElement>[];
+
+  void rebuild() {
+    _elements.forEach((element) {
+      element.markNeedsBuild();
+    });
+  }
+}
+
+class RebuildScope extends Widget {
+  final WidgetBuilder builder;
+  final RebuildScopeKey scopeKey;
+
+  const RebuildScope({
+    Key? key,
+    required this.builder,
+    required this.scopeKey,
+  }) : super(key: key);
+
+  @override
+  RebuildScopeElement createElement() {
+    return RebuildScopeElement(this);
+  }
+}
+
+class RebuildScopeElement extends ComponentElement {
+  RebuildScopeElement(RebuildScope widget) : super(widget);
+
+  @override
+  RebuildScope get widget => super.widget as RebuildScope;
+
+  late RebuildScopeKey scopeKey;
+
+  void _registerElement(RebuildScope widget) {
+    scopeKey = widget.scopeKey;
+    scopeKey._elements.add(this);
+  }
+
+  @override
+  void mount(Element? parent, Object? newSlot) {
+    _registerElement(widget);
+    super.mount(parent, newSlot);
+  }
+
+  @override
+  void update(RebuildScope newWidget) {
+    scopeKey._elements.clear();
+    _registerElement(widget);
+
+    super.update(newWidget);
+    markNeedsBuild();
+  }
+
+  @override
+  Widget build() {
+    return widget.builder(this);
+  }
+}

--- a/packages/flutterfire_ui/lib/src/auth/widgets/sign_out_button.dart
+++ b/packages/flutterfire_ui/lib/src/auth/widgets/sign_out_button.dart
@@ -1,7 +1,9 @@
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/cupertino.dart';
+import 'package:flutterfire_ui/auth.dart';
 import 'package:flutterfire_ui/i10n.dart';
 import 'package:flutter/material.dart';
+
 import '../widgets/internal/universal_button.dart';
 
 class SignOutButton extends StatelessWidget {
@@ -11,10 +13,6 @@ class SignOutButton extends StatelessWidget {
     this.auth,
   }) : super(key: key);
 
-  void _signOut() {
-    (auth ?? FirebaseAuth.instance).signOut();
-  }
-
   @override
   Widget build(BuildContext context) {
     final l = FlutterFireUILocalizations.labelsOf(context);
@@ -22,7 +20,10 @@ class SignOutButton extends StatelessWidget {
 
     return UniversalButton(
       text: l.signOutButtonText,
-      onPressed: _signOut,
+      onPressed: () => FlutterFireUIAuth.signOut(
+        context: context,
+        auth: auth,
+      ),
       icon: isCupertino ? CupertinoIcons.arrow_right_circle : Icons.logout,
     );
   }

--- a/packages/flutterfire_ui/pubspec.yaml
+++ b/packages/flutterfire_ui/pubspec.yaml
@@ -5,7 +5,7 @@ repository: https://github.com/FirebaseExtended/flutterfire/tree/master/packages
 homepage: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/flutterfire_ui
 
 false_secrets:
- - example/**
+  - example/**
 
 environment:
   sdk: '>=2.12.0 <3.0.0'
@@ -46,7 +46,6 @@ flutter:
   assets:
     - assets/icons/
     - assets/countries.json
-
 # To add assets to your package, add an assets section, like this:
 # assets:
 #   - images/a_dot_burr.jpeg


### PR DESCRIPTION
## Description

Alongside fixing the issue, this PR introduces a new mechanism to configure auth providers.
The underlying issue requires storing auth providers globally, this PR updates existing screens to fetch provider configurations from global storage if none passed as an argument. 

## Related Issues

Fixes #7801

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
