### PR TITLE
fix(firebase_remote_config): add missing `default_package` entry for web in `pubspec.yaml`

### DIFF
--- a/packages/firebase_remote_config/firebase_remote_config/pubspec.yaml
+++ b/packages/firebase_remote_config/firebase_remote_config/pubspec.yaml
@@ -39,3 +39,5 @@ flutter:
         pluginClass: FLTFirebaseRemoteConfigPlugin
       macos:
         pluginClass: FLTFirebaseRemoteConfigPlugin
+      web:
+        default_package: firebase_remote_config_web


### PR DESCRIPTION
[Firebase remote config](https://pub.dev/packages/firebase_remote_config) dependency already has web implementation but the pub.dev shows only "Android", "iOS", "MacOS" platforms supported by the plugin.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.
