### PR TITLE
chore: Rename internal `guard`  function to `convertWebException` to be clearer

### DIFF
--- a/packages/cloud_firestore/cloud_firestore_web/lib/cloud_firestore_web.dart
+++ b/packages/cloud_firestore/cloud_firestore_web/lib/cloud_firestore_web.dart
@@ -63,7 +63,7 @@ class FirebaseFirestoreWeb extends FirebaseFirestorePlatform {
 
   @override
   Future<void> clearPersistence() {
-    return guard(_delegate.clearPersistence);
+    return convertWebExceptions(_delegate.clearPersistence);
   }
 
   @override
@@ -80,7 +80,7 @@ class FirebaseFirestoreWeb extends FirebaseFirestorePlatform {
 
   @override
   Future<void> disableNetwork() {
-    return guard(_delegate.disableNetwork);
+    return convertWebExceptions(_delegate.disableNetwork);
   }
 
   @override
@@ -89,7 +89,7 @@ class FirebaseFirestoreWeb extends FirebaseFirestorePlatform {
 
   @override
   Future<void> enableNetwork() {
-    return guard(_delegate.enableNetwork);
+    return convertWebExceptions(_delegate.enableNetwork);
   }
 
   @override
@@ -100,7 +100,7 @@ class FirebaseFirestoreWeb extends FirebaseFirestorePlatform {
   @override
   Future<T?> runTransaction<T>(TransactionHandler<T> transactionHandler,
       {Duration timeout = const Duration(seconds: 30)}) async {
-    await guard(() {
+    await convertWebExceptions(() {
       return _delegate.runTransaction((transaction) async {
         return transactionHandler(
             TransactionWeb(this, _delegate, transaction!));
@@ -149,20 +149,21 @@ class FirebaseFirestoreWeb extends FirebaseFirestorePlatform {
           firestore_interop.PersistenceSettings(
               synchronizeTabs: settings.synchronizeTabs);
 
-      return guard(() => _delegate.enablePersistence(interopSettings));
+      return convertWebExceptions(
+          () => _delegate.enablePersistence(interopSettings));
     }
 
-    return guard(_delegate.enablePersistence);
+    return convertWebExceptions(_delegate.enablePersistence);
   }
 
   @override
   Future<void> terminate() {
-    return guard(_delegate.terminate);
+    return convertWebExceptions(_delegate.terminate);
   }
 
   @override
   Future<void> waitForPendingWrites() {
-    return guard(_delegate.waitForPendingWrites);
+    return convertWebExceptions(_delegate.waitForPendingWrites);
   }
 
   @override

--- a/packages/cloud_firestore/cloud_firestore_web/lib/src/document_reference_web.dart
+++ b/packages/cloud_firestore/cloud_firestore_web/lib/src/document_reference_web.dart
@@ -29,7 +29,7 @@ class DocumentReferenceWeb extends DocumentReferencePlatform {
 
   @override
   Future<void> set(Map<String, dynamic> data, [SetOptions? options]) {
-    return guard(
+    return convertWebExceptions(
       () => _delegate.set(
         EncodeUtility.encodeMapData(data)!,
         convertSetOptions(options),
@@ -39,13 +39,15 @@ class DocumentReferenceWeb extends DocumentReferencePlatform {
 
   @override
   Future<void> update(Map<String, dynamic> data) {
-    return guard(() => _delegate.update(EncodeUtility.encodeMapData(data)!));
+    return convertWebExceptions(
+        () => _delegate.update(EncodeUtility.encodeMapData(data)!));
   }
 
   @override
   Future<DocumentSnapshotPlatform> get(
       [GetOptions options = const GetOptions()]) async {
-    firestore_interop.DocumentSnapshot documentSnapshot = await guard(
+    firestore_interop.DocumentSnapshot documentSnapshot =
+        await convertWebExceptions(
       () => _delegate.get(convertGetOptions(options)),
     );
 
@@ -54,7 +56,7 @@ class DocumentReferenceWeb extends DocumentReferencePlatform {
 
   @override
   Future<void> delete() {
-    return guard(_delegate.delete);
+    return convertWebExceptions(_delegate.delete);
   }
 
   @override
@@ -67,7 +69,7 @@ class DocumentReferenceWeb extends DocumentReferencePlatform {
       querySnapshots = _delegate.onMetadataChangesSnapshot;
     }
 
-    return guard(
+    return convertWebExceptions(
       () => querySnapshots.map((webSnapshot) {
         return convertWebDocumentSnapshot(firestore, webSnapshot);
       }),

--- a/packages/cloud_firestore/cloud_firestore_web/lib/src/internals.dart
+++ b/packages/cloud_firestore/cloud_firestore_web/lib/src/internals.dart
@@ -7,7 +7,7 @@ import 'package:firebase_core/src/internals.dart' as internals;
 
 /// Will return a [FirebaseException] from a thrown web error.
 /// Any other errors will be propagated as normal.
-R guard<R>(R Function() cb) {
+R convertWebExceptions<R>(R Function() cb) {
   return internals.guard(
     cb,
     plugin: 'cloud_firestore',

--- a/packages/cloud_firestore/cloud_firestore_web/lib/src/internals.dart
+++ b/packages/cloud_firestore/cloud_firestore_web/lib/src/internals.dart
@@ -1,5 +1,5 @@
 // ignore_for_file: require_trailing_commas
-export 'package:firebase_core/src/internals.dart' hide guard;
+export 'package:firebase_core/src/internals.dart' hide guardWebExceptions;
 
 import 'package:firebase_core/firebase_core.dart';
 // ignore: implementation_imports
@@ -8,7 +8,7 @@ import 'package:firebase_core/src/internals.dart' as internals;
 /// Will return a [FirebaseException] from a thrown web error.
 /// Any other errors will be propagated as normal.
 R convertWebExceptions<R>(R Function() cb) {
-  return internals.guard(
+  return internals.guardWebExceptions(
     cb,
     plugin: 'cloud_firestore',
     codeParser: (code) => code.replaceFirst('firestore/', ''),

--- a/packages/cloud_firestore/cloud_firestore_web/lib/src/query_web.dart
+++ b/packages/cloud_firestore/cloud_firestore_web/lib/src/query_web.dart
@@ -146,7 +146,7 @@ class QueryWeb extends QueryPlatform {
 
   @override
   Future<QuerySnapshotPlatform> get([GetOptions options = const GetOptions()]) {
-    return guard(() async {
+    return convertWebExceptions(() async {
       return convertWebQuerySnapshot(
         firestore,
         await _buildWebQueryWithParameters().get(convertGetOptions(options)),
@@ -181,7 +181,7 @@ class QueryWeb extends QueryPlatform {
       querySnapshots = _buildWebQueryWithParameters().onSnapshot;
     }
 
-    return guard(
+    return convertWebExceptions(
       () => querySnapshots.map((webQuerySnapshot) {
         return convertWebQuerySnapshot(firestore, webQuerySnapshot);
       }),

--- a/packages/cloud_firestore/cloud_firestore_web/lib/src/transaction_web.dart
+++ b/packages/cloud_firestore/cloud_firestore_web/lib/src/transaction_web.dart
@@ -30,7 +30,7 @@ class TransactionWeb extends TransactionPlatform {
 
   @override
   Future<DocumentSnapshotPlatform> get(String documentPath) {
-    return guard(
+    return convertWebExceptions(
       () async {
         final webDocumentSnapshot = await _webTransactionDelegate
             .get(_webFirestoreDelegate.doc(documentPath));

--- a/packages/cloud_firestore/cloud_firestore_web/lib/src/write_batch_web.dart
+++ b/packages/cloud_firestore/cloud_firestore_web/lib/src/write_batch_web.dart
@@ -22,7 +22,7 @@ class WriteBatchWeb extends WriteBatchPlatform {
 
   @override
   Future<void> commit() {
-    return guard(_webWriteBatchDelegate.commit);
+    return convertWebExceptions(_webWriteBatchDelegate.commit);
   }
 
   @override

--- a/packages/firebase_analytics/firebase_analytics_web/lib/firebase_analytics_web.dart
+++ b/packages/firebase_analytics/firebase_analytics_web/lib/firebase_analytics_web.dart
@@ -44,7 +44,7 @@ class FirebaseAnalyticsWeb extends FirebaseAnalyticsPlatform {
     Map<String, Object?>? parameters,
     AnalyticsCallOptions? callOptions,
   }) async {
-    return guard(() {
+    return convertWebExceptions(() {
       return _delegate.logEvent(
         name: name,
         parameters: parameters ?? {},
@@ -63,7 +63,7 @@ class FirebaseAnalyticsWeb extends FirebaseAnalyticsPlatform {
 
   @override
   Future<void> setAnalyticsCollectionEnabled(bool enabled) async {
-    return guard(() {
+    return convertWebExceptions(() {
       return _delegate.setAnalyticsCollectionEnabled(enabled: enabled);
     });
   }
@@ -73,7 +73,7 @@ class FirebaseAnalyticsWeb extends FirebaseAnalyticsPlatform {
     String? id,
     AnalyticsCallOptions? callOptions,
   }) async {
-    return guard(() {
+    return convertWebExceptions(() {
       return _delegate.setUserId(
         id: id,
         callOptions: callOptions,
@@ -87,7 +87,7 @@ class FirebaseAnalyticsWeb extends FirebaseAnalyticsPlatform {
     String? screenClassOverride,
     AnalyticsCallOptions? callOptions,
   }) async {
-    return guard(() {
+    return convertWebExceptions(() {
       return _delegate.setCurrentScreen(
         screenName: screenName,
         callOptions: callOptions,
@@ -106,7 +106,7 @@ class FirebaseAnalyticsWeb extends FirebaseAnalyticsPlatform {
     required String? value,
     AnalyticsCallOptions? callOptions,
   }) async {
-    return guard(() {
+    return convertWebExceptions(() {
       return _delegate.setUserProperty(
         name: name,
         value: value,

--- a/packages/firebase_analytics/firebase_analytics_web/lib/utils/exception.dart
+++ b/packages/firebase_analytics/firebase_analytics_web/lib/utils/exception.dart
@@ -1,4 +1,4 @@
-export 'package:firebase_core/src/internals.dart' hide guard;
+export 'package:firebase_core/src/internals.dart' hide guardWebExceptions;
 
 import 'package:firebase_core/firebase_core.dart';
 // ignore: implementation_imports
@@ -7,7 +7,7 @@ import 'package:firebase_core/src/internals.dart' as internals;
 /// Will return a [FirebaseException] from a thrown web error.
 /// Any other errors will be propagated as normal.
 R convertWebExceptions<R>(R Function() cb) {
-  return internals.guard(
+  return internals.guardWebExceptions(
     cb,
     plugin: 'firebase_analytics',
     codeParser: (code) => code.replaceFirst('analytics/', ''),

--- a/packages/firebase_analytics/firebase_analytics_web/lib/utils/exception.dart
+++ b/packages/firebase_analytics/firebase_analytics_web/lib/utils/exception.dart
@@ -6,7 +6,7 @@ import 'package:firebase_core/src/internals.dart' as internals;
 
 /// Will return a [FirebaseException] from a thrown web error.
 /// Any other errors will be propagated as normal.
-R guard<R>(R Function() cb) {
+R convertWebExceptions<R>(R Function() cb) {
   return internals.guard(
     cb,
     plugin: 'firebase_analytics',

--- a/packages/firebase_app_check/firebase_app_check_web/lib/firebase_app_check_web.dart
+++ b/packages/firebase_app_check/firebase_app_check_web/lib/firebase_app_check_web.dart
@@ -64,13 +64,13 @@ class FirebaseAppCheckWeb extends FirebaseAppCheckPlatform {
 
   @override
   Future<void> activate({String? webRecaptchaSiteKey}) async {
-    return guard<Future<void>>(
+    return convertWebExceptions<Future<void>>(
         () async => _delegate.activate(webRecaptchaSiteKey));
   }
 
   @override
   Future<String?> getToken(bool forceRefresh) async {
-    return guard<Future<String?>>(() async {
+    return convertWebExceptions<Future<String?>>(() async {
       app_check_interop.AppCheckTokenResult result =
           await _delegate.getToken(forceRefresh);
       return result.token;
@@ -81,7 +81,7 @@ class FirebaseAppCheckWeb extends FirebaseAppCheckPlatform {
   Future<void> setTokenAutoRefreshEnabled(
     bool isTokenAutoRefreshEnabled,
   ) async {
-    return guard<Future<void>>(
+    return convertWebExceptions<Future<void>>(
       () async =>
           _delegate.setTokenAutoRefreshEnabled(isTokenAutoRefreshEnabled),
     );

--- a/packages/firebase_app_check/firebase_app_check_web/lib/src/internals.dart
+++ b/packages/firebase_app_check/firebase_app_check_web/lib/src/internals.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-export 'package:firebase_core/src/internals.dart' hide guard;
+export 'package:firebase_core/src/internals.dart' hide guardWebExceptions;
 
 import 'package:firebase_core/firebase_core.dart';
 // ignore: implementation_imports
@@ -11,7 +11,7 @@ import 'package:firebase_core/src/internals.dart' as internals;
 /// Will return a [FirebaseException] from a thrown web error.
 /// Any other errors will be propagated as normal.
 R convertWebExceptions<R>(R Function() cb) {
-  return internals.guard(
+  return internals.guardWebExceptions(
     cb,
     plugin: 'app-check',
     codeParser: (code) => code.replaceFirst('appCheck/', ''),

--- a/packages/firebase_app_check/firebase_app_check_web/lib/src/internals.dart
+++ b/packages/firebase_app_check/firebase_app_check_web/lib/src/internals.dart
@@ -10,7 +10,7 @@ import 'package:firebase_core/src/internals.dart' as internals;
 
 /// Will return a [FirebaseException] from a thrown web error.
 /// Any other errors will be propagated as normal.
-R guard<R>(R Function() cb) {
+R convertWebExceptions<R>(R Function() cb) {
   return internals.guard(
     cb,
     plugin: 'app-check',

--- a/packages/firebase_app_installations/firebase_app_installations_web/lib/firebase_app_installations_web.dart
+++ b/packages/firebase_app_installations/firebase_app_installations_web/lib/firebase_app_installations_web.dart
@@ -52,21 +52,21 @@ class FirebaseAppInstallationsWeb extends FirebaseAppInstallationsPlatform {
 
   @override
   Future<void> delete() async {
-    return guard(() => _delegate.delete());
+    return convertWebExceptions(() => _delegate.delete());
   }
 
   @override
   Future<String> getId() async {
-    return guard(() => _delegate.getId());
+    return convertWebExceptions(() => _delegate.getId());
   }
 
   @override
   Future<String> getToken(bool forceRefresh) async {
-    return guard(() => _delegate.getToken(forceRefresh));
+    return convertWebExceptions(() => _delegate.getToken(forceRefresh));
   }
 
   @override
   Stream<String> get onIdChange {
-    return guard(() => _delegate.onIdChange);
+    return convertWebExceptions(() => _delegate.onIdChange);
   }
 }

--- a/packages/firebase_app_installations/firebase_app_installations_web/lib/src/guard.dart
+++ b/packages/firebase_app_installations/firebase_app_installations_web/lib/src/guard.dart
@@ -7,12 +7,12 @@ import 'package:firebase_core/firebase_core.dart';
 // ignore: implementation_imports
 import 'package:firebase_core/src/internals.dart' as internals;
 
-export 'package:firebase_core/src/internals.dart' hide guard;
+export 'package:firebase_core/src/internals.dart' hide guardWebExceptions;
 
 /// Will return a [FirebaseException] from a thrown web error.
 /// Any other errors will be propagated as normal.
 R convertWebExceptions<R>(R Function() cb) {
-  return internals.guard(
+  return internals.guardWebExceptions(
     cb,
     plugin: 'firebase_app_installations',
     codeParser: (code) => code.replaceFirst('installations/', ''),

--- a/packages/firebase_app_installations/firebase_app_installations_web/lib/src/guard.dart
+++ b/packages/firebase_app_installations/firebase_app_installations_web/lib/src/guard.dart
@@ -11,7 +11,7 @@ export 'package:firebase_core/src/internals.dart' hide guard;
 
 /// Will return a [FirebaseException] from a thrown web error.
 /// Any other errors will be propagated as normal.
-R guard<R>(R Function() cb) {
+R convertWebExceptions<R>(R Function() cb) {
   return internals.guard(
     cb,
     plugin: 'firebase_app_installations',

--- a/packages/firebase_core/firebase_core/lib/src/internals.dart
+++ b/packages/firebase_core/firebase_core/lib/src/internals.dart
@@ -77,7 +77,7 @@ Object _mapException(
 
 /// Will return a [FirebaseException] from a thrown web error.
 /// Any other errors will be propagated as normal.
-R guard<R>(
+R guardWebExceptions<R>(
   R Function() cb, {
   required String plugin,
   required String Function(String) codeParser,

--- a/packages/firebase_messaging/firebase_messaging_web/lib/firebase_messaging_web.dart
+++ b/packages/firebase_messaging/firebase_messaging_web/lib/firebase_messaging_web.dart
@@ -96,7 +96,7 @@ class FirebaseMessagingWeb extends FirebaseMessagingPlatform {
       return;
     }
 
-    return guard(_delegate.deleteToken);
+    return convertWebExceptions(_delegate.deleteToken);
   }
 
   @override
@@ -113,7 +113,7 @@ class FirebaseMessagingWeb extends FirebaseMessagingPlatform {
       return null;
     }
 
-    return guard(
+    return convertWebExceptions(
       () => _delegate.getToken(vapidKey: vapidKey),
     );
   }
@@ -142,7 +142,7 @@ class FirebaseMessagingWeb extends FirebaseMessagingPlatform {
     bool provisional = false,
     bool sound = true,
   }) {
-    return guard(() async {
+    return convertWebExceptions(() async {
       String status = await WindowNotification.requestPermission();
       return utils.getNotificationSettings(status);
     });

--- a/packages/firebase_messaging/firebase_messaging_web/lib/src/internals.dart
+++ b/packages/firebase_messaging/firebase_messaging_web/lib/src/internals.dart
@@ -7,7 +7,7 @@ import 'package:firebase_core/src/internals.dart' as internals;
 
 /// Will return a [FirebaseException] from a thrown web error.
 /// Any other errors will be propagated as normal.
-R guard<R>(R Function() cb) {
+R convertWebExceptions<R>(R Function() cb) {
   return internals.guard(
     cb,
     plugin: 'firebase_messaging',

--- a/packages/firebase_messaging/firebase_messaging_web/lib/src/internals.dart
+++ b/packages/firebase_messaging/firebase_messaging_web/lib/src/internals.dart
@@ -1,5 +1,5 @@
 // ignore_for_file: require_trailing_commas
-export 'package:firebase_core/src/internals.dart' hide guard;
+export 'package:firebase_core/src/internals.dart' hide guardWebExceptions;
 
 import 'package:firebase_core/firebase_core.dart';
 // ignore: implementation_imports
@@ -8,7 +8,7 @@ import 'package:firebase_core/src/internals.dart' as internals;
 /// Will return a [FirebaseException] from a thrown web error.
 /// Any other errors will be propagated as normal.
 R convertWebExceptions<R>(R Function() cb) {
-  return internals.guard(
+  return internals.guardWebExceptions(
     cb,
     plugin: 'firebase_messaging',
     codeParser: (code) => code.replaceFirst('messaging/', ''),

--- a/packages/firebase_performance/firebase_performance_web/lib/src/internals.dart
+++ b/packages/firebase_performance/firebase_performance_web/lib/src/internals.dart
@@ -10,7 +10,7 @@ import 'package:firebase_core/src/internals.dart' as internals;
 
 /// Will return a [FirebaseException] from a thrown web error.
 /// Any other errors will be propagated as normal.
-Future<R> guard<R>(R Function() cb) async {
+Future<R> convertWebExceptions<R>(R Function() cb) async {
   return internals.guard(
     cb,
     plugin: 'firebase_performance',

--- a/packages/firebase_performance/firebase_performance_web/lib/src/internals.dart
+++ b/packages/firebase_performance/firebase_performance_web/lib/src/internals.dart
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-export 'package:firebase_core/src/internals.dart' hide guard;
+export 'package:firebase_core/src/internals.dart' hide guardWebExceptions;
 
 import 'package:firebase_core/firebase_core.dart';
 // ignore: implementation_imports
@@ -11,7 +11,7 @@ import 'package:firebase_core/src/internals.dart' as internals;
 /// Will return a [FirebaseException] from a thrown web error.
 /// Any other errors will be propagated as normal.
 Future<R> convertWebExceptions<R>(R Function() cb) async {
-  return internals.guard(
+  return internals.guardWebExceptions(
     cb,
     plugin: 'firebase_performance',
     codeParser: (code) => code.replaceFirst('performance/', ''),

--- a/packages/firebase_performance/firebase_performance_web/lib/src/trace.dart
+++ b/packages/firebase_performance/firebase_performance_web/lib/src/trace.dart
@@ -14,12 +14,12 @@ class TraceWeb extends TracePlatform {
 
   @override
   Future<void> start() async {
-    await guard(traceDelegate.start);
+    await convertWebExceptions(traceDelegate.start);
   }
 
   @override
   Future<void> stop() async {
-    await guard(traceDelegate.stop);
+    await convertWebExceptions(traceDelegate.stop);
   }
 
   @override

--- a/packages/firebase_storage/firebase_storage_web/lib/src/utils/errors.dart
+++ b/packages/firebase_storage/firebase_storage_web/lib/src/utils/errors.dart
@@ -17,7 +17,7 @@ Map<String, String?> _errorCodeToMessage = {
 /// Will return a [FirebaseException] from a thrown web error.
 /// Any other errors will be propagated as normal.
 R guard<R>(R Function() cb) {
-  return internals.guard(
+  return internals.guardWebExceptions(
     cb,
     plugin: 'firebase_storage',
     codeParser: (code) => code.split('/').last,


### PR DESCRIPTION
## Description

Just an internal function rename, nothing to see here 

## Related Issues


## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [ ] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
