### PR TITLE
fix(flutterfire_ui): Upgrade `desktop_webview_auth` package causing a problem on macOS.

### DIFF
--- a/packages/flutterfire_ui/lib/src/auth/oauth/providers/facebook_provider.dart
+++ b/packages/flutterfire_ui/lib/src/auth/oauth/providers/facebook_provider.dart
@@ -49,7 +49,7 @@ class FacebookProviderImpl extends OAuthProvider {
 
   @override
   OAuthCredential fromDesktopAuthResult(AuthResult result) {
-    return FacebookAuthProvider.credential(result.accessToken);
+    return FacebookAuthProvider.credential(result.accessToken!);
   }
 
   @override

--- a/packages/flutterfire_ui/lib/src/auth/oauth/providers/google_provider.dart
+++ b/packages/flutterfire_ui/lib/src/auth/oauth/providers/google_provider.dart
@@ -59,7 +59,10 @@ class GoogleProviderImpl extends OAuthProvider {
 
   @override
   OAuthCredential fromDesktopAuthResult(AuthResult result) {
-    return GoogleAuthProvider.credential(accessToken: result.accessToken);
+    return GoogleAuthProvider.credential(
+      idToken: result.idToken,
+      accessToken: result.accessToken,
+    );
   }
 }
 

--- a/packages/flutterfire_ui/lib/src/auth/oauth/providers/twitter_provider.dart
+++ b/packages/flutterfire_ui/lib/src/auth/oauth/providers/twitter_provider.dart
@@ -58,7 +58,7 @@ class TwitterProviderImpl extends OAuthProvider {
   @override
   OAuthCredential fromDesktopAuthResult(AuthResult result) {
     return TwitterAuthProvider.credential(
-      accessToken: result.accessToken,
+      accessToken: result.accessToken!,
       secret: result.tokenSecret!,
     );
   }

--- a/packages/flutterfire_ui/pubspec.yaml
+++ b/packages/flutterfire_ui/pubspec.yaml
@@ -5,7 +5,7 @@ repository: https://github.com/FirebaseExtended/flutterfire/tree/master/packages
 homepage: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/flutterfire_ui
 
 false_secrets:
- - example/**
+  - example/**
 
 environment:
   sdk: '>=2.12.0 <3.0.0'
@@ -15,7 +15,7 @@ dependencies:
   cloud_firestore: ^3.1.8
   collection: ^1.15.0
   crypto: ^3.0.1
-  desktop_webview_auth: ^0.0.2
+  desktop_webview_auth: ^0.0.4
   email_validator: ^2.0.1
   firebase_auth: ^3.3.7
   firebase_core: ^1.10.2
@@ -46,7 +46,6 @@ flutter:
   assets:
     - assets/icons/
     - assets/countries.json
-
 # To add assets to your package, add an assets section, like this:
 # assets:
 #   - images/a_dot_burr.jpeg


### PR DESCRIPTION
## Description

Upgrade `desktop_webview_auth` to 0.0.4.

## Related Issues

Fixes an issue with Google sign in with emulator in macOS.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
