### PR TITLE
docs(analytics): code comment typo - `logAdImpression` mentions wrong event

### DIFF
--- a/packages/firebase_analytics/firebase_analytics/lib/src/firebase_analytics.dart
+++ b/packages/firebase_analytics/firebase_analytics/lib/src/firebase_analytics.dart
@@ -379,14 +379,13 @@ class FirebaseAnalytics extends FirebasePluginPlatform {
     );
   }
 
-  /// Logs the standard `add_to_wishlist` event.
+  /// Logs the standard `ad_impression` event.
   ///
-  /// This event signifies that an item was added to a wishlist. Use this event
-  /// to identify popular gift items in your app. Note: If you supply the
-  /// [value] parameter, you must also supply the [currency] parameter so that
+  /// This event signifies when a user sees an ad impression. Note: If you supply
+  /// the [value] parameter, you must also supply the [currency] parameter so that
   /// revenue metrics can be computed accurately.
   ///
-  /// See: https://firebase.google.com/docs/reference/android/com/google/firebase/analytics/FirebaseAnalytics.Event.html#ADD_TO_WISHLIST
+  /// See: https://firebase.google.com/docs/reference/android/com/google/firebase/analytics/FirebaseAnalytics.Event.html#AD_IMPRESSION
   Future<void> logAdImpression({
     String? adPlatform,
     String? adSource,


### PR DESCRIPTION
## Description

The logAdImpression doc comments refers to `add_to_wishlist` instead of `ad_impression`
https://firebase.google.com/docs/reference/android/com/google/firebase/analytics/FirebaseAnalytics.Event.html#AD_IMPRESSION

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
