### PR TITLE
docs: Indicate missing Messaging Support for Dart-only initialization on iOS

### DIFF
--- a/docs/cli.mdx
+++ b/docs/cli.mdx
@@ -37,6 +37,7 @@ The following table shows the current plugins with Dart-only Firebase initializa
 |              Analytics |                                ✔                                |                              **?**                              |  ✔  |                                ✔                                |
 |            Crashlytics | [**?**](./crashlytics/overview#2-optional-platform-integration) | [**?**](./crashlytics/overview#2-optional-platform-integration) | N/A | [**?**](./crashlytics/overview#2-optional-platform-integration) |
 | Performance Monitoring |                                ✔                                |                               ❌                                |  ✔  |                               N/A                               |
+|              Messaging |                               ❌                                |                               ✔                                 | N/A |                              **?**                              |
 
 - **?** Indicates your app will build and run but plugin behavior may be different.
 - ❌ Indicates your app will crash on startup without manual Google services PLIST/JSON file setup.


### PR DESCRIPTION
## Description

You cannot use Firebase Messaging and Dart-only initialization on iOS. When adding the push notifications (APNs) entitlement, the app will crash on startup. See #7983.

This PR fixes the usage docs to rectify that.

cc @russellwheatley 

## Related Issues

* Related to #7983

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
