### PR TITLE
chore: tighting dependency on firebase_core

### DIFF
--- a/packages/cloud_firestore/cloud_firestore/pubspec.yaml
+++ b/packages/cloud_firestore/cloud_firestore/pubspec.yaml
@@ -18,7 +18,7 @@ dependencies:
   cloud_firestore_platform_interface: ^5.5.1
   cloud_firestore_web: ^2.6.10
   collection: ^1.0.0
-  firebase_core: ^1.10.2
+  firebase_core: 1.13.1
   firebase_core_platform_interface: ^4.2.5
   flutter:
     sdk: flutter

--- a/packages/cloud_firestore/cloud_firestore_platform_interface/pubspec.yaml
+++ b/packages/cloud_firestore/cloud_firestore_platform_interface/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 
 dependencies:
   collection: ^1.15.0
-  firebase_core: ^1.10.0
+  firebase_core: 1.13.1
   flutter:
     sdk: flutter
   meta: ^1.3.0

--- a/packages/cloud_firestore/cloud_firestore_web/pubspec.yaml
+++ b/packages/cloud_firestore/cloud_firestore_web/pubspec.yaml
@@ -12,7 +12,7 @@ environment:
 dependencies:
   cloud_firestore_platform_interface: ^5.5.1
   collection: ^1.0.0
-  firebase_core: ^1.10.0
+  firebase_core: 1.13.1
   firebase_core_web: ^1.6.1
   flutter:
     sdk: flutter

--- a/packages/cloud_functions/cloud_functions/pubspec.yaml
+++ b/packages/cloud_functions/cloud_functions/pubspec.yaml
@@ -14,7 +14,7 @@ environment:
 dependencies:
   cloud_functions_platform_interface: ^5.1.1
   cloud_functions_web: ^4.2.9
-  firebase_core: ^1.10.0
+  firebase_core: 1.13.1
   firebase_core_platform_interface: ^4.2.5
   flutter:
     sdk: flutter

--- a/packages/cloud_functions/cloud_functions_platform_interface/pubspec.yaml
+++ b/packages/cloud_functions/cloud_functions_platform_interface/pubspec.yaml
@@ -12,7 +12,7 @@ environment:
   flutter: ">=1.9.1+hotfix.5"
 
 dependencies:
-  firebase_core: ^1.10.0
+  firebase_core: 1.13.1
   flutter:
     sdk: flutter
   meta: ^1.3.0

--- a/packages/cloud_functions/cloud_functions_web/pubspec.yaml
+++ b/packages/cloud_functions/cloud_functions_web/pubspec.yaml
@@ -11,7 +11,7 @@ environment:
 
 dependencies:
   cloud_functions_platform_interface: ^5.1.1
-  firebase_core: ^1.10.0
+  firebase_core: 1.13.1
   firebase_core_web: ^1.6.1
   flutter:
     sdk: flutter

--- a/packages/firebase_analytics/firebase_analytics/pubspec.yaml
+++ b/packages/firebase_analytics/firebase_analytics/pubspec.yaml
@@ -16,7 +16,7 @@ environment:
 dependencies:
   firebase_analytics_platform_interface: ^3.1.1
   firebase_analytics_web: ^0.4.0+8
-  firebase_core: ^1.10.0
+  firebase_core: 1.13.1
   firebase_core_platform_interface: ^4.2.5
   flutter:
     sdk: flutter

--- a/packages/firebase_analytics/firebase_analytics_platform_interface/pubspec.yaml
+++ b/packages/firebase_analytics/firebase_analytics_platform_interface/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
   flutter: '>=1.9.1+hotfix.5'
 
 dependencies:
-  firebase_core: ^1.10.0
+  firebase_core: 1.13.1
   flutter:
     sdk: flutter
   meta: ^1.3.0

--- a/packages/firebase_analytics/firebase_analytics_web/pubspec.yaml
+++ b/packages/firebase_analytics/firebase_analytics_web/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 
 dependencies:
   firebase_analytics_platform_interface: ^3.1.1
-  firebase_core: ^1.10.0
+  firebase_core: 1.13.1
   firebase_core_web: ^1.6.1
   flutter:
     sdk: flutter

--- a/packages/firebase_app_check/firebase_app_check/pubspec.yaml
+++ b/packages/firebase_app_check/firebase_app_check/pubspec.yaml
@@ -14,7 +14,7 @@ environment:
 dependencies:
   firebase_app_check_platform_interface: ^0.0.4+1
   firebase_app_check_web: ^0.0.5+7
-  firebase_core: ^1.10.0
+  firebase_core: 1.13.1
   firebase_core_platform_interface: ^4.2.5
   flutter:
     sdk: flutter

--- a/packages/firebase_app_check/firebase_app_check_platform_interface/pubspec.yaml
+++ b/packages/firebase_app_check/firebase_app_check_platform_interface/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
   flutter: ">=1.20.0"
 
 dependencies:
-  firebase_core: ^1.10.0
+  firebase_core: 1.13.1
   flutter:
     sdk: flutter
   meta: ^1.3.0

--- a/packages/firebase_app_check/firebase_app_check_web/pubspec.yaml
+++ b/packages/firebase_app_check/firebase_app_check_web/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
 
 dependencies:
   firebase_app_check_platform_interface: ^0.0.4+1
-  firebase_core: ^1.10.0
+  firebase_core: 1.13.1
   firebase_core_web: ^1.6.1
   flutter:
     sdk: flutter

--- a/packages/firebase_app_installations/firebase_app_installations/example/pubspec.yaml
+++ b/packages/firebase_app_installations/firebase_app_installations/example/pubspec.yaml
@@ -27,7 +27,7 @@ environment:
 # the latest version available on pub.dev. To see which dependencies have newer
 # versions available, run `flutter pub outdated`.
 dependencies:
-  firebase_core: ^1.10.0
+  firebase_core: 1.13.1
   firebase_app_installations:
     path: ../
   flutter:

--- a/packages/firebase_app_installations/firebase_app_installations/pubspec.yaml
+++ b/packages/firebase_app_installations/firebase_app_installations/pubspec.yaml
@@ -15,7 +15,7 @@ environment:
 dependencies:
   firebase_app_installations_platform_interface: ^0.1.1+1
   firebase_app_installations_web: ^0.1.0+8
-  firebase_core: ^1.10.0
+  firebase_core: 1.13.1
   firebase_core_platform_interface: ^4.2.5
   flutter:
     sdk: flutter

--- a/packages/firebase_app_installations/firebase_app_installations_platform_interface/pubspec.yaml
+++ b/packages/firebase_app_installations/firebase_app_installations_platform_interface/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
   flutter: ">=1.17.0"
 
 dependencies:
-  firebase_core: ^1.10.0
+  firebase_core: 1.13.1
   flutter:
     sdk: flutter
   meta: ^1.3.0

--- a/packages/firebase_app_installations/firebase_app_installations_web/pubspec.yaml
+++ b/packages/firebase_app_installations/firebase_app_installations_web/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 
 dependencies:
   firebase_app_installations_platform_interface: ^0.1.1+1
-  firebase_core: ^1.10.0
+  firebase_core: 1.13.1
   firebase_core_web: ^1.6.1
   flutter:
     sdk: flutter

--- a/packages/firebase_auth/firebase_auth/pubspec.yaml
+++ b/packages/firebase_auth/firebase_auth/pubspec.yaml
@@ -16,7 +16,7 @@ environment:
 dependencies:
   firebase_auth_platform_interface: ^6.2.1
   firebase_auth_web: ^3.3.9
-  firebase_core: ^1.10.0
+  firebase_core: 1.13.1
   firebase_core_platform_interface: ^4.2.5
   flutter:
     sdk: flutter

--- a/packages/firebase_auth/firebase_auth_platform_interface/pubspec.yaml
+++ b/packages/firebase_auth/firebase_auth_platform_interface/pubspec.yaml
@@ -11,7 +11,7 @@ environment:
   flutter: ">=1.9.1+hotfix.5"
 
 dependencies:
-  firebase_core: ^1.10.0
+  firebase_core: 1.13.1
   flutter:
     sdk: flutter
   meta: ^1.3.0

--- a/packages/firebase_auth/firebase_auth_web/pubspec.yaml
+++ b/packages/firebase_auth/firebase_auth_web/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 
 dependencies:
   firebase_auth_platform_interface: ^6.2.1
-  firebase_core: ^1.10.0
+  firebase_core: 1.13.1
   firebase_core_web: ^1.6.1
   flutter:
     sdk: flutter

--- a/packages/firebase_core/firebase_core_web/pubspec.yaml
+++ b/packages/firebase_core/firebase_core_web/pubspec.yaml
@@ -18,7 +18,7 @@ dependencies:
   meta: ^1.3.0
 
 dev_dependencies:
-  firebase_core: ^1.10.0
+  firebase_core: 1.13.1
   flutter_test:
     sdk: flutter
 

--- a/packages/firebase_crashlytics/firebase_crashlytics/pubspec.yaml
+++ b/packages/firebase_crashlytics/firebase_crashlytics/pubspec.yaml
@@ -14,7 +14,7 @@ environment:
   flutter: ">=1.12.13+hotfix.5"
 
 dependencies:
-  firebase_core: ^1.10.0
+  firebase_core: 1.13.1
   firebase_core_platform_interface: ^4.2.5
   firebase_crashlytics_platform_interface: ^3.2.1
   flutter:

--- a/packages/firebase_crashlytics/firebase_crashlytics_platform_interface/pubspec.yaml
+++ b/packages/firebase_crashlytics/firebase_crashlytics_platform_interface/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 
 dependencies:
   collection: ^1.15.0
-  firebase_core: ^1.10.0
+  firebase_core: 1.13.1
   flutter:
     sdk: flutter
   meta: ^1.3.0

--- a/packages/firebase_database/firebase_database/pubspec.yaml
+++ b/packages/firebase_database/firebase_database/pubspec.yaml
@@ -13,7 +13,7 @@ environment:
   flutter: ">=1.12.13+hotfix.5"
 
 dependencies:
-  firebase_core: ^1.10.0
+  firebase_core: 1.13.1
   firebase_core_platform_interface: ^4.2.5
   firebase_database_platform_interface: ^0.2.1+1
   firebase_database_web: ^0.2.0+7

--- a/packages/firebase_database/firebase_database_platform_interface/pubspec.yaml
+++ b/packages/firebase_database/firebase_database_platform_interface/pubspec.yaml
@@ -5,7 +5,7 @@ homepage: https://github.com/FirebaseExtended/flutterfire/tree/master/packages/f
 
 dependencies:
   collection: ^1.14.3
-  firebase_core: ^1.10.0
+  firebase_core: 1.13.1
   flutter:
     sdk: flutter
   meta: ^1.3.0

--- a/packages/firebase_database/firebase_database_web/pubspec.yaml
+++ b/packages/firebase_database/firebase_database_web/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
   flutter: ">=1.20.0"
 
 dependencies:
-  firebase_core: ^1.10.0
+  firebase_core: 1.13.1
   firebase_core_web: ^1.6.1
   firebase_database_platform_interface: ^0.2.1+1
   flutter:

--- a/packages/firebase_dynamic_links/firebase_dynamic_links/pubspec.yaml
+++ b/packages/firebase_dynamic_links/firebase_dynamic_links/pubspec.yaml
@@ -14,7 +14,7 @@ environment:
   flutter: ">=1.12.13+hotfix.5"
 
 dependencies:
-  firebase_core: ^1.10.0
+  firebase_core: 1.13.1
   firebase_core_platform_interface: ^4.2.5
   firebase_dynamic_links_platform_interface: ^0.2.1+1
   flutter:

--- a/packages/firebase_dynamic_links/firebase_dynamic_links_platform_interface/pubspec.yaml
+++ b/packages/firebase_dynamic_links/firebase_dynamic_links_platform_interface/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
   flutter: ">=1.9.1+hotfix.5"
 
 dependencies:
-  firebase_core: ^1.10.3
+  firebase_core: 1.13.1
   flutter:
     sdk: flutter
   meta: ^1.3.0

--- a/packages/firebase_in_app_messaging/firebase_in_app_messaging/pubspec.yaml
+++ b/packages/firebase_in_app_messaging/firebase_in_app_messaging/pubspec.yaml
@@ -12,7 +12,7 @@ environment:
   flutter: ">=1.12.13+hotfix.5"
 
 dependencies:
-  firebase_core: ^1.10.0
+  firebase_core: 1.13.1
   firebase_core_platform_interface: ^4.2.5
   firebase_in_app_messaging_platform_interface: ^0.2.1+1
   flutter:

--- a/packages/firebase_in_app_messaging/firebase_in_app_messaging_platform_interface/pubspec.yaml
+++ b/packages/firebase_in_app_messaging/firebase_in_app_messaging_platform_interface/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
   flutter: ">=1.9.1+hotfix.5"
 
 dependencies:
-  firebase_core: ^1.10.0
+  firebase_core: 1.13.1
   flutter:
     sdk: flutter
   meta: ^1.3.0

--- a/packages/firebase_messaging/firebase_messaging/pubspec.yaml
+++ b/packages/firebase_messaging/firebase_messaging/pubspec.yaml
@@ -13,7 +13,7 @@ environment:
   flutter: ">=1.12.13+hotfix.5"
 
 dependencies:
-  firebase_core: ^1.10.0
+  firebase_core: 1.13.1
   firebase_core_platform_interface: ^4.2.5
   firebase_messaging_platform_interface: ^3.2.1
   firebase_messaging_web: ^2.2.9

--- a/packages/firebase_messaging/firebase_messaging_platform_interface/pubspec.yaml
+++ b/packages/firebase_messaging/firebase_messaging_platform_interface/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
   flutter: ">=1.9.1+hotfix.5"
 
 dependencies:
-  firebase_core: ^1.10.0
+  firebase_core: 1.13.1
   flutter:
     sdk: flutter
   meta: ^1.3.0

--- a/packages/firebase_messaging/firebase_messaging_web/pubspec.yaml
+++ b/packages/firebase_messaging/firebase_messaging_web/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
   flutter: ">=1.12.13+hotfix.4"
 
 dependencies:
-  firebase_core: ^1.10.0
+  firebase_core: 1.13.1
   firebase_core_web: ^1.6.1
   firebase_messaging_platform_interface: ^3.2.1
   flutter:

--- a/packages/firebase_ml_model_downloader/firebase_ml_model_downloader/pubspec.yaml
+++ b/packages/firebase_ml_model_downloader/firebase_ml_model_downloader/pubspec.yaml
@@ -12,7 +12,7 @@ environment:
   flutter: '>=1.20.0'
 
 dependencies:
-  firebase_core: ^1.10.0
+  firebase_core: 1.13.1
   firebase_core_platform_interface: ^4.2.5
   firebase_ml_model_downloader_platform_interface: ^0.1.1+1
   flutter:

--- a/packages/firebase_ml_model_downloader/firebase_ml_model_downloader_platform_interface/pubspec.yaml
+++ b/packages/firebase_ml_model_downloader/firebase_ml_model_downloader_platform_interface/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
   flutter: ">=1.17.0"
 
 dependencies:
-  firebase_core: ^1.10.0
+  firebase_core: 1.13.1
   flutter:
     sdk: flutter
   meta: ^1.3.0

--- a/packages/firebase_performance/firebase_performance/pubspec.yaml
+++ b/packages/firebase_performance/firebase_performance/pubspec.yaml
@@ -15,7 +15,7 @@ environment:
   flutter: ">=1.12.13+hotfix.5"
 
 dependencies:
-  firebase_core: ^1.10.0
+  firebase_core: 1.13.1
   firebase_core_platform_interface: ^4.2.5
   firebase_performance_platform_interface: ^0.1.1+1
   firebase_performance_web: ^0.1.0+7

--- a/packages/firebase_performance/firebase_performance_platform_interface/pubspec.yaml
+++ b/packages/firebase_performance/firebase_performance_platform_interface/pubspec.yaml
@@ -8,7 +8,7 @@ environment:
   flutter: ">=1.17.0"
 
 dependencies:
-  firebase_core: ^1.10.0
+  firebase_core: 1.13.1
   flutter:
     sdk: flutter
   plugin_platform_interface: ^2.0.1

--- a/packages/firebase_performance/firebase_performance_web/pubspec.yaml
+++ b/packages/firebase_performance/firebase_performance_web/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
 
 dependencies:
   firebase: ^9.0.1
-  firebase_core: ^1.10.0
+  firebase_core: 1.13.1
   firebase_core_web: ^1.6.1
   firebase_performance_platform_interface: ^0.1.1+1
   flutter:

--- a/packages/firebase_remote_config/firebase_remote_config/pubspec.yaml
+++ b/packages/firebase_remote_config/firebase_remote_config/pubspec.yaml
@@ -14,7 +14,7 @@ environment:
   flutter: ">=1.12.13+hotfix.5"
 
 dependencies:
-  firebase_core: ^1.10.0
+  firebase_core: 1.13.1
   firebase_core_platform_interface: ^4.2.5
   firebase_remote_config_platform_interface: ^1.1.1
   firebase_remote_config_web: ^1.0.7

--- a/packages/firebase_remote_config/firebase_remote_config_platform_interface/pubspec.yaml
+++ b/packages/firebase_remote_config/firebase_remote_config_platform_interface/pubspec.yaml
@@ -11,7 +11,7 @@ environment:
   flutter: ">=1.9.1+hotfix.5"
 
 dependencies:
-  firebase_core: ^1.10.0
+  firebase_core: 1.13.1
   flutter:
     sdk: flutter
   meta: ^1.3.0

--- a/packages/firebase_remote_config/firebase_remote_config_web/pubspec.yaml
+++ b/packages/firebase_remote_config/firebase_remote_config_web/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
   flutter: ">=1.20.0"
 
 dependencies:
-  firebase_core: ^1.10.0
+  firebase_core: 1.13.1
   firebase_core_web: ^1.6.1
   firebase_remote_config_platform_interface: ^1.1.1
   flutter:

--- a/packages/firebase_storage/firebase_storage/pubspec.yaml
+++ b/packages/firebase_storage/firebase_storage/pubspec.yaml
@@ -13,7 +13,7 @@ environment:
   flutter: ">=1.12.13+hotfix.5"
 
 dependencies:
-  firebase_core: ^1.10.0
+  firebase_core: 1.13.1
   firebase_core_platform_interface: ^4.2.5
   firebase_storage_platform_interface: ^4.1.1
   firebase_storage_web: ^3.2.10

--- a/packages/firebase_storage/firebase_storage_platform_interface/pubspec.yaml
+++ b/packages/firebase_storage/firebase_storage_platform_interface/pubspec.yaml
@@ -9,7 +9,7 @@ environment:
 
 dependencies:
   collection: ^1.15.0
-  firebase_core: ^1.10.0
+  firebase_core: 1.13.1
   flutter:
     sdk: flutter
   meta: ^1.3.0

--- a/packages/firebase_storage/firebase_storage_web/pubspec.yaml
+++ b/packages/firebase_storage/firebase_storage_web/pubspec.yaml
@@ -10,7 +10,7 @@ environment:
 
 dependencies:
   async: ^2.5.0
-  firebase_core: ^1.10.0
+  firebase_core: 1.13.1
   firebase_core_web: ^1.6.1
   firebase_storage_platform_interface: ^4.1.1
   flutter:

--- a/packages/flutterfire_ui/example/pubspec.yaml
+++ b/packages/flutterfire_ui/example/pubspec.yaml
@@ -25,7 +25,7 @@ dependencies:
   crypto: ^3.0.1
   cupertino_icons: ^1.0.2
   firebase_auth: ^3.3.9
-  firebase_core: ^1.10.3
+  firebase_core: 1.13.1
   firebase_database: ^9.0.8
   firebase_dynamic_links: ^4.0.8
   flutter:

--- a/packages/flutterfire_ui/pubspec.yaml
+++ b/packages/flutterfire_ui/pubspec.yaml
@@ -18,7 +18,7 @@ dependencies:
   desktop_webview_auth: ^0.0.5
   email_validator: ^2.0.1
   firebase_auth: ^3.3.9
-  firebase_core: ^1.10.2
+  firebase_core: 1.13.1
   firebase_database: ^9.0.8
   firebase_dynamic_links: ^4.0.8
   flutter:


### PR DESCRIPTION
## Description

The existence of firebase_core/src/internals.dart and the fact that other firebase packages import it when breaking changes on that files don't involve a major release means that doing `firebase_core: ^x.y.z` is unsafe

This PR is switching to tight constraints as a solution to this problem. This way if somehow a breaking change on that file is made, this won't break previous releases of other firebase packages.


## Related Issues

related to https://github.com/FirebaseExtended/flutterfire/issues/8194 and https://github.com/FirebaseExtended/flutterfire/issues/8181

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [ ] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
