### PR TITLE
fix(auth): Fixed bug that sets email to `nil` on `iOS` when the `User` has no provider.

### DIFF
--- a/packages/firebase_auth/firebase_auth/ios/Classes/FLTFirebaseAuthPlugin.m
+++ b/packages/firebase_auth/firebase_auth/ios/Classes/FLTFirebaseAuthPlugin.m
@@ -1252,12 +1252,6 @@ NSString *const kErrMsgInvalidCredential =
   NSMutableDictionary *userData = [[self getNSDictionaryFromUserInfo:user] mutableCopy];
   NSMutableDictionary *metadata = [NSMutableDictionary dictionary];
 
-  // This code is necessary to avoid an iOS issue where when unlinking the `password` provider
-  // the previous email still remains on the currentUser.
-  if ([user.providerData count] == 0) {
-    userData[@"email"] = [NSNull null];
-  }
-
   // metadata.creationTimestamp as milliseconds
   long creationDate = (long)([user.metadata.creationDate timeIntervalSince1970] * 1000);
   metadata[@"creationTime"] = @(creationDate);


### PR DESCRIPTION
## Description

From combing the iOS SDK, it appears if you wish to remove the email address you ought to actually set the email address once you unlink the password provider. [See here](https://github.com/firebase/firebase-ios-sdk/issues/3858). Unlinking the password provider will only remove the password provider, not remove the email address from the `currentUser`.


## Related Issues

fixes https://github.com/FirebaseExtended/flutterfire/issues/4163

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
