### PR TITLE
fix(android,auth): return correct error code for linkWithCredential `provider-already-linked` on Android

### DIFF
--- a/packages/firebase_auth/firebase_auth/android/src/main/java/io/flutter/plugins/firebase/auth/FlutterFirebaseAuthPlugin.java
+++ b/packages/firebase_auth/firebase_auth/android/src/main/java/io/flutter/plugins/firebase/auth/FlutterFirebaseAuthPlugin.java
@@ -813,7 +813,8 @@ public class FlutterFirebaseAuthPlugin
           } catch (Exception exception) {
             String message = exception.getMessage();
 
-            if(message != null && message.contains("User has already been linked to the given provider.")) {
+            if (message != null
+                && message.contains("User has already been linked to the given provider.")) {
               throw FlutterFirebaseAuthPluginException.alreadyLinkedProvider();
             }
 

--- a/packages/firebase_auth/firebase_auth/android/src/main/java/io/flutter/plugins/firebase/auth/FlutterFirebaseAuthPlugin.java
+++ b/packages/firebase_auth/firebase_auth/android/src/main/java/io/flutter/plugins/firebase/auth/FlutterFirebaseAuthPlugin.java
@@ -806,7 +806,20 @@ public class FlutterFirebaseAuthPlugin
             throw FlutterFirebaseAuthPluginException.invalidCredential();
           }
 
-          AuthResult authResult = Tasks.await(firebaseUser.linkWithCredential(credential));
+          AuthResult authResult;
+
+          try {
+            authResult = Tasks.await(firebaseUser.linkWithCredential(credential));
+          } catch (Exception exception) {
+            String message = exception.getMessage();
+
+            if(message != null && message.contains("User has already been linked to the given provider.")) {
+              throw FlutterFirebaseAuthPluginException.alreadyLinkedProvider();
+            }
+
+            throw exception;
+          }
+
           return parseAuthResult(authResult);
         });
   }

--- a/packages/firebase_auth/firebase_auth/android/src/main/java/io/flutter/plugins/firebase/auth/FlutterFirebaseAuthPluginException.java
+++ b/packages/firebase_auth/firebase_auth/android/src/main/java/io/flutter/plugins/firebase/auth/FlutterFirebaseAuthPluginException.java
@@ -77,7 +77,7 @@ public class FlutterFirebaseAuthPluginException extends Exception {
 
   static FlutterFirebaseAuthPluginException alreadyLinkedProvider() {
     return new FlutterFirebaseAuthPluginException(
-      "PROVIDER_ALREADY_LINKED", "User has already been linked to the given provider.");
+        "PROVIDER_ALREADY_LINKED", "User has already been linked to the given provider.");
   }
 
   public String getCode() {

--- a/packages/firebase_auth/firebase_auth/android/src/main/java/io/flutter/plugins/firebase/auth/FlutterFirebaseAuthPluginException.java
+++ b/packages/firebase_auth/firebase_auth/android/src/main/java/io/flutter/plugins/firebase/auth/FlutterFirebaseAuthPluginException.java
@@ -75,6 +75,11 @@ public class FlutterFirebaseAuthPluginException extends Exception {
         "NO_SUCH_PROVIDER", "User was not linked to an account with the given provider.");
   }
 
+  static FlutterFirebaseAuthPluginException alreadyLinkedProvider() {
+    return new FlutterFirebaseAuthPluginException(
+      "PROVIDER_ALREADY_LINKED", "User has already been linked to the given provider.");
+  }
+
   public String getCode() {
     return code.toLowerCase(Locale.ROOT).replace("error_", "").replace("_", "-");
   }


### PR DESCRIPTION
## Description

*Replace this paragraph with a description of what this PR is doing. If you're modifying existing behavior, describe the existing behavior, how this PR is changing it, and what motivated the change.*

## Related Issues

closes #6062

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
