### PR TITLE
fix(firebase_dynamic_links): Properly type cast `utmParameters` coming from native side.

### DIFF
--- a/packages/firebase_dynamic_links/firebase_dynamic_links_platform_interface/lib/src/method_channel/method_channel_firebase_dynamic_links.dart
+++ b/packages/firebase_dynamic_links/firebase_dynamic_links_platform_interface/lib/src/method_channel/method_channel_firebase_dynamic_links.dart
@@ -104,7 +104,7 @@ class MethodChannelFirebaseDynamicLinks extends FirebaseDynamicLinksPlatform {
       link: Uri.parse(link),
       android: androidData,
       ios: iosData,
-      utmParameters: linkData['utmParameters'],
+      utmParameters: Map<String,String>.from(linkData['utmParameters']),
     );
   }
 


### PR DESCRIPTION
## Description

The `PendingDynamicLinkData` constructs expects the parameter `utmParams` to be a `Map<String, String>` but was passed a `Map<dynamic,dynamic>` this silently fails with a typecast exception and deep links seems to just not show up in the flutter app.

## Related Issues

fixes #8261 

## Checklist

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
