### PR TITLE
docs(firebase_app_installations):  Changed import statement in documentation.

### DIFF
--- a/docs/installations/overview.mdx
+++ b/docs/installations/overview.mdx
@@ -35,7 +35,7 @@ Typically, Firebase services use the Firebase installations service without requ
 On the root of your Flutter project, run the following command to install the plugin:
 
 ```bash
-flutter pub add firebase_app_installations
+flutter pub add flutterfire_installations
 ```
 
 ### 3. Rebuild your app

--- a/docs/installations/overview.mdx
+++ b/docs/installations/overview.mdx
@@ -35,7 +35,7 @@ Typically, Firebase services use the Firebase installations service without requ
 On the root of your Flutter project, run the following command to install the plugin:
 
 ```bash
-flutter pub add flutterfire_installations
+flutter pub add firebase_app_installations
 ```
 
 ### 3. Rebuild your app

--- a/docs/installations/usage.mdx
+++ b/docs/installations/usage.mdx
@@ -6,7 +6,7 @@ sidebar_label: Usage
 To start using the Firebase Installations package within your project, import it at the top of your project files:
 
 ```dart
-import 'package:flutterfire_installations/flutterfire_installations.dart';
+import 'package:firebase_app_installations/firebase_app_installations.dart';
 ```
 
 Before using Firebase Installations, you must first have ensured you have [initialized FlutterFire](../overview.mdx#initializing-flutterfire).


### PR DESCRIPTION
…page to match the imported package in the usage page

## Description

the overview page was install a package (firebase_app_installations) and in the usage page importing another one (flutterfire_installations), it's confusing even though both package offer same functionality so I did changed the download command to get the flutterfire_installations package

## Related Issues

no issue

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ x] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ x] All existing and new tests are passing.
- [ x] I updated/added relevant documentation (doc comments with `///`).
- [ x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ x] I read and followed the [Flutter Style Guide].
- [ x] I signed the [CLA].
- [ x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x ] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
