### PR TITLE
fix(firebase_auth): check metadata is not null

### DIFF
--- a/packages/firebase_auth/firebase_auth_web/lib/src/firebase_auth_web_user.dart
+++ b/packages/firebase_auth/firebase_auth_web/lib/src/firebase_auth_web_user.dart
@@ -25,13 +25,17 @@ class UserWeb extends UserPlatform {
           'email': _webUser.email,
           'emailVerified': _webUser.emailVerified,
           'isAnonymous': _webUser.isAnonymous,
-          'metadata': <String, int>{
-            'creationTime': _dateFormat
-                .parse(_webUser.metadata.creationTime)
-                .millisecondsSinceEpoch,
-            'lastSignInTime': _dateFormat
-                .parse(_webUser.metadata.lastSignInTime)
-                .millisecondsSinceEpoch,
+          'metadata': <String, int?>{
+            'creationTime': _webUser.metadata.creationTime != null
+                ? _dateFormat
+                    .parse(_webUser.metadata.creationTime!)
+                    .millisecondsSinceEpoch
+                : null,
+            'lastSignInTime': _webUser.metadata.lastSignInTime != null
+                ? _dateFormat
+                    .parse(_webUser.metadata.lastSignInTime!)
+                    .millisecondsSinceEpoch
+                : null,
           },
           'phoneNumber': _webUser.phoneNumber,
           'photoURL': _webUser.photoURL,

--- a/packages/firebase_auth/firebase_auth_web/lib/src/interop/auth_interop.dart
+++ b/packages/firebase_auth/firebase_auth_web/lib/src/interop/auth_interop.dart
@@ -344,11 +344,11 @@ abstract class ActionCodeInfo {
 abstract class UserMetadata {
   /// The date the user was created, formatted as a UTC string.
   /// For example, 'Fri, 22 Sep 2017 01:49:58 GMT'.
-  external String get creationTime;
+  external String? get creationTime;
 
   /// The date the user last signed in, formatted as a UTC string.
   /// For example, 'Fri, 22 Sep 2017 01:49:58 GMT'.
-  external String get lastSignInTime;
+  external String? get lastSignInTime;
 }
 
 /// A structure for [User]'s user profile.


### PR DESCRIPTION
## Description

User metadata can be null in some scenarios (see https://firebase.google.com/docs/reference/js/v8/firebase.auth.UserMetadata), for example if a user was created via the admin sdk, but the current web sdk assumes it is not null.

## Related Issues

Fixes #8309
Related #3374

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
