### PR TITLE
fix(flutterfire_ui): Fix Flutter Cupertino button color bug.

### DIFF
--- a/packages/flutterfire_ui/lib/src/auth/widgets/internal/loading_button.dart
+++ b/packages/flutterfire_ui/lib/src/auth/widgets/internal/loading_button.dart
@@ -56,15 +56,19 @@ class LoadingButton extends StatelessWidget {
         );
       }
 
-      return CupertinoTheme(
-        data: CupertinoTheme.of(context).copyWith(
-          primaryColor: color ?? CupertinoColors.activeBlue,
-        ),
-        child: CupertinoButton.filled(
-          onPressed: onTap,
-          child: child,
-        ),
+      final button = CupertinoButton.filled(
+        onPressed: onTap,
+        child: child,
       );
+
+      return color != null
+          ? CupertinoTheme(
+              data: CupertinoTheme.of(context).copyWith(
+                primaryColor: color,
+              ),
+              child: button,
+            )
+          : button;
     }
 
     if (icon != null) {


### PR DESCRIPTION
## Description

A CupertinoButton color should **not** be overridden by a custom color if it is not set. It should pick the theme primary color instead. The default blue color will be created by the default CupertinoTheme, so no need to use it explicitly either.
This PR fixes the aforementioned behavior.

To see the bug in action, add the `SignInScreen` with `EmailProviderConfiguration` to your cupertino app and change the primary color of the cupertino theme to something different than blue.
Expected behavior: the "Sign in"/"Register" button picks the primary color of the theme.
Actual behavior: the color of the button stays blue.

## Related Issues

There seem to be no related issues. Instead of creating one myself, I have decided to provide a PR directly.

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [x] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [x] All existing and new tests are passing.
- [] I updated/added relevant documentation (doc comments with `///`).
- [x] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [x] I read and followed the [Flutter Style Guide].
- [x] I signed the [CLA].
- [x] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/FirebaseExtended/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
