### PR TITLE
test(firestore): Use `DocumentReference` within `arrayContains` query within integration tests

### DIFF
--- a/packages/cloud_firestore/cloud_firestore/example/integration_test/query_e2e.dart
+++ b/packages/cloud_firestore/cloud_firestore/example/integration_test/query_e2e.dart
@@ -1816,10 +1816,11 @@ void runQueryTests() {
     });
 
     group('Query.where() with Filter class', () {
-      testWidgets('returns documents with `DocumentReference` as an argument',
+      testWidgets(
+          'returns documents with `DocumentReference` as an argument in `isEqualTo`',
           (_) async {
         CollectionReference<Map<String, dynamic>> collection =
-            await initializeTest('doc-ref-arg');
+            await initializeTest('doc-ref-arg-isequal-to');
         final ref = FirebaseFirestore.instance.doc('foo/bar');
         final ref2 = FirebaseFirestore.instance.doc('foo/foo');
         await Future.wait([
@@ -1852,6 +1853,56 @@ void runQueryTests() {
                   Filter(
                     'ref',
                     isEqualTo: ref2,
+                  ),
+                ),
+              ),
+            )
+            .orderBy('title', descending: true)
+            .get();
+
+        expect(results.docs.length, equals(3));
+        expect(results.docs[0].data()['title'], equals('Book C'));
+        expect(results.docs[1].data()['title'], equals('Book B'));
+        expect(results.docs[2].data()['title'], equals('Book A'));
+      });
+
+      testWidgets(
+          'returns documents with `DocumentReference` as an argument in `arrayContains`',
+          (_) async {
+        CollectionReference<Map<String, dynamic>> collection =
+            await initializeTest('doc-ref-arg-array-contains');
+        final ref = FirebaseFirestore.instance.doc('foo/bar');
+        final ref2 = FirebaseFirestore.instance.doc('foo/foo');
+        await Future.wait([
+          collection.doc('doc1').set({
+            'genre': 'fantasy',
+            'title': 'Book A',
+            'ref': [ref],
+          }),
+          collection.doc('doc2').set({
+            'genre': 'fantasy',
+            'title': 'Book B',
+            'ref': [ref],
+          }),
+          collection.doc('doc3').set({
+            'genre': 'adventure',
+            'title': 'Book C',
+            'ref': [ref2],
+          }),
+        ]);
+
+        final results = await collection
+            .where(
+              Filter.or(
+                Filter.and(
+                  Filter('genre', isEqualTo: 'fantasy'),
+                  Filter('ref', arrayContains: ref),
+                ),
+                Filter.and(
+                  Filter('genre', isEqualTo: 'adventure'),
+                  Filter(
+                    'ref',
+                    arrayContains: ref2,
                   ),
                 ),
               ),


### PR DESCRIPTION
## Description

See title.

## Related Issues

related to: https://github.com/firebase/flutterfire/issues/11682

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [x] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/master/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
