### PR TITLE
fix(firestore, ios): fix an issue where unlimited cache wasn't properly set on iOS

### DIFF
--- a/packages/cloud_firestore/cloud_firestore/ios/cloud_firestore/Sources/cloud_firestore/FLTFirebaseFirestorePlugin.m
+++ b/packages/cloud_firestore/cloud_firestore/ios/cloud_firestore/Sources/cloud_firestore/FLTFirebaseFirestorePlugin.m
@@ -224,9 +224,8 @@ FlutterStandardMethodCodec *_codec;
     if (pigeonApp.settings.persistenceEnabled != nil) {
       bool persistEnabled = [pigeonApp.settings.persistenceEnabled boolValue];
 
-      // This is the maximum amount of cache allowed. We use the same number on android.
-      // This now causes an exception: kFIRFirestoreCacheSizeUnlimited
-      NSNumber *size = @104857600;
+      // We default to the maximum amount of cache allowed.
+      NSNumber *size = @(kFIRFirestoreCacheSizeUnlimited);
 
       if (pigeonApp.settings.cacheSizeBytes) {
         NSNumber *cacheSizeBytes = pigeonApp.settings.cacheSizeBytes;

--- a/packages/cloud_firestore/cloud_firestore/ios/cloud_firestore/Sources/cloud_firestore/FLTFirebaseFirestoreReader.m
+++ b/packages/cloud_firestore/cloud_firestore/ios/cloud_firestore/Sources/cloud_firestore/FLTFirebaseFirestoreReader.m
@@ -104,9 +104,8 @@
   if (![values[@"persistenceEnabled"] isEqual:[NSNull null]]) {
     bool persistEnabled = [((NSNumber *)values[@"persistenceEnabled"]) boolValue];
 
-    // This is the maximum amount of cache allowed. We use the same number on android.
-    // This now causes an exception: kFIRFirestoreCacheSizeUnlimited
-    NSNumber *size = @104857600;
+    // We default to the maximum amount of cache allowed.
+    NSNumber *size = @(kFIRFirestoreCacheSizeUnlimited);
 
     if (![values[@"cacheSizeBytes"] isEqual:[NSNull null]]) {
       NSNumber *cacheSizeBytes = ((NSNumber *)values[@"cacheSizeBytes"]);


### PR DESCRIPTION
## Description

We were setting the same number as Android instead of using the correct variable from iOS.
We have no way to test garbage collecting currently.

## Related Issues

closes #12315 

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [X] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
