### PR TITLE
feat(auth): add signInSecondFactor property to IdTokenResult for MFA support

### DIFF
--- a/packages/firebase_auth/firebase_auth_platform_interface/lib/src/id_token_result.dart
+++ b/packages/firebase_auth/firebase_auth_platform_interface/lib/src/id_token_result.dart
@@ -46,11 +46,15 @@ class IdTokenResult {
   /// custom, phone, password, etc). Note, this does not map to provider IDs.
   String? get signInProvider => _data.signInProvider;
 
+  /// The type of second factor associated with this session, provided the user
+  /// was multi-factor authenticated (for example, phone, etc.).
+  String? get signInSecondFactor => _data.signInSecondFactor;
+
   /// The Firebase Auth ID token JWT string.
   String? get token => _data.token;
 
   @override
   String toString() {
-    return '$IdTokenResult(authTime: $authTime, claims: $claims, expirationTime: $expirationTime, issuedAtTime: $issuedAtTime, signInProvider: $signInProvider, token: $token)';
+    return '$IdTokenResult(authTime: $authTime, claims: $claims, expirationTime: $expirationTime, issuedAtTime: $issuedAtTime, signInProvider: $signInProvider, signInSecondFactor: $signInSecondFactor, token: $token)';
   }
 }

--- a/packages/firebase_auth/firebase_auth_platform_interface/test/id_token_result_test.dart
+++ b/packages/firebase_auth/firebase_auth_platform_interface/test/id_token_result_test.dart
@@ -9,6 +9,7 @@ import 'package:flutter_test/flutter_test.dart';
 
 void main() {
   const String kMockSignInProvider = 'password';
+  const String kMockSignInSecondFactor = 'phone';
   const String kMockToken = 'test-token';
   const int kMockExpirationTimestamp = 1234566;
   const int kMockAuthTimestamp = 1234567;
@@ -23,6 +24,7 @@ void main() {
       authTimestamp: kMockAuthTimestamp,
       expirationTimestamp: kMockExpirationTimestamp,
       signInProvider: kMockSignInProvider,
+      signInSecondFactor: kMockSignInSecondFactor,
       token: kMockToken);
 
   group('$IdTokenResult', () {
@@ -38,6 +40,8 @@ void main() {
         expect(idTokenResult.issuedAtTime!.millisecondsSinceEpoch,
             equals(kMockIssuedAtTimestamp));
         expect(idTokenResult.signInProvider, equals(kMockSignInProvider));
+        expect(
+            idTokenResult.signInSecondFactor, equals(kMockSignInSecondFactor));
         expect(idTokenResult.token, equals(kMockToken));
       });
     });
@@ -53,6 +57,7 @@ void main() {
             authTimestamp: kMockAuthTimestamp,
             expirationTimestamp: kMockExpirationTimestamp,
             signInProvider: kMockSignInProvider,
+            signInSecondFactor: kMockSignInSecondFactor,
             token: kMockToken);
 
         final testIdTokenResult = IdTokenResult(kMockData);
@@ -62,7 +67,7 @@ void main() {
 
     test('toString()', () {
       expect(idTokenResult.toString(),
-          '$IdTokenResult(authTime: ${idTokenResult.authTime}, claims: $kMockClaims, expirationTime: ${idTokenResult.expirationTime}, issuedAtTime: ${idTokenResult.issuedAtTime}, signInProvider: $kMockSignInProvider, token: $kMockToken)');
+          '$IdTokenResult(authTime: ${idTokenResult.authTime}, claims: $kMockClaims, expirationTime: ${idTokenResult.expirationTime}, issuedAtTime: ${idTokenResult.issuedAtTime}, signInProvider: $kMockSignInProvider, signInSecondFactor: $kMockSignInSecondFactor, token: $kMockToken)');
     });
   });
 }


### PR DESCRIPTION
This PR adds support for the signInSecondFactor property to the IdTokenResult class, which is needed for multi-factor authentication scenarios. The changes include the implementation in the IdTokenResult class and corresponding updates to the tests.