### PR TITLE
docs(firebase_messaging): fix incorrect HTML example for service worker registration

### DIFF
--- a/docs/cloud-messaging/receive.md
+++ b/docs/cloud-messaging/receive.md
@@ -189,7 +189,9 @@ The file must import both the app and messaging SDKs, initialize Firebase and ex
 Next, the worker must be registered. Within the `index.html` file, register the worker by modifying the `<script>` tag which bootstraps Flutter:
 
 ```html
-<script src="flutter_bootstrap.js" async>
+<script src="flutter_bootstrap.js" async></script>
+
+<script>
   if ('serviceWorker' in navigator) {
     window.addEventListener('load', function () {
       navigator.serviceWorker.register('firebase-messaging-sw.js', {


### PR DESCRIPTION
## Description
Fixed incorrect HTML example in the Flutter Web documentation for Firebase Cloud Messaging service worker registration.

## Problem
The documentation showed inline JavaScript inside a `<script>` tag with a `src` attribute:
```html
<script src="flutter_bootstrap.js" async>
  if ('serviceWorker' in navigator) {
    // ...
  }
</script>
```

This is incorrect because browsers ignore inline JavaScript when a script tag has a `src` attribute, which prevents the service worker registration from running.

## Solution
Separated the script tags as follows:
```html
<script src="flutter_bootstrap.js" async></script>

<script>
  if ('serviceWorker' in navigator) {
    window.addEventListener('load', function () {
      navigator.serviceWorker.register('firebase-messaging-sw.js', {
        scope: '/firebase-cloud-messaging-push-scope',
      });
    });
  }
</script>
```

## Related Issue
Fixes #17837

## Testing
- ✅ Analyzed code with `melos analyze-ci` - all checks passed
- ✅ Verified HTML syntax is correct
- ✅ Confirmed the fix matches the issue description

## Type of Change
- [x] Documentation fix