### PR TITLE
fix(crashlytics, ios): remove warning regarding legacy firebase_app_id_file.json file

### DIFF
--- a/packages/firebase_crashlytics/firebase_crashlytics/ios/crashlytics_add_upload_symbols
+++ b/packages/firebase_crashlytics/firebase_crashlytics/ios/crashlytics_add_upload_symbols
@@ -35,15 +35,14 @@ end
 # Path to the Xcode project to modify
 project_path = File.join(options_dict[:project_dir], options_dict[:project_name])
 
-unless (File.exist?(project_path)) 
+unless (File.exist?(project_path))
    abort("Project at #{project_path} does not exist. Please check paths or incorporate Crashlytics upload symbols manually.\n");
 end
 
 # If this is a Flutter project, upload-symbols will use the firebase_app_id_file.json to get the app's ID. If this file doesn't exist, upload-symbols may not be
-# able to upload symbols correctly. 
+# able to upload symbols correctly.
 if(options_dict[:flutter_project])
     unless File.exist?("#{options_dict[:project_dir]}/firebase_app_id_file.json")
-        puts("Warning: firebase_app_id_file.json file does not exist. This may cause issues in upload-symbols. If this error is unexpected, try running flutterfire configure again.")
         exit(0)
     end
 end
@@ -57,9 +56,9 @@ end
 # Actually open and modify the project
 project = Xcodeproj::Project.open(project_path)
 project.targets.each do |target|
-    if (target.name == "Runner") 
+    if (target.name == "Runner")
         # We need to make sure that we're not adding more than one run script to upload-symbols (or overwriting custom upload-symbols scripts).
-        target.shell_script_build_phases().each { |phase| 
+        target.shell_script_build_phases().each { |phase|
             if (phase.shell_script.include? "FirebaseCrashlytics/upload-symbols")
                 puts("Run script to upload symbols already exists.")
                 exit(0)


### PR DESCRIPTION
## Description

`firebase_app_id_file.json` file is legacy way of uploading DSYM files for Crashlytics iOS. Remove warning about its absence so not to confuse consumers.

See https://github.com/invertase/flutterfire_cli/issues/414

## Related Issues

*Replace this paragraph with a list of issues related to this PR from the [issue database](https://github.com/flutter/flutter/issues). Indicate, which of these issues are resolved or fixed by this PR. Note that you'll have to prefix the issue numbers with flutter/flutter#.*

## Checklist

Before you create this PR confirm that it meets all requirements listed below by checking the relevant checkboxes (`[x]`).
This will ensure a smooth and quick review process. Updating the `pubspec.yaml` and changelogs is not required.

- [ ] I read the [Contributor Guide] and followed the process outlined there for submitting PRs.
- [ ] My PR includes unit or integration tests for *all* changed/updated/fixed behaviors (See [Contributor Guide]).
- [ ] All existing and new tests are passing.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] The analyzer (`melos run analyze`) does not report any problems on my PR.
- [ ] I read and followed the [Flutter Style Guide].
- [ ] I signed the [CLA].
- [ ] I am willing to follow-up on review comments in a timely manner.

## Breaking Change

Does your PR require plugin users to manually update their apps to accommodate your change?

- [ ] Yes, this is a breaking change.
- [ ] No, this is *not* a breaking change.

<!-- Links -->
[issue database]: https://github.com/flutter/flutter/issues
[Contributor Guide]: https://github.com/firebase/flutterfire/blob/main/CONTRIBUTING.md
[Flutter Style Guide]: https://github.com/flutter/flutter/wiki/Style-guide-for-Flutter-repo
[pub versioning philosophy]: https://dart.dev/tools/pub/versioning
[CLA]: https://cla.developers.google.com/
